### PR TITLE
Add progress bar for virtualization publishing status

### DIFF
--- a/app/ui-react/packages/models/src/dv.d.ts
+++ b/app/ui-react/packages/models/src/dv.d.ts
@@ -17,6 +17,7 @@ export interface RestDataService {
     | 'NOTFOUND'
     | 'RUNNING'
     | 'SUBMITTED';
+  publishLogUrl?: string;
   serviceVdbName: string;
   serviceVdbVersion: string;
   serviceViewDefinitions: string[];
@@ -96,4 +97,20 @@ export interface RowData {
 export interface QueryResults {
   columns: ColumnData[];
   rows: RowData[];
+}
+
+export interface VirtualizationPublishingDetails {
+  state:
+    | 'BUILDING'
+    | 'CANCELLED'
+    | 'CONFIGURING'
+    | 'DEPLOYING'
+    | 'FAILED'
+    | 'NOTFOUND'
+    | 'RUNNING'
+    | 'SUBMITTED';
+  logUrl?: string;
+  stepNumber: number;
+  stepText: string;
+  stepTotal: number;
 }

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationListItem.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationListItem.tsx
@@ -53,7 +53,10 @@ export interface IVirtualizationListItemProps {
   onExport: (virtualizationName: string) => void;
   onPublish: (virtualizationName: string) => void;
   onUnpublish: (virtualizationName: string) => void;
-  publishLogUrl?: string;
+  publishingCurrentStep?: number;
+  publishingLogUrl?: string;
+  publishingTotalSteps?: number;
+  publishingStepText?: string;
   serviceVdbName: string;
   virtualizationName: string;
   virtualizationDescription: string;
@@ -191,7 +194,10 @@ export class VirtualizationListItem extends React.Component<
             <div className="form-group">
               {publishInProgress ? (
                 <VirtualizationPublishStatusDetail
-                  logUrl={this.props.publishLogUrl}
+                  logUrl={this.props.publishingLogUrl}
+                  stepText={this.props.publishingStepText}
+                  currentStep={this.props.publishingCurrentStep}
+                  totalSteps={this.props.publishingTotalSteps}
                   i18nPublishInProgress={this.props.i18nPublishInProgress}
                   i18nLogUrlText={this.props.i18nPublishLogUrlText}
                 />
@@ -221,12 +227,13 @@ export class VirtualizationListItem extends React.Component<
                   {this.props.i18nExport}
                 </MenuItem>
                 <MenuItem
-                  disabled={publishInProgress}
                   onClick={
-                    isPublished ? this.handleUnpublish : this.handlePublish
+                    isPublished || publishInProgress
+                      ? this.handleUnpublish
+                      : this.handlePublish
                   }
                 >
-                  {isPublished
+                  {isPublished || publishInProgress
                     ? this.props.i18nUnpublish
                     : this.props.i18nPublish}
                 </MenuItem>

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationPublishStatus.css
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationPublishStatus.css
@@ -1,0 +1,3 @@
+.virtualization-publish-status-label {
+  margin-right: 10px;
+}

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationPublishStatus.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationPublishStatus.tsx
@@ -11,6 +11,7 @@ import {
   SUBMITTED,
   VirtualizationPublishState,
 } from './models';
+import './VirtualizationPublishStatus.css';
 
 export interface IVirtualizationPublishStatusProps {
   currentState?: VirtualizationPublishState;
@@ -47,6 +48,10 @@ export class VirtualizationPublishStatus extends React.Component<
         label = DEPLOYING;
         break;
     }
-    return <Label type={labelType}>{label}</Label>;
+    return (
+      <Label className={'virtualization-publish-status-label'} type={labelType}>
+        {label}
+      </Label>
+    );
   }
 }

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationPublishStatusDetail.css
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationPublishStatusDetail.css
@@ -1,0 +1,6 @@
+.virtualization-publish-status-detail {
+  align-items: center;
+  display: inline-flex;
+  flex-flow: row;
+  margin-right: 10px;
+}

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationPublishStatusDetail.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationPublishStatusDetail.tsx
@@ -1,7 +1,13 @@
-import { Icon, Spinner } from 'patternfly-react';
+import { Spinner } from 'patternfly-react';
 import * as React from 'react';
+import { ProgressWithLink } from '../../Shared';
+
+import './VirtualizationPublishStatusDetail.css';
 
 export interface IVirtualizationPublishStatusDetailProps {
+  currentStep?: number;
+  totalSteps?: number;
+  stepText?: string;
   logUrl?: string;
   i18nPublishInProgress: string;
   i18nLogUrlText: string;
@@ -12,15 +18,27 @@ export class VirtualizationPublishStatusDetail extends React.Component<
 > {
   public render() {
     return (
-      <>
-        <Spinner loading={true} inline={true} />
-        {this.props.i18nPublishInProgress}
-        {this.props.logUrl && (
-          <a target="_blank" href={this.props.logUrl}>
-            {this.props.i18nLogUrlText} <Icon name={'external-link'} />
-          </a>
+      <div
+        data-testid="virtualization-publish-status-detail"
+        className={'virtualization-publish-status-detail'}
+      >
+        {this.props.stepText &&
+        this.props.currentStep &&
+        this.props.totalSteps ? (
+          <ProgressWithLink
+            currentStep={this.props.currentStep}
+            totalSteps={this.props.totalSteps}
+            value={this.props.stepText}
+            logUrl={this.props.logUrl}
+            i18nLogUrlText={this.props.i18nLogUrlText}
+          />
+        ) : (
+          <>
+            <Spinner loading={true} inline={true} />
+            {this.props.i18nPublishInProgress}
+          </>
         )}
-      </>
+      </div>
     );
   }
 }

--- a/app/ui-react/packages/ui/src/Integration/IntegrationProgress.css
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationProgress.css
@@ -1,7 +1,0 @@
-.integration-progress {
-  width: 180px;
-}
-
-.integration-progress .integration-progress-value {
-  text-transform: capitalize;
-}

--- a/app/ui-react/packages/ui/src/Integration/IntegrationStatusDetail.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationStatusDetail.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from 'patternfly-react';
 import * as React from 'react';
-import { IntegrationProgress } from './IntegrationProgress';
+import { ProgressWithLink } from '../Shared/ProgressWithLink';
 import { IntegrationState, PUBLISHED, UNPUBLISHED } from './models';
 
 import './IntegrationStatusDetail.css';
@@ -36,7 +36,7 @@ export class IntegrationStatusDetail extends React.Component<
         className={'integration-status-detail'}
       >
         {this.props.value && this.props.currentStep && this.props.totalSteps ? (
-          <IntegrationProgress
+          <ProgressWithLink
             currentStep={this.props.currentStep}
             totalSteps={this.props.totalSteps}
             value={this.props.value}

--- a/app/ui-react/packages/ui/src/Integration/index.ts
+++ b/app/ui-react/packages/ui/src/Integration/index.ts
@@ -21,7 +21,6 @@ export * from './IntegrationFlowStepDetails';
 export * from './IntegrationFlowStepGeneric';
 export * from './IntegrationFlowStepWithOverview';
 export * from './IntegrationIcon';
-export * from './IntegrationProgress';
 export * from './IntegrationStatus';
 export * from './IntegrationStatusDetail';
 export * from './IntegrationStepsHorizontalView';

--- a/app/ui-react/packages/ui/src/Shared/ProgressWithLink.css
+++ b/app/ui-react/packages/ui/src/Shared/ProgressWithLink.css
@@ -1,0 +1,7 @@
+.progress-link {
+  width: 180px;
+}
+
+.progress-link .progress-link-value {
+  text-transform: capitalize;
+}

--- a/app/ui-react/packages/ui/src/Shared/ProgressWithLink.tsx
+++ b/app/ui-react/packages/ui/src/Shared/ProgressWithLink.tsx
@@ -1,9 +1,9 @@
 import { Icon, ProgressBar } from 'patternfly-react';
 import * as React from 'react';
 
-import './IntegrationProgress.css';
+import './ProgressWithLink.css';
 
-export interface IIntegrationProgressProps {
+export interface IProgressWithLinkProps {
   value: string;
   currentStep: number;
   totalSteps: number;
@@ -11,19 +11,19 @@ export interface IIntegrationProgressProps {
   i18nLogUrlText: string;
 }
 
-export class IntegrationProgress extends React.PureComponent<
-  IIntegrationProgressProps
+export class ProgressWithLink extends React.PureComponent<
+  IProgressWithLinkProps
 > {
   public render() {
     return (
-      <div className="integration-progress">
+      <div className="progress-link">
         <div>
-          <i data-testid="integration-progress-value">
+          <i data-testid="progress-link-value">
             {this.props.value} ( {this.props.currentStep} /{' '}
             {this.props.totalSteps} )
           </i>
           {this.props.logUrl && (
-            <span data-testid="deployment-log-link" className="pull-right">
+            <span data-testid="progress-log-link" className="pull-right">
               <a target="_blank" href={this.props.logUrl}>
                 {this.props.i18nLogUrlText} <Icon name={'external-link'} />
               </a>

--- a/app/ui-react/packages/ui/src/Shared/index.ts
+++ b/app/ui-react/packages/ui/src/Shared/index.ts
@@ -7,4 +7,5 @@ export * from './ListViewToolbar';
 export * from './LogViewer';
 export * from './Notifications';
 export * from './SimplePageHeader';
+export * from './ProgressWithLink';
 export * from './UnrecoverableError';

--- a/app/ui-react/packages/ui/stories/Data/Virtualizations/VirtualizationList.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/Virtualizations/VirtualizationList.stories.tsx
@@ -22,8 +22,11 @@ const virtualizationName1 = 'Virtualization_1';
 const virtualizationDescription1 = 'Virtualization 1 description ...';
 const virtualizationName2 = 'Virtualization_2';
 const virtualizationDescription2 = 'Virtualization 2 description ...';
+const virtualizationName3 = 'Virtualization_3';
+const virtualizationDescription3 = 'Virtualization 3 description ...';
 const serviceVdbName1 = 'virtualization_1vdb';
 const serviceVdbName2 = 'virtualization_2vdb';
+const serviceVdbName3 = 'virtualization_3vdb';
 const cancelText = 'Cancel';
 const editText = 'Edit';
 const editTip1 = 'Edit ' + virtualizationName1 + ' virtualization';
@@ -45,6 +48,7 @@ const publishInProgressText = 'Publish In Progress';
 const publishLogUrlText = 'View Logs';
 const currentStatusPublished = 'RUNNING';
 const currentStatusDraft = 'NOTFOUND';
+const currentStatusBuilding = 'BUILDING';
 
 const viewItems = [
   <ViewListItem
@@ -105,7 +109,7 @@ const virtItem = [
     onUnpublish={action(unpublishText)}
     onPublish={action(publishText)}
     currentPublishedState={currentStatusDraft}
-    publishLogUrl=""
+    publishingLogUrl=""
     children={viewItems}
   />,
 ];
@@ -138,7 +142,7 @@ const virtualizationItems = [
     onUnpublish={action(unpublishText)}
     onPublish={action(publishText)}
     currentPublishedState={currentStatusDraft}
-    publishLogUrl=""
+    publishingLogUrl=""
   />,
   <VirtualizationListItem
     key="virtualizationListItem2"
@@ -167,7 +171,38 @@ const virtualizationItems = [
     onUnpublish={action(unpublishText)}
     onPublish={action(publishText)}
     currentPublishedState={currentStatusPublished}
-    publishLogUrl=""
+  />,
+  <VirtualizationListItem
+    key="virtualizationListItem3"
+    virtualizationName={virtualizationName3}
+    virtualizationDescription={virtualizationDescription3}
+    serviceVdbName={serviceVdbName3}
+    detailsPageLink={''}
+    i18nCancelText={cancelText}
+    i18nDelete={deleteText}
+    i18nDeleteModalMessage={confirmDeleteMessage}
+    i18nDeleteModalTitle={confirmDeleteTitle}
+    i18nDraft={draftText}
+    i18nEdit={editText}
+    i18nEditTip={editTip2}
+    i18nError={errorText}
+    i18nExport={exportText}
+    i18nPublished={publishedText}
+    i18nUnpublish={unpublishText}
+    i18nPublish={publishText}
+    i18nPublishInProgress={publishInProgressText}
+    i18nPublishLogUrlText={publishLogUrlText}
+    i18nUnpublishModalMessage={confirmUnpublishMessage}
+    i18nUnpublishModalTitle={confirmUnpublishTitle}
+    onDelete={action(deleteText)}
+    onExport={action(exportText)}
+    onUnpublish={action(unpublishText)}
+    onPublish={action(publishText)}
+    currentPublishedState={currentStatusBuilding}
+    publishingLogUrl={''}
+    publishingCurrentStep={2}
+    publishingTotalSteps={4}
+    publishingStepText={'Building'}
   />,
 ];
 
@@ -208,7 +243,7 @@ const defaultNotes =
   '" button tooltip is "' +
   createVirtualizationTip;
 
-const twoVirtualizationsTestNotes =
+const threeVirtualizationsTestNotes =
   defaultNotes +
   '"\n' +
   '- Verify empty state component does not show\n' +
@@ -303,8 +338,8 @@ stories
   )
 
   .add(
-    '2 virtualizations',
-    withNotes(twoVirtualizationsTestNotes)(() => (
+    '3 virtualizations',
+    withNotes(threeVirtualizationsTestNotes)(() => (
       <Router>
         <VirtualizationList
           activeFilters={[]}

--- a/app/ui-react/packages/ui/stories/Data/Virtualizations/VirtualizationListItem.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/Virtualizations/VirtualizationListItem.stories.tsx
@@ -120,7 +120,7 @@ stories.add(
         ],
         'NOTFOUND'
       )}
-      publishLogUrl={text('publishLogUrl', publishLogUrl)}
+      publishingLogUrl={text('publishLogUrl', publishLogUrl)}
     />
   ))
 );

--- a/app/ui-react/packages/ui/stories/Data/Virtualizations/VirtualizationPublishStatusDetail.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Data/Virtualizations/VirtualizationPublishStatusDetail.stories.tsx
@@ -16,12 +16,18 @@ stories
 
   .add('without logs link', () => (
     <VirtualizationPublishStatusDetail
+      currentStep={2}
+      totalSteps={4}
+      stepText={'Building'}
       i18nPublishInProgress={publishInProgress}
       i18nLogUrlText={logUrlText}
     />
   ))
   .add('with logs link', () => (
     <VirtualizationPublishStatusDetail
+      currentStep={2}
+      totalSteps={4}
+      stepText={'Building'}
       logUrl={logsLink}
       i18nPublishInProgress={publishInProgress}
       i18nLogUrlText={logUrlText}

--- a/app/ui-react/packages/ui/stories/Shared/ProgressWithLink.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Shared/ProgressWithLink.stories.tsx
@@ -2,14 +2,14 @@ import { text } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 
-import { IntegrationProgress } from '../../src';
+import { ProgressWithLink } from '../../src';
 
-const stories = storiesOf('Integration/IntegrationProgress', module);
+const stories = storiesOf('Shared/ProgressWithLink', module);
 
 stories
 
   .add('without log link', () => (
-    <IntegrationProgress
+    <ProgressWithLink
       value={text('value', 'Building')}
       currentStep={text('currentStep', '2')}
       totalSteps={text('totalSteps', '4')}
@@ -17,7 +17,7 @@ stories
     />
   ))
   .add('with log link', () => (
-    <IntegrationProgress
+    <ProgressWithLink
       value={text('value', 'Deploying')}
       currentStep={text('currentStep', '3')}
       totalSteps={text('totalSteps', '4')}

--- a/app/ui-react/packages/ui/tests/ProgressWithLink.spec.tsx
+++ b/app/ui-react/packages/ui/tests/ProgressWithLink.spec.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { render } from 'react-testing-library';
-import { IntegrationProgress } from '../src/Integration';
+import { ProgressWithLink } from '../src/Shared';
 
 export default describe('IntegrationProgress', () => {
   // Component with a log link
   const testComponent = (
-    <IntegrationProgress
+    <ProgressWithLink
       value={'Deploying'}
       currentStep={2}
       totalSteps={4}
@@ -16,7 +16,7 @@ export default describe('IntegrationProgress', () => {
 
   // Component without a log link
   const testComponentNoLog = (
-    <IntegrationProgress
+    <ProgressWithLink
       value={'Assembling'}
       currentStep={1}
       totalSteps={4}
@@ -26,23 +26,23 @@ export default describe('IntegrationProgress', () => {
 
   it('Should show the progress value and steps', () => {
     const { getByTestId } = render(testComponent);
-    expect(getByTestId('integration-progress-value')).toHaveTextContent(
+    expect(getByTestId('progress-link-value')).toHaveTextContent(
       'Deploying ( 2 / 4 )'
     );
   });
   it('Should show the log link when supplied', () => {
     const { queryByTestId } = render(testComponent);
-    expect(queryByTestId('deployment-log-link')).toBeDefined();
-    expect(queryByTestId('deployment-log-link')).toHaveTextContent('View Logs');
+    expect(queryByTestId('progress-log-link')).toBeDefined();
+    expect(queryByTestId('progress-log-link')).toHaveTextContent('View Logs');
   });
   it('Should show the progress value and steps', () => {
     const { getByTestId } = render(testComponentNoLog);
-    expect(getByTestId('integration-progress-value')).toHaveTextContent(
+    expect(getByTestId('progress-link-value')).toHaveTextContent(
       'Assembling ( 1 / 4 )'
     );
   });
   it('Should not show the log link if not supplied', () => {
     const { queryByTestId } = render(testComponentNoLog);
-    expect(queryByTestId('deployment-log-link')).toEqual(null);
+    expect(queryByTestId('progess-log-link')).toEqual(null);
   });
 });

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.en.json
@@ -7,7 +7,7 @@
     "deleteModalTitle": "Delete Virtualization",
     "deleteViewModalMessage": "Are you sure you want to delete the \"{{name}}\" view?",
     "editDataVirtualizationTip": "Edit the data virtualization",
-    "emptyStateInfoMessage": "There are no virtualizations available. Please click on the button below to import one.",
+    "emptyStateInfoMessage": "There are no virtualizations available. Please click on the button below to create one.",
     "emptyStateTitle": "$t(virtualization.createDataVirtualization)",
     "importVirtualizationTip": "Import a data virtualization",
     "publishedDataVirtualization": "Published",

--- a/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
+++ b/app/ui-react/syndesis/src/modules/data/locales/data-translations.it.json
@@ -7,7 +7,7 @@
     "deleteModalTitle": "Delete Virtualization",
     "deleteViewModalMessage": "Are you sure you want to delete the \"{{name}}\" view?",
     "editDataVirtualizationTip": "Edit the data virtualization",
-    "emptyStateInfoMessage": "There are no virtualizations available. Please click on the button below to import one.",
+    "emptyStateInfoMessage": "There are no virtualizations available. Please click on the button below to create one.",
     "emptyStateTitle": "$t(virtualization.createDataVirtualization)",
     "importVirtualizationTip": "Import a data virtualization",
     "publishedDataVirtualization": "Published",

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationsPage.tsx
@@ -14,6 +14,7 @@ import { Translation } from 'react-i18next';
 import i18n from '../../../i18n';
 import { ApiError } from '../../../shared';
 import resolvers from '../resolvers';
+import { getPublishingDetails } from '../shared/VirtualizationUtils';
 
 function getFilteredAndSortedVirtualizations(
   virtualizations: RestDataService[],
@@ -183,67 +184,85 @@ export class VirtualizationsPage extends React.Component {
                                   (
                                     virtualization: RestDataService,
                                     index: number
-                                  ) => (
-                                    <VirtualizationListItem
-                                      key={index}
-                                      detailsPageLink={resolvers.virtualizations.views.root(
-                                        { virtualization }
-                                      )}
-                                      virtualizationName={
-                                        virtualization.keng__id
-                                      }
-                                      virtualizationDescription={
-                                        virtualization.tko__description
-                                          ? virtualization.tko__description
-                                          : ''
-                                      }
-                                      serviceVdbName={
-                                        virtualization.serviceVdbName
-                                      }
-                                      i18nCancelText={t('shared:Cancel')}
-                                      i18nDelete={t('shared:Delete')}
-                                      i18nDeleteModalMessage={t(
-                                        'virtualization.deleteModalMessage',
-                                        { name: virtualization.keng__id }
-                                      )}
-                                      i18nDeleteModalTitle={t(
-                                        'virtualization.deleteModalTitle'
-                                      )}
-                                      i18nDraft={t('shared:Draft')}
-                                      i18nEdit={t('shared:Edit')}
-                                      i18nEditTip={t(
-                                        'virtualization.editDataVirtualizationTip'
-                                      )}
-                                      i18nError={t('shared:Error')}
-                                      i18nExport={t('shared:Export')}
-                                      i18nPublish={t('shared:Publish')}
-                                      i18nPublished={t(
-                                        'virtualization.publishedDataVirtualization'
-                                      )}
-                                      i18nUnpublish={t('shared:Unpublish')}
-                                      i18nUnpublishModalMessage={t(
-                                        'virtualization.unpublishModalMessage',
-                                        { name: virtualization.keng__id }
-                                      )}
-                                      i18nUnpublishModalTitle={t(
-                                        'virtualization.unpublishModalTitle'
-                                      )}
-                                      onDelete={handleDelete}
-                                      onExport={this.handleExportVirtualization}
-                                      onUnpublish={handleUnpublish}
-                                      onPublish={handlePublish}
-                                      currentPublishedState={
-                                        virtualization.publishedState
-                                      }
-                                      publishLogUrl={''} // TODO set the generated url for the pod
-                                      i18nPublishInProgress={t(
-                                        'virtualization.publishInProgress'
-                                      )}
-                                      i18nPublishLogUrlText={t(
-                                        'shared:viewLogs'
-                                      )}
-                                    />
-                                  )
+                                  ) => {
+                                    const publishingDetails = getPublishingDetails(
+                                      virtualization
+                                    );
+                                    return (
+                                      <VirtualizationListItem
+                                        key={index}
+                                        detailsPageLink={resolvers.virtualizations.views.root(
+                                          { virtualization }
+                                        )}
+                                        virtualizationName={
+                                          virtualization.keng__id
+                                        }
+                                        virtualizationDescription={
+                                          virtualization.tko__description
+                                            ? virtualization.tko__description
+                                            : ''
+                                        }
+                                        serviceVdbName={
+                                          virtualization.serviceVdbName
+                                        }
+                                        i18nCancelText={t('shared:Cancel')}
+                                        i18nDelete={t('shared:Delete')}
+                                        i18nDeleteModalMessage={t(
+                                          'virtualization.deleteModalMessage',
+                                          { name: virtualization.keng__id }
+                                        )}
+                                        i18nDeleteModalTitle={t(
+                                          'virtualization.deleteModalTitle'
+                                        )}
+                                        i18nDraft={t('shared:Draft')}
+                                        i18nEdit={t('shared:Edit')}
+                                        i18nEditTip={t(
+                                          'virtualization.editDataVirtualizationTip'
+                                        )}
+                                        i18nError={t('shared:Error')}
+                                        i18nExport={t('shared:Export')}
+                                        i18nPublish={t('shared:Publish')}
+                                        i18nPublished={t(
+                                          'virtualization.publishedDataVirtualization'
+                                        )}
+                                        i18nUnpublish={t('shared:Unpublish')}
+                                        i18nUnpublishModalMessage={t(
+                                          'virtualization.unpublishModalMessage',
+                                          { name: virtualization.keng__id }
+                                        )}
+                                        i18nUnpublishModalTitle={t(
+                                          'virtualization.unpublishModalTitle'
+                                        )}
+                                        onDelete={handleDelete}
+                                        onExport={
+                                          this.handleExportVirtualization
+                                        }
+                                        onUnpublish={handleUnpublish}
+                                        onPublish={handlePublish}
+                                        currentPublishedState={
+                                          publishingDetails.state
+                                        }
+                                        publishingLogUrl={
+                                          publishingDetails.logUrl
+                                        }
+                                        publishingCurrentStep={
+                                          publishingDetails.stepNumber
+                                        }
+                                        publishingTotalSteps={
+                                          publishingDetails.stepTotal
+                                        }
+                                        publishingStepText={
+                                          publishingDetails.stepText
+                                        }
+                                        i18nPublishInProgress={t(
+                                          'virtualization.publishInProgress'
+                                        )}
+                                        i18nPublishLogUrlText={t(
+                                          'shared:viewLogs'
+                                        )}
+                                      />
+                                    );
+                                  }
                                 )
                               }
                             </WithLoader>

--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
@@ -1,10 +1,12 @@
 import {
   Connection,
   ProjectedColumn,
+  RestDataService,
   SchemaNode,
   ViewDefinition,
   ViewEditorState,
   ViewInfo,
+  VirtualizationPublishingDetails,
   VirtualizationSourceStatus,
 } from '@syndesis/models';
 
@@ -203,6 +205,44 @@ export function isDvConnectionSelected(conn: Connection) {
     isSelected = true;
   }
   return isSelected;
+}
+
+/**
+ * Get publishing state details for the specified virtualization
+ * @param virtualization the RestDataService
+ */
+export function getPublishingDetails(
+  virtualization: RestDataService
+): VirtualizationPublishingDetails {
+  // Determine published state
+  const publishStepDetails: VirtualizationPublishingDetails = {
+    state: virtualization.publishedState,
+    stepNumber: 0,
+    stepText: '',
+    stepTotal: 4,
+  };
+  switch (virtualization.publishedState) {
+    case 'CONFIGURING':
+      publishStepDetails.stepNumber = 1;
+      publishStepDetails.stepText = 'Configuring';
+      break;
+    case 'BUILDING':
+      publishStepDetails.stepNumber = 2;
+      publishStepDetails.stepText = 'Building';
+      break;
+    case 'DEPLOYING':
+      publishStepDetails.stepNumber = 3;
+      publishStepDetails.stepText = 'Deploying';
+      break;
+    case 'RUNNING':
+      publishStepDetails.stepNumber = 4;
+      publishStepDetails.stepText = 'Published';
+      break;
+  }
+  if (virtualization.publishLogUrl) {
+    publishStepDetails.logUrl = virtualization.publishLogUrl;
+  }
+  return publishStepDetails;
 }
 
 /**


### PR DESCRIPTION
Adds progress bar for status updates when virtualization is being published, similar to integrations progress bar.
- renames IntegrationProgress to ProgressWithLink and moves it into /Shared.  Update usages, stories and tests accordingly.
- VirtualizationPublishStatusDetail component is updated to use the shared component
- Add VirtualizationPublishingDetails model, and add function in VirtualizationUtils to return the publishing details for a virtualization
- updates data stories
