### PR TITLE
chore: add various types and enums from the old codebase that aren't in the swagger

### DIFF
--- a/app/ui-react/packages/api/src/WithIntegrationHelpers.tsx
+++ b/app/ui-react/packages/api/src/WithIntegrationHelpers.tsx
@@ -3,8 +3,8 @@ import {
   ActionDescriptor,
   Connection,
   Integration,
-  Step,
   PUBLISHED,
+  Step,
   UNPUBLISHED,
 } from '@syndesis/models';
 import { key } from '@syndesis/utils';
@@ -38,26 +38,6 @@ export interface IWithIntegrationHelpersChildrenProps {
    * @todo perhaps rename it with a better name
    */
   addConnection: UpdateOrAddConnection;
-
-  /**
-   * Deploy the integration with the specified ID and version.
-   *
-   * @param id
-   * @param version
-   * @param isIntegrationDeployment
-   */
-  deploy(
-    id: string,
-    version: string | number,
-    isIntegrationDeployment: boolean
-  ): Promise<{}>;
-
-  /**
-   * Request that the given integration ID at the given version be deactivated
-   * @param id
-   * @param version
-   */
-  undeploy(id: string, version: string | number): Promise<{}>;
   /**
    * updates a step of type connection to the provided integration object.
    *
@@ -91,6 +71,18 @@ export interface IWithIntegrationHelpersChildrenProps {
    */
   updateOrAddConnection: UpdateOrAddConnection;
   /**
+   * Deploy the integration with the specified ID and version.
+   *
+   * @param id
+   * @param version
+   * @param isIntegrationDeployment
+   */
+  deploy(
+    id: string,
+    version: string | number,
+    isIntegrationDeployment: boolean
+  ): Promise<{}>;
+  /**
    * asynchronously saves the provided integration, returning the saved
    * integration in case of success.
    *
@@ -99,6 +91,12 @@ export interface IWithIntegrationHelpersChildrenProps {
    * @todo make the returned object immutable to avoid uncontrolled changes
    */
   saveIntegration(integration: Integration): Promise<Integration>;
+  /**
+   * Request that the given integration ID at the given version be deactivated
+   * @param id
+   * @param version
+   */
+  undeploy(id: string, version: string | number): Promise<{}>;
 }
 
 export interface IWithIntegrationHelpersProps {
@@ -189,23 +187,23 @@ export class WithIntegrationHelpersWrapped extends React.Component<
     isIntegrationDeployment = false
   ) {
     return callFetch({
+      body: isIntegrationDeployment ? { targetState: PUBLISHED } : {},
+      method: isIntegrationDeployment ? 'POST' : 'PUT',
       url: isIntegrationDeployment
         ? `${
             this.props.apiUri
           }/integrations/${id}/deployments/${version}/targetState`
         : `${this.props.apiUri}/integrations/${id}/deployments`,
-      body: isIntegrationDeployment ? { targetState: PUBLISHED } : {},
-      method: isIntegrationDeployment ? 'POST' : 'PUT',
     });
   }
 
   public async undeploy(id: string, version: string | number) {
     return callFetch({
+      body: { targetState: UNPUBLISHED },
+      method: 'POST',
       url: `${
         this.props.apiUri
       }/integrations/${id}/deployments/${version}/targetState`,
-      body: { targetState: UNPUBLISHED },
-      method: 'POST',
     });
   }
 

--- a/app/ui-react/packages/models/src/extra.d.ts
+++ b/app/ui-react/packages/models/src/extra.d.ts
@@ -5,12 +5,26 @@ import {
   IntegrationOverview,
 } from './models';
 
+export interface StringMap<T> {
+  [key: string]: T;
+}
+
+export interface WithId {
+  id?: string;
+}
+
+export interface BaseEntity extends WithId {
+  kind?: string;
+  name?: string;
+}
+
 // TODO remove when these values are advertised by the swagger
 export interface IConfigurationProperty extends ConfigurationProperty {
   required?: boolean;
   secret?: boolean;
 }
 
+// Extended connection interface to add support for the 'iconFile' property
 export interface IConnectionWithIconFile extends Connection {
   icon?: any;
   iconFile?: File;
@@ -40,3 +54,112 @@ export interface IntegrationMonitoring {
   namespace: string;
   podName: string;
 }
+
+// Enum for the LeveledMessage level field
+export enum MessageLevel {
+  INFO = 'INFO',
+  WARN = 'WARN',
+  ERROR = 'ERROR',
+}
+
+// These are message codes that we know about
+export enum MessageCode {
+  SYNDESIS000 = 'SYNDESIS000', // generic message
+  SYNDESIS001 = 'SYNDESIS001', // One or more properties have been updated
+  SYNDESIS002 = 'SYNDESIS002', // One or more properties have been added or removed
+  SYNDESIS003 = 'SYNDESIS003', // Connector has been deleted
+  SYNDESIS004 = 'SYNDESIS004', // Extension has been deleted
+  SYNDESIS005 = 'SYNDESIS005', // Action has been deleted
+  SYNDESIS006 = 'SYNDESIS006', // One or more required properties is not set
+  SYNDESIS007 = 'SYNDESIS007', // Secrets update needed
+  SYNDESIS008 = 'SYNDESIS008', // Validation Error
+}
+
+// Integration status types and consts
+export const PENDING = 'Pending';
+export const PUBLISHED = 'Published';
+export const UNPUBLISHED = 'Unpublished';
+export const ERROR = 'Error';
+
+export type IntegrationStatus =
+  | 'Pending'
+  | 'Published'
+  | 'Unpublished'
+  | 'Error';
+
+export enum IntegrationType {
+  SingleFlow = 'SingleFlow',
+  ApiProvider = 'ApiProvider',
+  MultiFlow = 'MultiFlow',
+}
+
+// These types are for the integration detailed state
+// TODO: this should come from the swagger but it's missing
+export enum ConsoleLinkType {
+  Events = 'EVENTS',
+  Logs = 'LOGS',
+}
+
+export enum DetailedStatus {
+  Assembling = 'ASSEMBLING',
+  Building = 'BUILDING',
+  Deploying = 'DEPLOYNG',
+  Starting = 'STARTING',
+}
+
+export interface DetailedState {
+  value: DetailedStatus;
+  currentStep: number;
+  totalSteps: number;
+}
+
+export interface IntegrationStatusDetail {
+  detailedState: DetailedState;
+  linkType?: ConsoleLinkType;
+  logsUrl?: string;
+  eventsUrl?: string;
+  id: string;
+  integrationId: string;
+  deploymentVersion: number;
+  namespace: string;
+  podName: string;
+}
+
+// These types are for the logging backend, not in the swagger
+// TODO: this should come from the swagger but it's missing
+export interface Activity extends BaseEntity {
+  logts?: string;
+  at: number;
+  pod: string;
+  ver: string;
+  status: string;
+  failed: boolean;
+  steps?: ActivityStep[];
+  metadata?: any;
+}
+
+export interface ActivityStep extends BaseEntity {
+  at: number;
+  duration?: number;
+  isFailed: boolean;
+  failure?: string;
+  messages?: string[];
+  output?: string;
+  events?: any;
+}
+
+// Data shape kind enum when working with the DataShape type
+export enum DataShapeKinds {
+  ANY = 'any',
+  JAVA = 'java',
+  JSON_SCHEMA = 'json-schema',
+  JSON_INSTANCE = 'json-instance',
+  XML_SCHEMA = 'xml-schema',
+  XML_SCHEMA_INSPECTED = 'xml-schema-inspected',
+  XML_INSTANCE = 'xml-instance',
+  NONE = 'none',
+}
+
+// Special sekret connection metadata keys
+export const HIDE_FROM_STEP_SELECT = 'hide-from-step-select';
+export const HIDE_FROM_CONNECTION_PAGES = 'hide-from-connection-pages';

--- a/app/ui-react/packages/models/src/extra.d.ts
+++ b/app/ui-react/packages/models/src/extra.d.ts
@@ -3,14 +3,11 @@ import {
   ConfigurationProperty,
   IntegrationMetricsSummary,
   IntegrationOverview,
+  WithId,
 } from './models';
 
 export interface StringMap<T> {
   [key: string]: T;
-}
-
-export interface WithId {
-  id?: string;
 }
 
 export interface BaseEntity extends WithId {


### PR DESCRIPTION
We'll probably need them anyways when we copypasta stuff from the angular codebase.

Secretly I'm wondering if this will get me around this compiler error:

```
Failed to compile.
../packages/api/dist/api.js
Module not found: Can't resolve '@syndesis/models' in '/home/gashcrumb/Source/syndesis-react/app/ui-react/packages/api/dist'
```

Which I see the instant I add `PUBLISHED`/`UNPUBLISHED` to `WithIntegrationHelpers` in the API package like:

```
import {
  Action,
  ActionDescriptor,
  Connection,
  Integration,
  Step,
  PUBLISHED,
  UNPUBLISHED,
} from '@syndesis/models';
```