### PR TITLE
fix: Swap out TODOs with generic api error element

### DIFF
--- a/app/ui-react/packages/ui/stories/Shared/InlineTextEdit.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Shared/InlineTextEdit.stories.tsx
@@ -1,9 +1,10 @@
-import { number } from '@storybook/addon-knobs';
+import { number, withKnobs } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 import { InlineTextEdit } from '../../src';
 
 const stories = storiesOf('Shared/InlineTextEdit', module);
+stories.addDecorator(withKnobs);
 
 const fooErrorMsg = 'Value cannot be foo';
 const requiredErrorMsg = 'Value cannot be empty';

--- a/app/ui-react/packages/ui/stories/Shared/UnrecoverableError.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Shared/UnrecoverableError.stories.tsx
@@ -1,0 +1,23 @@
+import { text, withKnobs } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { UnrecoverableError } from '../../src';
+
+const stories = storiesOf('Shared/UnrecoverableError', module);
+stories.addDecorator(withKnobs);
+
+stories.add('404', () => (
+  <Router>
+    <UnrecoverableError
+      i18nTitle={text('404 Title', 'Oops! 404')}
+      i18nInfo={text('404 Info', "This page couldn't be found.")}
+      i18nHelp={text(
+        'Help Text',
+        'If you think this is a bug, please report the issue.'
+      )}
+      i18nRefreshLabel={text('Refresh Label', 'Refresh')}
+      i18nReportIssue={text('Report the issue', 'Report the issue')}
+    />
+  </Router>
+));

--- a/app/ui-react/syndesis/src/modules/connections/pages/ConnectionDetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/pages/ConnectionDetailsPage.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { Translation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import i18n from '../../../i18n';
+import { ApiError } from '../../../shared';
 import resolvers from '../../resolvers';
 
 export interface IConnectionDetailsRouteParams {
@@ -66,7 +67,7 @@ export class ConnectionDetailsPage extends React.Component {
                   error={error}
                   loading={!hasData}
                   loaderChildren={<Loader />}
-                  errorChildren={<div>TODO</div>}
+                  errorChildren={<ApiError />}
                 >
                   {() => (
                     <Translation ns={['connections', 'shared']}>

--- a/app/ui-react/syndesis/src/modules/connections/pages/create/ConfigurationPage.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/pages/create/ConfigurationPage.tsx
@@ -3,7 +3,7 @@ import { Connector } from '@syndesis/models';
 import { ButtonLink, ConnectionCreatorLayout, Loader } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
 import * as React from 'react';
-import { PageTitle } from '../../../../shared';
+import { ApiError, PageTitle } from '../../../../shared';
 import { ConnectionCreatorBreadcrumbs } from '../../components';
 import resolvers from '../../resolvers';
 import { WithConfigurationForm } from '../../shared';
@@ -30,7 +30,7 @@ export default class ConfigurationPage extends React.Component {
                 error={error}
                 loading={!hasData}
                 loaderChildren={<Loader />}
-                errorChildren={<div>TODO</div>}
+                errorChildren={<ApiError />}
               >
                 {() => {
                   const onSave = (configuredProperties: {

--- a/app/ui-react/syndesis/src/modules/connections/pages/create/ConnectorsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/pages/create/ConnectorsPage.tsx
@@ -8,7 +8,7 @@ import {
 } from '@syndesis/ui';
 import { getConnectionIcon, WithLoader } from '@syndesis/utils';
 import * as React from 'react';
-import { PageTitle } from '../../../../shared';
+import { ApiError, PageTitle } from '../../../../shared';
 import { ConnectionCreatorBreadcrumbs } from '../../components';
 import resolvers from '../../resolvers';
 
@@ -35,7 +35,7 @@ export default class ConnectorsPage extends React.Component {
                         ))}
                       </>
                     }
-                    errorChildren={<div>TODO</div>}
+                    errorChildren={<ApiError />}
                   >
                     {() =>
                       data.connectorsForDisplay

--- a/app/ui-react/syndesis/src/modules/connections/shared/Connections.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/shared/Connections.tsx
@@ -8,6 +8,7 @@ import {
 import { getConnectionIcon, WithLoader } from '@syndesis/utils';
 import * as H from 'history';
 import * as React from 'react';
+import { ApiError } from '../../../shared';
 
 export interface IConnectionsProps {
   error: boolean;
@@ -32,7 +33,7 @@ export class Connections extends React.Component<IConnectionsProps> {
               ))}
             </>
           }
-          errorChildren={<div>TODO</div>}
+          errorChildren={<ApiError />}
         >
           {() =>
             this.props.connections.map((c, index) => (

--- a/app/ui-react/syndesis/src/modules/customizations/pages/ApiConnectorsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/customizations/pages/ApiConnectorsPage.tsx
@@ -16,6 +16,7 @@ import {
 import * as React from 'react';
 import { Translation } from 'react-i18next';
 import i18n from '../../../i18n';
+import { ApiError } from '../../../shared';
 import routes from '../routes';
 import CustomizationsNavBar from '../shared/CustomizationsNavBar';
 
@@ -148,7 +149,7 @@ export default class ApiConnectorsPage extends React.Component {
                               }}
                             />
                           }
-                          errorChildren={<div>TODO</div>}
+                          errorChildren={<ApiError />}
                         >
                           {() =>
                             filteredAndSorted

--- a/app/ui-react/syndesis/src/modules/customizations/pages/ExtensionDetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/customizations/pages/ExtensionDetailsPage.tsx
@@ -13,6 +13,7 @@ import * as React from 'react';
 import { Translation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import i18n from '../../../i18n';
+import { ApiError } from '../../../shared';
 import resolvers from '../../resolvers';
 import ExtensionIntegrations from '../shared/ExtensionIntegrations';
 
@@ -85,7 +86,7 @@ export default class ExtensionDetailsPage extends React.Component {
                         error={error}
                         loading={!hasData}
                         loaderChildren={<Loader />}
-                        errorChildren={<div>TODO</div>}
+                        errorChildren={<ApiError />}
                       >
                         {() => (
                           <Translation ns={['customizations', 'shared']}>

--- a/app/ui-react/syndesis/src/modules/customizations/pages/ExtensionsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/customizations/pages/ExtensionsPage.tsx
@@ -12,6 +12,7 @@ import { WithListViewToolbarHelpers, WithLoader } from '@syndesis/utils';
 import * as React from 'react';
 import { Translation } from 'react-i18next';
 import i18n from '../../../i18n';
+import { ApiError } from '../../../shared';
 import { getExtensionTypeName } from '../customizationsUtils';
 import resolvers from '../resolvers';
 import CustomizationsNavBar from '../shared/CustomizationsNavBar';
@@ -145,7 +146,7 @@ export default class ExtensionsPage extends React.Component {
                                     }}
                                   />
                                 }
-                                errorChildren={<div>TODO</div>}
+                                errorChildren={<ApiError />}
                               >
                                 {() =>
                                   filteredAndSorted

--- a/app/ui-react/syndesis/src/modules/customizations/shared/ExtensionIntegrations.tsx
+++ b/app/ui-react/syndesis/src/modules/customizations/shared/ExtensionIntegrations.tsx
@@ -8,6 +8,7 @@ import { WithLoader } from '@syndesis/utils';
 import * as React from 'react';
 import { Translation } from 'react-i18next';
 import i18n from '../../../i18n';
+import { ApiError } from '../../../shared';
 
 export interface IExtensionIntegrationsProps {
   extensionId: string;
@@ -39,7 +40,7 @@ export default class ExtensionIntegrations extends React.Component<
             error={error}
             loading={!hasData}
             loaderChildren={<Loader />}
-            errorChildren={<div>TODO</div>}
+            errorChildren={<ApiError />}
           >
             {() => (
               <Translation ns={['customizations', 'shared']}>

--- a/app/ui-react/syndesis/src/modules/dashboard/pages/DashboardPage.tsx
+++ b/app/ui-react/syndesis/src/modules/dashboard/pages/DashboardPage.tsx
@@ -22,6 +22,7 @@ import {
 import { WithLoader } from '@syndesis/utils';
 import * as React from 'react';
 import { Translation } from 'react-i18next';
+import { ApiError } from '../../../shared';
 import { Connections } from '../../connections/shared';
 import { Integrations } from '../../integrations/components';
 import resolvers from '../../resolvers';
@@ -107,11 +108,19 @@ export function getConnectionHref(connection: Connection) {
 
 export default () => (
   <WithMonitoredIntegrations>
-    {({ data: integrationsData, hasData: hasIntegrations }) => (
+    {({
+      data: integrationsData,
+      hasData: hasIntegrations,
+      error: integrationsError,
+    }) => (
       <WithIntegrationsMetrics>
         {({ data: metricsData }) => (
           <WithConnections>
-            {({ data: connectionsData, hasData: hasConnections }) => {
+            {({
+              data: connectionsData,
+              hasData: hasConnections,
+              error: connectionsError,
+            }) => {
               const integrationStatesCount = getIntegrationsCountsByState(
                 integrationsData.items
               );
@@ -187,7 +196,7 @@ export default () => (
                           })}
                         >
                           <Integrations
-                            error={false}
+                            error={integrationsError}
                             loading={!hasIntegrations}
                             integrations={topIntegrations}
                           />
@@ -222,7 +231,7 @@ export default () => (
                             error={false}
                             loading={!hasIntegrations}
                             loaderChildren={<RecentUpdatesSkeleton />}
-                            errorChildren={<div>TODO</div>}
+                            errorChildren={<ApiError />}
                           >
                             {() =>
                               recentlyUpdatedIntegrations.map(i => (
@@ -242,7 +251,7 @@ export default () => (
                       }
                       connections={
                         <Connections
-                          error={false}
+                          error={connectionsError}
                           loading={!hasConnections}
                           connections={connectionsData.connectionsForDisplay}
                           getConnectionHref={getConnectionHref}

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
@@ -3,6 +3,7 @@ import { RestDataService } from '@syndesis/models';
 import { RestViewDefinition } from '@syndesis/models';
 import * as React from 'react';
 import i18n from '../../../i18n';
+import { ApiError } from '../../../shared';
 import { HeaderView } from '../shared';
 import { VirtualizationNavBar } from '../shared';
 
@@ -195,7 +196,7 @@ export class VirtualizationViewsPage extends React.Component<
                                           }}
                                         />
                                       }
-                                      errorChildren={<div>TODO</div>}
+                                      errorChildren={<ApiError />}
                                     >
                                       {() =>
                                         filteredAndSorted

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationsPage.tsx
@@ -12,6 +12,7 @@ import { WithListViewToolbarHelpers, WithLoader } from '@syndesis/utils';
 import * as React from 'react';
 import { Translation } from 'react-i18next';
 import i18n from '../../../i18n';
+import { ApiError } from '../../../shared';
 import resolvers from '../resolvers';
 
 function getFilteredAndSortedVirtualizations(
@@ -175,7 +176,7 @@ export class VirtualizationsPage extends React.Component {
                                   }}
                                 />
                               }
-                              errorChildren={<div>TODO</div>}
+                              errorChildren={<ApiError />}
                             >
                               {() =>
                                 filteredAndSorted.map(

--- a/app/ui-react/syndesis/src/modules/data/shared/DvConnections.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/DvConnections.tsx
@@ -7,6 +7,7 @@ import {
 } from '@syndesis/ui';
 import { getConnectionIcon, WithLoader } from '@syndesis/utils';
 import * as React from 'react';
+import { ApiError } from '../../../shared';
 import {
   getDvConnectionStatus,
   isDvConnectionSelected,
@@ -46,7 +47,7 @@ export class DvConnections extends React.Component<IDvConnectionsProps> {
               ))}
             </>
           }
-          errorChildren={<div>TODO</div>}
+          errorChildren={<ApiError />}
         >
           {() =>
             this.props.connections.map((c, index) => (

--- a/app/ui-react/syndesis/src/modules/data/shared/HeaderView.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/HeaderView.tsx
@@ -2,6 +2,7 @@ import { WithVirtualization } from '@syndesis/api';
 import { Container, Loader } from '@syndesis/ui';
 import { WithLoader } from '@syndesis/utils';
 import * as React from 'react';
+import { ApiError } from '../../../shared';
 
 export interface IWithVirtualizationDetailHeaderProps {
   virtualizationId: string;
@@ -22,7 +23,7 @@ export class HeaderView extends React.Component<
             error={error}
             loading={!hasData}
             loaderChildren={<Loader />}
-            errorChildren={<div>TODO</div>}
+            errorChildren={<ApiError />}
           >
             {() => (
               <Container>

--- a/app/ui-react/syndesis/src/modules/data/shared/ViewInfosContent.tsx
+++ b/app/ui-react/syndesis/src/modules/data/shared/ViewInfosContent.tsx
@@ -12,6 +12,7 @@ import { WithListViewToolbarHelpers, WithLoader } from '@syndesis/utils';
 import * as React from 'react';
 import { Translation } from 'react-i18next';
 import i18n from '../../../i18n';
+import { ApiError } from '../../../shared';
 import { generateViewInfos } from './VirtualizationUtils';
 
 function getFilteredAndSortedSchemaNodes(
@@ -152,7 +153,7 @@ export class ViewInfosContent extends React.Component<IViewInfosContentProps> {
                             }}
                           />
                         }
-                        errorChildren={<div>TODO</div>}
+                        errorChildren={<ApiError />}
                       >
                         {() =>
                           filteredAndSorted.map(

--- a/app/ui-react/syndesis/src/modules/integrations/components/Integrations.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/Integrations.tsx
@@ -22,6 +22,7 @@ import { WithLoader } from '@syndesis/utils';
 import * as React from 'react';
 import { Translation } from 'react-i18next';
 import { AppContext } from '../../../app';
+import { ApiError } from '../../../shared';
 import resolvers from '../resolvers';
 import { TagIntegrationDialogWrapper } from './TagIntegrationDialogWrapper';
 
@@ -146,7 +147,7 @@ export class Integrations extends React.Component<
                         error={this.props.error}
                         loading={this.props.loading}
                         loaderChildren={<IntegrationsListSkeleton />}
-                        errorChildren={<div>TODO</div>}
+                        errorChildren={<ApiError />}
                       >
                         {() =>
                           this.props.integrations.map(

--- a/app/ui-react/syndesis/src/modules/integrations/components/TagIntegrationDialogWrapper.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/TagIntegrationDialogWrapper.tsx
@@ -9,6 +9,7 @@ import {
 import { WithLoader } from '@syndesis/utils';
 import * as React from 'react';
 import { Translation } from 'react-i18next';
+import { ApiError } from '../../../shared';
 
 export interface ITagIntegrationDialogWrapperProps {
   manageCiCdHref: string;
@@ -70,7 +71,7 @@ export class TagIntegrationDialogWrapper extends React.Component<
                                 <CiCdListSkeleton />
                               </CiCdList>
                             }
-                            errorChildren={<p>TODO - Error</p>}
+                            errorChildren={<ApiError />}
                           >
                             {() => {
                               const mappedItems = environments.map(item => ({

--- a/app/ui-react/syndesis/src/modules/integrations/pages/cicd/ManageCiCdPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/cicd/ManageCiCdPage.tsx
@@ -16,7 +16,7 @@ import * as React from 'react';
 import { Translation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import i18n from '../../../../i18n';
-import { PageTitle } from '../../../../shared';
+import { ApiError, PageTitle } from '../../../../shared';
 import resolvers from '../../resolvers';
 
 function getFilteredAndSortedEnvironments(
@@ -182,7 +182,7 @@ export class ManageCiCdPage extends React.Component<{}, IManageCiCdPageState> {
                                 loaderChildren={
                                   <CiCdList children={<CiCdListSkeleton />} />
                                 }
-                                errorChildren={<div>TODO - error</div>}
+                                errorChildren={<ApiError />}
                               >
                                 {() => (
                                   <>

--- a/app/ui-react/syndesis/src/modules/integrations/pages/create/configure/addStep/SelectActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/create/configure/addStep/SelectActionPage.tsx
@@ -8,7 +8,7 @@ import {
 } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
 import * as React from 'react';
-import { PageTitle } from '../../../../../../shared';
+import { ApiError, PageTitle } from '../../../../../../shared';
 import {
   IntegrationCreatorBreadcrumbs,
   IntegrationEditorSidebar,
@@ -46,7 +46,7 @@ export class SelectActionPage extends React.Component {
                   error={error}
                   loading={!hasData}
                   loaderChildren={<Loader />}
-                  errorChildren={<div>TODO</div>}
+                  errorChildren={<ApiError />}
                 >
                   {() => (
                     <>

--- a/app/ui-react/syndesis/src/modules/integrations/pages/create/configure/addStep/SelectConnectionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/create/configure/addStep/SelectConnectionPage.tsx
@@ -8,7 +8,7 @@ import {
 } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
 import * as React from 'react';
-import { PageTitle } from '../../../../../../shared';
+import { ApiError, PageTitle } from '../../../../../../shared';
 import {
   IntegrationCreatorBreadcrumbs,
   IntegrationEditorSidebar,
@@ -64,7 +64,7 @@ export class SelectConnectionPage extends React.Component {
                           error={error}
                           loading={!hasData}
                           loaderChildren={<IntegrationsListSkeleton />}
-                          errorChildren={<div>TODO</div>}
+                          errorChildren={<ApiError />}
                         >
                           {() => (
                             <>

--- a/app/ui-react/syndesis/src/modules/integrations/pages/create/configure/editStep/SelectActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/create/configure/editStep/SelectActionPage.tsx
@@ -8,7 +8,7 @@ import {
 } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
 import * as React from 'react';
-import { PageTitle } from '../../../../../../shared';
+import { ApiError, PageTitle } from '../../../../../../shared';
 import {
   IntegrationCreatorBreadcrumbs,
   IntegrationEditorSidebar,
@@ -44,7 +44,7 @@ export class SelectActionPage extends React.Component {
                   error={error}
                   loading={!hasData}
                   loaderChildren={<Loader />}
-                  errorChildren={<div>TODO</div>}
+                  errorChildren={<ApiError />}
                 >
                   {() => (
                     <>

--- a/app/ui-react/syndesis/src/modules/integrations/pages/create/finish/FinishActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/create/finish/FinishActionPage.tsx
@@ -12,7 +12,7 @@ import {
 } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
 import * as React from 'react';
-import { PageTitle } from '../../../../../shared';
+import { ApiError, PageTitle } from '../../../../../shared';
 import { IntegrationCreatorBreadcrumbs } from '../../../components';
 import resolvers from '../../../resolvers';
 
@@ -116,7 +116,7 @@ export class FinishActionPage extends React.Component {
                       error={error}
                       loading={!hasData}
                       loaderChildren={<Loader />}
-                      errorChildren={<div>TODO</div>}
+                      errorChildren={<ApiError />}
                     >
                       {() => (
                         <IntegrationEditorChooseAction

--- a/app/ui-react/syndesis/src/modules/integrations/pages/create/finish/FinishConnectionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/create/finish/FinishConnectionPage.tsx
@@ -12,7 +12,7 @@ import {
 } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
 import * as React from 'react';
-import { PageTitle } from '../../../../../shared';
+import { ApiError, PageTitle } from '../../../../../shared';
 import { IntegrationCreatorBreadcrumbs } from '../../../components';
 import resolvers from '../../../resolvers';
 
@@ -96,7 +96,7 @@ export class FinishConnectionPage extends React.Component {
                         error={error}
                         loading={!hasData}
                         loaderChildren={<IntegrationsListSkeleton />}
-                        errorChildren={<div>TODO</div>}
+                        errorChildren={<ApiError />}
                       >
                         {() => (
                           <>

--- a/app/ui-react/syndesis/src/modules/integrations/pages/create/start/StartActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/create/start/StartActionPage.tsx
@@ -12,7 +12,7 @@ import {
 } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
 import * as React from 'react';
-import { PageTitle } from '../../../../../shared';
+import { ApiError, PageTitle } from '../../../../../shared';
 import { IntegrationCreatorBreadcrumbs } from '../../../components';
 import resolvers from '../../../resolvers';
 
@@ -61,7 +61,7 @@ export class StartActionPage extends React.Component {
                   error={error}
                   loading={!hasData}
                   loaderChildren={<Loader />}
-                  errorChildren={<div>TODO</div>}
+                  errorChildren={<ApiError />}
                 >
                   {() => (
                     <>

--- a/app/ui-react/syndesis/src/modules/integrations/pages/create/start/StartConnectionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/create/start/StartConnectionPage.tsx
@@ -11,7 +11,7 @@ import {
 } from '@syndesis/ui';
 import { WithLoader } from '@syndesis/utils';
 import * as React from 'react';
-import { PageTitle } from '../../../../../shared';
+import { ApiError, PageTitle } from '../../../../../shared';
 import { IntegrationCreatorBreadcrumbs } from '../../../components';
 import resolvers from '../../../resolvers';
 
@@ -68,7 +68,7 @@ export class StartConnectionPage extends React.Component {
                     error={error}
                     loading={!hasData}
                     loaderChildren={<IntegrationsListSkeleton />}
-                    errorChildren={<div>TODO</div>}
+                    errorChildren={<ApiError />}
                   >
                     {() => (
                       <>

--- a/app/ui-react/syndesis/src/modules/integrations/pages/integration/edit/addStep/SelectActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/integration/edit/addStep/SelectActionPage.tsx
@@ -8,7 +8,7 @@ import {
 } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
 import * as React from 'react';
-import { PageTitle } from '../../../../../../shared';
+import { ApiError, PageTitle } from '../../../../../../shared';
 import {
   IntegrationEditorBreadcrumbs,
   IntegrationEditorSidebar,
@@ -45,7 +45,7 @@ export class SelectActionPage extends React.Component {
                   error={error}
                   loading={!hasData}
                   loaderChildren={<Loader />}
-                  errorChildren={<div>TODO</div>}
+                  errorChildren={<ApiError />}
                 >
                   {() => (
                     <>

--- a/app/ui-react/syndesis/src/modules/integrations/pages/integration/edit/addStep/SelectConnectionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/integration/edit/addStep/SelectConnectionPage.tsx
@@ -8,7 +8,7 @@ import {
 } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
 import * as React from 'react';
-import { PageTitle } from '../../../../../../shared';
+import { ApiError, PageTitle } from '../../../../../../shared';
 import {
   IntegrationEditorBreadcrumbs,
   IntegrationEditorSidebar,
@@ -63,7 +63,7 @@ export class SelectConnectionPage extends React.Component {
                           error={error}
                           loading={!hasData}
                           loaderChildren={<IntegrationsListSkeleton />}
-                          errorChildren={<div>TODO</div>}
+                          errorChildren={<ApiError />}
                         >
                           {() => (
                             <>

--- a/app/ui-react/syndesis/src/modules/integrations/pages/integration/edit/editStep/SelectActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/integration/edit/editStep/SelectActionPage.tsx
@@ -8,7 +8,7 @@ import {
 } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
 import * as React from 'react';
-import { PageTitle } from '../../../../../../shared';
+import { ApiError, PageTitle } from '../../../../../../shared';
 import {
   IntegrationEditorBreadcrumbs,
   IntegrationEditorSidebar,
@@ -43,7 +43,7 @@ export class SelectActionPage extends React.Component {
                   error={error}
                   loading={!hasData}
                   loaderChildren={<Loader />}
-                  errorChildren={<div>TODO</div>}
+                  errorChildren={<ApiError />}
                 >
                   {() => (
                     <>

--- a/app/ui-react/syndesis/src/shared/ApiError.tsx
+++ b/app/ui-react/syndesis/src/shared/ApiError.tsx
@@ -1,0 +1,24 @@
+import { UnrecoverableError } from '@syndesis/ui';
+import * as React from 'react';
+import { Translation } from 'react-i18next';
+
+export interface IApiErrorProps {
+  error?: Error;
+  errorInfo?: React.ErrorInfo;
+}
+
+export const ApiError: React.SFC<IApiErrorProps> = props => (
+  <Translation ns={['shared']}>
+    {t => (
+      <UnrecoverableError
+        i18nTitle={t('error.title')}
+        i18nInfo={'error.info'}
+        i18nHelp={'error.help'}
+        i18nRefreshLabel={'error.refreshButton'}
+        i18nReportIssue={'error.reportIssueButton'}
+        error={props.error}
+        errorInfo={props.errorInfo}
+      />
+    )}
+  </Translation>
+);

--- a/app/ui-react/syndesis/src/shared/index.ts
+++ b/app/ui-react/syndesis/src/shared/index.ts
@@ -1,3 +1,4 @@
+export * from './ApiError';
 export * from './ModuleLoader';
 export * from './PageNotFound';
 export * from './PageTitle';


### PR DESCRIPTION
fixes #168

Also added in a quick storybook for `UnrecoverableError` just so it's there.