### PR TITLE
TTOOLS-601 Improvements to VirtualizationSqlClientPage

### DIFF
--- a/app/ui-react/packages/api/src/WithViewEditorStates.tsx
+++ b/app/ui-react/packages/api/src/WithViewEditorStates.tsx
@@ -4,6 +4,7 @@ import { DVFetch } from './DVFetch';
 import { IFetchState } from './Fetch';
 
 export interface IWithViewEditorStatesProps {
+  idPattern?: string;
   children(props: IFetchState<ViewEditorState[]>): any;
 }
 
@@ -13,7 +14,10 @@ export class WithViewEditorStates extends React.Component<
   public render() {
     return (
       <DVFetch<ViewEditorState[]>
-        url={'service/userProfile/viewEditorState'}
+        url={
+          'service/userProfile/viewEditorState' +
+          (this.props.idPattern ? '?pattern=' + this.props.idPattern : '')
+        }
         defaultValue={[]}
       >
         {({ response }) => this.props.children(response)}

--- a/app/ui-react/packages/api/src/WithVirtualizationHelpers.tsx
+++ b/app/ui-react/packages/api/src/WithVirtualizationHelpers.tsx
@@ -176,12 +176,6 @@ export class WithVirtualizationHelpersWrapped extends React.Component<
       target: virtualizationName,
     };
 
-    // The query results for the rest call
-    const queryResults = {
-      columns: [],
-      rows: [],
-    };
-
     const response = await callFetch({
       body: queryBody,
       headers: {},
@@ -193,7 +187,7 @@ export class WithVirtualizationHelpersWrapped extends React.Component<
       throw new Error(response.statusText);
     }
 
-    return Promise.resolve(queryResults);
+    return (await response.json()) as QueryResults;
   }
 
   /**

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationListItem.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationListItem.tsx
@@ -177,7 +177,11 @@ export class VirtualizationListItem extends React.Component<
               ? this.props.i18nUnpublishModalTitle
               : this.props.i18nDeleteModalTitle
           }
-          icon={ConfirmationIconType.DANGER}
+          icon={
+            isPublished
+              ? ConfirmationIconType.WARNING
+              : ConfirmationIconType.DANGER
+          }
           showDialog={this.state.showConfirmationDialog}
           onCancel={this.handleCancel}
           onConfirm={this.handleDelete}

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationSqlClientPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationSqlClientPage.tsx
@@ -1,4 +1,5 @@
-import { RestDataService } from '@syndesis/models';
+import { WithViewEditorStates } from '@syndesis/api';
+import { RestDataService, ViewEditorState } from '@syndesis/models';
 import { WithRouteData } from '@syndesis/utils';
 import * as React from 'react';
 import { Translation } from 'react-i18next';
@@ -7,6 +8,8 @@ import {
   ViewSqlFormAndTable,
   VirtualizationNavBar,
 } from '../shared/';
+import { getPreviewVdbName } from '../shared/VirtualizationUtils';
+
 /**
  * @param virtualizationId - the ID of the virtualization whose details are being shown by this page.
  */
@@ -51,10 +54,19 @@ export class VirtualizationSqlClientPage extends React.Component<
               <>
                 <HeaderView virtualizationId={virtualizationId} />
                 <VirtualizationNavBar virtualization={virtualization} />
-                <ViewSqlFormAndTable
-                  viewNames={virtualization.serviceViewDefinitions}
-                  virtualizationName={virtualizationId}
-                />
+                <WithViewEditorStates
+                  idPattern={virtualization.serviceVdbName + '*'}
+                >
+                  {({ data, hasData, error }) => (
+                    <ViewSqlFormAndTable
+                      views={data.map(
+                        (editorState: ViewEditorState) =>
+                          editorState.viewDefinition
+                      )}
+                      targetVdb={getPreviewVdbName()}
+                    />
+                  )}
+                </WithViewEditorStates>
               </>
             )}
           </Translation>

--- a/app/ui-react/syndesis/src/modules/data/shared/ViewSqlFormAndTable.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/ViewSqlFormAndTable.tsx
@@ -1,4 +1,4 @@
-import { QueryResults } from '@syndesis/models';
+import { QueryResults, ViewDefinition } from '@syndesis/models';
 import { Container, GenericTable } from '@syndesis/ui';
 // tslint:disable-next-line:no-implicit-dependencies
 import { EmptyState, Grid, Table } from 'patternfly-react';
@@ -8,15 +8,14 @@ import { ViewSqlForm } from '../shared/';
 
 export interface IViewSqlFormAndTableProps {
   /**
-   * @param viewNames the list of view names for a virtualization
-   * This will come from the virtualization.serviceViewDefinitions string[] array
+   * @param views the list of ViewDefinitions for the virtualization
    */
-  viewNames: string[];
+  views: ViewDefinition[];
 
   /**
-   * @param virtualizationName the name of the virtualization
+   * @param targetVdb the name of the vdb to query
    */
-  virtualizationName: string;
+  targetVdb: string;
 }
 
 export interface IViewSqlFormAndTableState {
@@ -61,8 +60,8 @@ export class ViewSqlFormAndTable extends React.Component<
         <Grid.Col md={6}>
           <Container>
             <ViewSqlForm
-              viewNames={this.props.viewNames}
-              virtualizationName={this.props.virtualizationName}
+              views={this.props.views}
+              targetVdb={this.props.targetVdb}
               onQueryResultsChanged={this.setQueryResults}
             />
           </Container>


### PR DESCRIPTION
Made some adjustments for the SqlClientPage and components to utilize a preview vdb.

- VirtualizationSqlClientPage now uses the ViewEditorStates instead of getting just the view names.  The ViewEditorState has more info needed for generating preview SQL, etc.
- WithViewEditorStates now allows specification of idPattern, so subset of states can be obtained.
- Now returning actual query results from WithVirtualizationHelpers function.
- changed ViewSqlForm props to specify targetVdb and viewDefinition.  The ViewSqlForm also now defers to VirtualizationUtils function to generate the preview sql.

There are several todos remaining, but I think @blafond has logged them under separate issues.
