### PR TITLE
feat: add dialog prompts for life-changing things; refactor delete confirmation dialog

### DIFF
--- a/app/ui-react/packages/ui/src/Customization/ExtensionDetail.tsx
+++ b/app/ui-react/packages/ui/src/Customization/ExtensionDetail.tsx
@@ -11,7 +11,11 @@ import {
 } from 'patternfly-react';
 import * as React from 'react';
 import { ButtonLink } from '../Layout';
-import { ConfirmationDialog, ConfirmationDialogType } from '../Shared';
+import {
+  ConfirmationButtonStyle,
+  ConfirmationDialog,
+  ConfirmationIconType,
+} from '../Shared';
 import './ExtensionDetail.css';
 
 export interface IExtensionDetailProps {
@@ -171,14 +175,15 @@ export class ExtensionDetail extends React.Component<
     return (
       <>
         <ConfirmationDialog
-          confirmationType={ConfirmationDialogType.DANGER}
+          buttonStyle={ConfirmationButtonStyle.DANGER}
           i18nCancelButtonText={this.props.i18nCancelText}
-          i18nAcceptButtonText={this.props.i18nDelete}
+          i18nConfirmButtonText={this.props.i18nDelete}
           i18nConfirmationMessage={this.props.i18nDeleteModalMessage}
           i18nTitle={this.props.i18nDeleteModalTitle}
+          icon={ConfirmationIconType.DANGER}
           showDialog={this.state.showDeleteDialog}
           onCancel={this.doCancel}
-          onAccept={this.doDelete}
+          onConfirm={this.doDelete}
         />
         <Card matchHeight={true}>
           <CardHeading>

--- a/app/ui-react/packages/ui/src/Customization/ExtensionListItem.tsx
+++ b/app/ui-react/packages/ui/src/Customization/ExtensionListItem.tsx
@@ -8,7 +8,11 @@ import {
 } from 'patternfly-react';
 import * as React from 'react';
 import { ButtonLink } from '../Layout';
-import { ConfirmationDialog, ConfirmationDialogType } from '../Shared';
+import {
+  ConfirmationButtonStyle,
+  ConfirmationDialog,
+  ConfirmationIconType,
+} from '../Shared';
 
 export interface IExtensionListItemProps {
   detailsPageLink: H.LocationDescriptor;
@@ -113,14 +117,15 @@ export class ExtensionListItem extends React.Component<
       <>
         <ConfirmationDialog
           // extensionId={this.props.extensionId}
-          confirmationType={ConfirmationDialogType.DANGER}
+          buttonStyle={ConfirmationButtonStyle.DANGER}
           i18nCancelButtonText={this.props.i18nCancelText}
-          i18nAcceptButtonText={this.props.i18nDelete}
+          i18nConfirmButtonText={this.props.i18nDelete}
           i18nConfirmationMessage={this.props.i18nDeleteModalMessage}
           i18nTitle={this.props.i18nDeleteModalTitle}
+          icon={ConfirmationIconType.DANGER}
           showDialog={this.state.showDeleteDialog}
           onCancel={this.doCancel}
-          onAccept={this.doDelete}
+          onConfirm={this.doDelete}
         />
         <ListViewItem
           actions={

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ViewListItem.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ViewListItem.tsx
@@ -8,7 +8,11 @@ import {
   Tooltip,
 } from 'patternfly-react';
 import * as React from 'react';
-import { ConfirmationDialog, ConfirmationDialogType } from '../../../Shared';
+import {
+  ConfirmationButtonStyle,
+  ConfirmationDialog,
+  ConfirmationIconType,
+} from '../../../Shared';
 
 export interface IViewListItemProps {
   viewDescription: string;
@@ -47,14 +51,15 @@ export class ViewListItem extends React.Component<
     return (
       <>
         <ConfirmationDialog
-          confirmationType={ConfirmationDialogType.DANGER}
+          buttonStyle={ConfirmationButtonStyle.DANGER}
           i18nCancelButtonText={this.props.i18nCancelText}
-          i18nAcceptButtonText={this.props.i18nDelete}
+          i18nConfirmButtonText={this.props.i18nDelete}
           i18nConfirmationMessage={this.props.i18nDeleteModalMessage}
           i18nTitle={this.props.i18nDeleteModalTitle}
+          icon={ConfirmationIconType.DANGER}
           showDialog={this.state.showDeleteDialog}
           onCancel={this.handleCancel}
-          onAccept={this.handleDelete}
+          onConfirm={this.handleDelete}
         />
         <ListViewItem
           actions={

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationListItem.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationListItem.tsx
@@ -15,7 +15,11 @@ import {
   VirtualizationPublishStatusDetail,
 } from '../';
 import { ButtonLink } from '../../Layout';
-import { ConfirmationDialog, ConfirmationDialogType } from '../../Shared';
+import {
+  ConfirmationButtonStyle,
+  ConfirmationDialog,
+  ConfirmationIconType,
+} from '../../Shared';
 import {
   BUILDING,
   CONFIGURING,
@@ -151,30 +155,32 @@ export class VirtualizationListItem extends React.Component<
         ? true
         : false;
 
-    // Determine confirmation dialog settings based on published state
-    let confirmationType: ConfirmationDialogType =
-      ConfirmationDialogType.DANGER;
-    let acceptButtonText = this.props.i18nDelete;
-    let confirmationMessage = this.props.i18nDeleteModalMessage;
-    let confirmationTitle = this.props.i18nDeleteModalTitle;
-    if (isPublished) {
-      confirmationType = ConfirmationDialogType.WARNING;
-      acceptButtonText = this.props.i18nUnpublish;
-      confirmationMessage = this.props.i18nUnpublishModalMessage;
-      confirmationTitle = this.props.i18nUnpublishModalTitle;
-    }
-
     return (
       <>
         <ConfirmationDialog
-          confirmationType={confirmationType}
+          buttonStyle={
+            isPublished
+              ? ConfirmationButtonStyle.WARNING
+              : ConfirmationButtonStyle.DANGER
+          }
           i18nCancelButtonText={this.props.i18nCancelText}
-          i18nAcceptButtonText={acceptButtonText}
-          i18nConfirmationMessage={confirmationMessage}
-          i18nTitle={confirmationTitle}
+          i18nConfirmButtonText={
+            isPublished ? this.props.i18nUnpublish : this.props.i18nDelete
+          }
+          i18nConfirmationMessage={
+            isPublished
+              ? this.props.i18nUnpublishModalMessage
+              : this.props.i18nDeleteModalMessage
+          }
+          i18nTitle={
+            isPublished
+              ? this.props.i18nUnpublishModalTitle
+              : this.props.i18nDeleteModalTitle
+          }
+          icon={ConfirmationIconType.DANGER}
           showDialog={this.state.showConfirmationDialog}
           onCancel={this.handleCancel}
-          onAccept={this.handleAcceptConfirmation}
+          onConfirm={this.handleDelete}
         />
         <ListViewItem
           actions={

--- a/app/ui-react/packages/ui/src/Shared/ConfirmationDialog.tsx
+++ b/app/ui-react/packages/ui/src/Shared/ConfirmationDialog.tsx
@@ -1,30 +1,49 @@
 import { Icon, MessageDialog } from 'patternfly-react';
 import * as React from 'react';
 
-const literal = <L extends string>(l: L) => l;
-export const ConfirmationDialogType = {
-  DANGER: literal('DANGER'),
-  INFO: literal('INFO'),
-  WARNING: literal('WARNING'),
-};
-export type ConfirmationDialogType = (typeof ConfirmationDialogType)[keyof typeof ConfirmationDialogType];
+/**
+ * Icon type enum that maps to patternfly icon types
+ */
+export enum ConfirmationIconType {
+  DANGER = 'error-circle-o',
+  WARNING = 'warning-triangle-o',
+  INFO = 'info',
+  OK = 'ok',
+  NONE = 'NONE',
+}
 
 /**
- * A dialog that can be used to obtain user confirmation.
+ * Button style enum that maps to patternfly button classes
  */
-export interface IConfirmationDialogProps {
+export enum ConfirmationButtonStyle {
+  NORMAL = 'primary',
+  SUCCESS = 'success',
+  DANGER = 'danger',
+  WARNING = 'warning',
+  INFO = 'info',
+  LINK = 'link',
+}
+
+/**
+ * A dialog that can be used to obtain user confirmation when deleting an object.
+ */
+export interface IDeleteConfirmationDialogProps {
+  /**
+   * The style of button to use for the primary action
+   */
+  buttonStyle: ConfirmationButtonStyle;
   /**
    * The localized cancel button text.
    */
   i18nCancelButtonText: string;
 
   /**
-   * The localized accept button text.
+   * The localized confirmation button text.
    */
-  i18nAcceptButtonText: string;
+  i18nConfirmButtonText: string;
 
   /**
-   * The localized accept confirmation message.
+   * The localized confirmation message.
    */
   i18nConfirmationMessage: string;
 
@@ -39,9 +58,9 @@ export interface IConfirmationDialogProps {
   i18nTitle: string;
 
   /**
-   * Confirmation type (DANGER, WARNING, INFO)
+   * The icon type to use, or unset for no icon
    */
-  confirmationType: ConfirmationDialogType;
+  icon: ConfirmationIconType;
 
   /**
    * A callback for when the cancel button is clicked. Caller should hide dialog.
@@ -49,9 +68,9 @@ export interface IConfirmationDialogProps {
   onCancel: () => void;
 
   /**
-   * A callback for when the accept button is clicked. Caller should hide dialog.
+   * A callback for when the confirmation button is clicked. Caller should hide dialog.
    */
-  onAccept: () => void;
+  onConfirm: () => void;
 
   /**
    * Indicates if the dialog should be visible.
@@ -60,38 +79,25 @@ export interface IConfirmationDialogProps {
 }
 
 /**
- * A modal dialog to display for user confirmation.
+ * A modal dialog to display when an object is being deleted.
  */
 export class ConfirmationDialog extends React.Component<
-  IConfirmationDialogProps
+  IDeleteConfirmationDialogProps
 > {
   public render() {
-    // Determine icon and button style based on dialog type
-    let iconName = 'error-circle-o';
-    let buttonStyle = 'danger';
-    switch (this.props.confirmationType) {
-      case ConfirmationDialogType.DANGER:
-        iconName = 'error-circle-o';
-        buttonStyle = 'danger';
-        break;
-      case ConfirmationDialogType.WARNING:
-        iconName = 'warning-triangle-o';
-        buttonStyle = 'primary';
-        break;
-      case ConfirmationDialogType.INFO:
-        iconName = 'info';
-        buttonStyle = 'primary';
-    }
-
     return (
       <MessageDialog
-        accessibleName="confirmationDialog"
-        accessibleDescription="confirmationDialogContent"
-        icon={<Icon type="pf" name={iconName} />}
+        accessibleName="deleteConfirmationDialog"
+        accessibleDescription="deleteConfirmationDialogContent"
+        icon={
+          this.props.icon !== ConfirmationIconType.NONE && (
+            <Icon type="pf" name={this.props.icon} />
+          )
+        }
         onHide={this.props.onCancel}
-        primaryAction={this.props.onAccept}
-        primaryActionButtonContent={this.props.i18nAcceptButtonText}
-        primaryActionButtonBsStyle={buttonStyle}
+        primaryAction={this.props.onConfirm}
+        primaryActionButtonContent={this.props.i18nConfirmButtonText}
+        primaryActionButtonBsStyle={this.props.buttonStyle}
         primaryContent={
           <p className="lead">{this.props.i18nConfirmationMessage}</p>
         }

--- a/app/ui-react/packages/ui/stories/Shared/ConfirmationDialog.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Shared/ConfirmationDialog.stories.tsx
@@ -1,7 +1,11 @@
 import { storiesOf } from '@storybook/react';
 import { Button } from 'patternfly-react';
 import * as React from 'react';
-import { ConfirmationDialog, ConfirmationDialogType } from '../../src';
+import {
+  ConfirmationButtonStyle,
+  ConfirmationDialog,
+  ConfirmationIconType,
+} from '../../src';
 
 const cancelText = 'Cancel';
 const deleteMessage = 'Are you sure you want to delete this object?';
@@ -81,14 +85,24 @@ const noDetailsMessageWarningStoryNotes =
 stories
   .add(
     'no details - danger',
-    () => <ConfirmDialog type={ConfirmationDialogType.DANGER} />,
+    () => (
+      <ConfirmationDialogStory
+        buttonStyle={ConfirmationButtonStyle.DANGER}
+        icon={ConfirmationIconType.DANGER}
+      />
+    ),
     {
       notes: noDetailsMessageDangerStoryNotes,
     }
   )
   .add(
     'no details - warning',
-    () => <ConfirmDialog type={ConfirmationDialogType.WARNING} />,
+    () => (
+      <ConfirmationDialogStory
+        buttonStyle={ConfirmationButtonStyle.WARNING}
+        icon={ConfirmationIconType.WARNING}
+      />
+    ),
     {
       notes: noDetailsMessageWarningStoryNotes,
     }
@@ -96,28 +110,30 @@ stories
   .add(
     'with details',
     () => (
-      <ConfirmDialog
+      <ConfirmationDialogStory
         includeDetailsMessage={true}
-        type={ConfirmationDialogType.DANGER}
+        buttonStyle={ConfirmationButtonStyle.DANGER}
+        icon={ConfirmationIconType.DANGER}
       />
     ),
     { notes: detailsMessageStoryNotes }
   );
 
-interface IConfirmationDialogProps {
+interface IConfirmationDialogStoryProps {
   includeDetailsMessage?: boolean;
-  type: ConfirmationDialogType;
+  buttonStyle: ConfirmationButtonStyle;
+  icon: ConfirmationIconType;
 }
 
-interface IConfirmationDialogState {
+interface IConfirmationDialogStoryState {
   show: boolean;
 }
 
-class ConfirmDialog extends React.Component<
-  IConfirmationDialogProps,
-  IConfirmationDialogState
+class ConfirmationDialogStory extends React.Component<
+  IConfirmationDialogStoryProps,
+  IConfirmationDialogStoryState
 > {
-  public constructor(props: IConfirmationDialogProps) {
+  public constructor(props: IConfirmationDialogStoryProps) {
     super(props);
     this.state = {
       show: false,
@@ -152,16 +168,17 @@ class ConfirmDialog extends React.Component<
             : showNoDetailsMessageDialogButtonText}
         </Button>
         <ConfirmationDialog
-          confirmationType={this.props.type}
+          buttonStyle={this.props.buttonStyle}
           i18nCancelButtonText={cancelText}
-          i18nAcceptButtonText={deleteText}
+          i18nConfirmButtonText={deleteText}
           i18nConfirmationMessage={deleteMessage}
           i18nDetailsMessage={
             this.props.includeDetailsMessage ? detailsMessage : undefined
           }
           i18nTitle={title}
+          icon={this.props.icon}
           onCancel={this.handleCancel}
-          onAccept={this.handleDelete}
+          onConfirm={this.handleDelete}
           showDialog={this.state.show}
         />
       </>

--- a/app/ui-react/syndesis/src/modules/integrations/components/Integrations.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/Integrations.tsx
@@ -8,6 +8,9 @@ import {
 } from '@syndesis/api';
 import { IntegrationWithMonitoring } from '@syndesis/models';
 import {
+  ConfirmationButtonStyle,
+  ConfirmationDialog,
+  ConfirmationIconType,
   IIntegrationAction,
   IntegrationsList,
   IntegrationsListItem,
@@ -27,7 +30,59 @@ export interface IIntegrationsProps {
   integrations: IntegrationWithMonitoring[];
 }
 
-export class Integrations extends React.Component<IIntegrationsProps> {
+export interface IIntegrationsState {
+  showPromptDialog: boolean;
+  promptDialogButtonText?: string;
+  promptDialogIcon?: ConfirmationIconType;
+  promptDialogText?: string;
+  promptDialogTitle?: string;
+  handleAction?: () => void;
+}
+
+interface IPromptActionOptions {
+  promptDialogButtonStyle: ConfirmationButtonStyle;
+  promptDialogButtonText: string;
+  promptDialogIcon: ConfirmationIconType;
+  promptDialogText: string;
+  promptDialogTitle: string;
+  handleAction: () => void;
+}
+
+export class Integrations extends React.Component<
+  IIntegrationsProps,
+  IIntegrationsState
+> {
+  public constructor(props: IIntegrationsProps) {
+    super(props);
+    this.state = {
+      showPromptDialog: false,
+    };
+    this.handleAction = this.handleAction.bind(this);
+    this.handleActionCancel = this.handleActionCancel.bind(this);
+    this.promptForAction = this.promptForAction.bind(this);
+  }
+  public handleActionCancel() {
+    this.setState({
+      showPromptDialog: false,
+    });
+  }
+  public handleAction() {
+    const action = this.state.handleAction;
+    this.setState({
+      showPromptDialog: false,
+    });
+    if (typeof action === 'function') {
+      action.apply(this);
+    } else {
+      throw Error('Undefined action set for confirmation dialog');
+    }
+  }
+  public promptForAction(options: IPromptActionOptions) {
+    this.setState({
+      ...options,
+      showPromptDialog: true,
+    });
+  }
   public render() {
     return (
       <Translation ns={['integrations', 'shared']}>
@@ -41,156 +96,216 @@ export class Integrations extends React.Component<IIntegrationsProps> {
                   exportIntegration,
                   undeployIntegration,
                 }) => (
-                  <IntegrationsList>
-                    <WithLoader
-                      error={this.props.error}
-                      loading={this.props.loading}
-                      loaderChildren={<IntegrationsListSkeleton />}
-                      errorChildren={<div>TODO</div>}
-                    >
-                      {() =>
-                        this.props.integrations.map(
-                          (mi: IntegrationWithMonitoring) => {
-                            try {
-                              const editAction: IIntegrationAction = {
-                                href: resolvers.integration.edit.index({
-                                  integration: mi.integration,
-                                }),
-                                label: 'Edit',
-                              };
-                              const startAction: IIntegrationAction = {
-                                label: 'Start',
-                                onClick: () =>
-                                  deployIntegration(
-                                    mi.integration.id!,
-                                    mi.integration.version!,
-                                    false
-                                  ),
-                              };
-                              const stopAction: IIntegrationAction = {
-                                label: 'Stop',
-                                onClick: () =>
-                                  undeployIntegration(
-                                    mi.integration.id!,
-                                    mi.integration.version!
-                                  ),
-                              };
-                              const deleteAction: IIntegrationAction = {
-                                label: 'Delete',
-                                onClick: () =>
-                                  deleteIntegration(mi.integration.id!),
-                              };
-                              const exportAction: IIntegrationAction = {
-                                label: 'Export',
-                                onClick: () =>
-                                  exportIntegration(
-                                    mi.integration.id!,
-                                    `${mi.integration.name}-export.zip`
-                                  ),
-                              };
-                              const actions: IIntegrationAction[] = [];
-                              if (canEdit(mi.integration)) {
-                                actions.push(editAction);
+                  <>
+                    <ConfirmationDialog
+                      buttonStyle={ConfirmationButtonStyle.NORMAL}
+                      i18nCancelButtonText={t('shared:Cancel')}
+                      i18nConfirmButtonText={this.state.promptDialogButtonText!}
+                      i18nConfirmationMessage={this.state.promptDialogText!}
+                      i18nTitle={this.state.promptDialogTitle!}
+                      icon={this.state.promptDialogIcon!}
+                      showDialog={this.state.showPromptDialog}
+                      onCancel={this.handleActionCancel}
+                      onConfirm={this.handleAction}
+                    />
+                    <IntegrationsList>
+                      <WithLoader
+                        error={this.props.error}
+                        loading={this.props.loading}
+                        loaderChildren={<IntegrationsListSkeleton />}
+                        errorChildren={<div>TODO</div>}
+                      >
+                        {() =>
+                          this.props.integrations.map(
+                            (mi: IntegrationWithMonitoring) => {
+                              try {
+                                const editAction: IIntegrationAction = {
+                                  href: resolvers.integration.edit.index({
+                                    integration: mi.integration,
+                                  }),
+                                  label: 'Edit',
+                                };
+                                const startAction: IIntegrationAction = {
+                                  label: 'Start',
+                                  onClick: () =>
+                                    this.promptForAction({
+                                      handleAction: () =>
+                                        deployIntegration(
+                                          mi.integration.id!,
+                                          mi.integration.version!,
+                                          false
+                                        ),
+                                      promptDialogButtonStyle:
+                                        ConfirmationButtonStyle.NORMAL,
+                                      promptDialogButtonText: t('shared:Start'),
+                                      promptDialogIcon:
+                                        ConfirmationIconType.NONE,
+                                      promptDialogText: t(
+                                        'integrations:publishIntegrationModal',
+                                        { name: mi.integration.name }
+                                      ),
+                                      promptDialogTitle: t(
+                                        'integrations:publishIntegrationModalTitle'
+                                      ),
+                                    } as IPromptActionOptions),
+                                };
+                                const stopAction: IIntegrationAction = {
+                                  label: 'Stop',
+                                  onClick: () =>
+                                    this.promptForAction({
+                                      handleAction: () =>
+                                        undeployIntegration(
+                                          mi.integration.id!,
+                                          mi.integration.version!
+                                        ),
+                                      promptDialogButtonStyle:
+                                        ConfirmationButtonStyle.NORMAL,
+                                      promptDialogButtonText: t('shared:Stop'),
+                                      promptDialogIcon:
+                                        ConfirmationIconType.NONE,
+                                      promptDialogText: t(
+                                        'integrations:unpublishIntegrationModal',
+                                        { name: mi.integration.name }
+                                      ),
+                                      promptDialogTitle: t(
+                                        'integrations:unpublishIntegrationModalTitle'
+                                      ),
+                                    } as IPromptActionOptions),
+                                };
+                                const deleteAction: IIntegrationAction = {
+                                  label: 'Delete',
+                                  onClick: () =>
+                                    this.promptForAction({
+                                      handleAction: () =>
+                                        deleteIntegration(mi.integration.id!),
+                                      promptDialogButtonStyle:
+                                        ConfirmationButtonStyle.DANGER,
+                                      promptDialogButtonText: t(
+                                        'shared:Delete'
+                                      ),
+                                      promptDialogIcon:
+                                        ConfirmationIconType.DANGER,
+                                      promptDialogText: t(
+                                        'integrations:deleteIntegrationModal',
+                                        { name: mi.integration.name }
+                                      ),
+                                      promptDialogTitle: t(
+                                        'integrations:deleteIntegrationModalTitle'
+                                      ),
+                                    } as IPromptActionOptions),
+                                };
+                                const exportAction: IIntegrationAction = {
+                                  label: 'Export',
+                                  onClick: () =>
+                                    exportIntegration(
+                                      mi.integration.id!,
+                                      `${mi.integration.name}-export.zip`
+                                    ),
+                                };
+                                const actions: IIntegrationAction[] = [];
+                                if (canEdit(mi.integration)) {
+                                  actions.push(editAction);
+                                }
+                                if (canActivate(mi.integration)) {
+                                  actions.push(startAction);
+                                }
+                                if (canDeactivate(mi.integration)) {
+                                  actions.push(stopAction);
+                                }
+                                actions.push(deleteAction);
+                                actions.push(exportAction);
+                                return (
+                                  <IntegrationsListItem
+                                    key={mi.integration.id}
+                                    integrationName={mi.integration.name}
+                                    currentState={mi.integration!.currentState!}
+                                    targetState={mi.integration!.targetState!}
+                                    isConfigurationRequired={
+                                      !!(
+                                        mi.integration!.board!.warnings ||
+                                        mi.integration!.board!.errors ||
+                                        mi.integration!.board!.notices
+                                      )
+                                    }
+                                    monitoringValue={
+                                      mi.monitoring &&
+                                      t(
+                                        'integrations:' +
+                                          mi.monitoring.detailedState.value
+                                      )
+                                    }
+                                    monitoringCurrentStep={
+                                      mi.monitoring &&
+                                      mi.monitoring.detailedState.currentStep
+                                    }
+                                    monitoringTotalSteps={
+                                      mi.monitoring &&
+                                      mi.monitoring.detailedState.totalSteps
+                                    }
+                                    monitoringLogUrl={getPodLogUrl(
+                                      config,
+                                      mi.monitoring
+                                    )}
+                                    startConnectionIcon={getStartIcon(
+                                      config.apiEndpoint,
+                                      mi.integration
+                                    )}
+                                    finishConnectionIcon={getFinishIcon(
+                                      config.apiEndpoint,
+                                      mi.integration
+                                    )}
+                                    actions={
+                                      <IntegrationsListItemActions
+                                        integrationId={mi.integration!.id!}
+                                        actions={actions}
+                                        detailsHref={resolvers.integration.details(
+                                          { integration: mi.integration }
+                                        )}
+                                      />
+                                    }
+                                    i18nConfigurationRequired={t(
+                                      'integrations:ConfigurationRequired'
+                                    )}
+                                    i18nError={t('shared:Error')}
+                                    i18nPublished={t('shared:Published')}
+                                    i18nUnpublished={t('shared:Unpublished')}
+                                    i18nProgressPending={t('shared:Pending')}
+                                    i18nProgressStarting={t(
+                                      'integrations:progressStarting'
+                                    )}
+                                    i18nProgressStopping={t(
+                                      'integrations:progressStopping'
+                                    )}
+                                    i18nLogUrlText={t('shared:viewLogs')}
+                                  />
+                                );
+                              } catch (e) {
+                                return (
+                                  <IntegrationsListItemUnreadable
+                                    key={mi.integration.id}
+                                    integrationName={
+                                      (mi &&
+                                        mi.integration &&
+                                        mi.integration.name) ||
+                                      'An integration'
+                                    }
+                                    i18nDescription={
+                                      "Sorry, we can't display more information about this integration right now."
+                                    }
+                                    rawObject={JSON.stringify(
+                                      mi.integration,
+                                      null,
+                                      2
+                                    )}
+                                  />
+                                );
                               }
-                              if (canActivate(mi.integration)) {
-                                actions.push(startAction);
-                              }
-                              if (canDeactivate(mi.integration)) {
-                                actions.push(stopAction);
-                              }
-                              actions.push(deleteAction);
-                              actions.push(exportAction);
-                              return (
-                                <IntegrationsListItem
-                                  key={mi.integration.id}
-                                  integrationName={mi.integration.name}
-                                  currentState={mi.integration!.currentState!}
-                                  targetState={mi.integration!.targetState!}
-                                  isConfigurationRequired={
-                                    !!(
-                                      mi.integration!.board!.warnings ||
-                                      mi.integration!.board!.errors ||
-                                      mi.integration!.board!.notices
-                                    )
-                                  }
-                                  monitoringValue={
-                                    mi.monitoring &&
-                                    t(
-                                      'integrations:' +
-                                        mi.monitoring.detailedState.value
-                                    )
-                                  }
-                                  monitoringCurrentStep={
-                                    mi.monitoring &&
-                                    mi.monitoring.detailedState.currentStep
-                                  }
-                                  monitoringTotalSteps={
-                                    mi.monitoring &&
-                                    mi.monitoring.detailedState.totalSteps
-                                  }
-                                  monitoringLogUrl={getPodLogUrl(
-                                    config,
-                                    mi.monitoring
-                                  )}
-                                  startConnectionIcon={getStartIcon(
-                                    config.apiEndpoint,
-                                    mi.integration
-                                  )}
-                                  finishConnectionIcon={getFinishIcon(
-                                    config.apiEndpoint,
-                                    mi.integration
-                                  )}
-                                  actions={
-                                    <IntegrationsListItemActions
-                                      integrationId={mi.integration!.id!}
-                                      actions={actions}
-                                      detailsHref={resolvers.integration.details(
-                                        { integration: mi.integration }
-                                      )}
-                                    />
-                                  }
-                                  i18nConfigurationRequired={t(
-                                    'integrations:ConfigurationRequired'
-                                  )}
-                                  i18nError={t('shared:Error')}
-                                  i18nPublished={t('shared:Published')}
-                                  i18nUnpublished={t('shared:Unpublished')}
-                                  i18nProgressPending={t('shared:Pending')}
-                                  i18nProgressStarting={t(
-                                    'integrations:progressStarting'
-                                  )}
-                                  i18nProgressStopping={t(
-                                    'integrations:progressStopping'
-                                  )}
-                                  i18nLogUrlText={t('shared:viewLogs')}
-                                />
-                              );
-                            } catch (e) {
-                              return (
-                                <IntegrationsListItemUnreadable
-                                  key={mi.integration.id}
-                                  integrationName={
-                                    (mi &&
-                                      mi.integration &&
-                                      mi.integration.name) ||
-                                    'An integration'
-                                  }
-                                  i18nDescription={
-                                    "Sorry, we can't display more information about this integration right now."
-                                  }
-                                  rawObject={JSON.stringify(
-                                    mi.integration,
-                                    null,
-                                    2
-                                  )}
-                                />
-                              );
                             }
-                          }
-                        )
-                      }
-                    </WithLoader>
-                  </IntegrationsList>
+                          )
+                        }
+                      </WithLoader>
+                    </IntegrationsList>
+                  </>
                 )}
               </WithIntegrationHelpers>
             )}

--- a/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -1,4 +1,10 @@
 {
+  "publishIntegrationModal": "Are you sure you want to start the \"{{name}}\" integration?",
+  "publishIntegrationModalTitle": "Confirm Start?",
+  "unpublishIntegrationModal": "Are you sure you want to stop the \"{{name}}\" integration?",
+  "unpublishIntegrationModalTitle": "Confirm Stop?",
+  "deleteIntegrationModal": "Are you sure you want to delete the \"{{name}}\" integration?",
+  "deleteIntegrationModalTitle": "Confirm Delete?",
   "ConfigurationRequired": "Configuration Required",
   "filterByConnectionPlaceholder": "Filter by Connection",
   "progressStarting": "Starting...",


### PR DESCRIPTION
fixes #149

Adds dialog prompts for starting, stopping and deleting an integration.  Refactors the DeleteConfirmationDialog widget to ConfirmationDialog, and exposes properties to control the button text, class, and icon, for the latter two I opted for enums that map to the underlying patternfly class that the component is expecting.

@mdrillin Hope you don't mind!  I adapted your most recent changes so worth taking a scan and make sure that's okay.