### PR TITLE
TTOOLS-615 Updates Virtualization and View lists upon delete

### DIFF
--- a/app/ui-react/packages/api/src/WithViewEditorStates.tsx
+++ b/app/ui-react/packages/api/src/WithViewEditorStates.tsx
@@ -3,9 +3,14 @@ import * as React from 'react';
 import { DVFetch } from './DVFetch';
 import { IFetchState } from './Fetch';
 
+export interface IWithViewEditorStatesRenderProps
+  extends IFetchState<ViewEditorState[]> {
+  read(): Promise<void>;
+}
+
 export interface IWithViewEditorStatesProps {
   idPattern?: string;
-  children(props: IFetchState<ViewEditorState[]>): any;
+  children(props: IWithViewEditorStatesRenderProps): any;
 }
 
 export class WithViewEditorStates extends React.Component<
@@ -20,7 +25,7 @@ export class WithViewEditorStates extends React.Component<
         }
         defaultValue={[]}
       >
-        {({ response }) => this.props.children(response)}
+        {({ read, response }) => this.props.children({ ...response, read })}
       </DVFetch>
     );
   }

--- a/app/ui-react/packages/api/src/WithVirtualizationHelpers.tsx
+++ b/app/ui-react/packages/api/src/WithVirtualizationHelpers.tsx
@@ -13,7 +13,7 @@ export interface IWithVirtualizationHelpersChildrenProps {
   createVirtualization(
     virtualizationName: string,
     virtualizationDescription?: string
-  ): Promise<void>;
+  ): Promise<RestDataService>;
   deleteView(virtualization: RestDataService, viewName: string): Promise<void>;
   deleteViewEditorState(viewEditorStateId: string): Promise<void>;
   deleteVirtualization(virtualizationName: string): Promise<void>;
@@ -63,7 +63,7 @@ export class WithVirtualizationHelpersWrapped extends React.Component<
   public async createVirtualization(
     virtName: string,
     virtDesc?: string
-  ): Promise<void> {
+  ): Promise<RestDataService> {
     const newVirtualization = {
       keng__dataPath: `${WORKSPACE_ROOT}${this.props.username}/${virtName}`,
       keng__id: `${virtName}`,
@@ -80,7 +80,7 @@ export class WithVirtualizationHelpersWrapped extends React.Component<
       throw new Error(response.statusText);
     }
 
-    return Promise.resolve();
+    return Promise.resolve(newVirtualization);
   }
 
   /**

--- a/app/ui-react/packages/api/src/WithVirtualizations.tsx
+++ b/app/ui-react/packages/api/src/WithVirtualizations.tsx
@@ -4,8 +4,13 @@ import { DVFetch } from './DVFetch';
 import { IFetchState } from './Fetch';
 import { WithPolling } from './WithPolling';
 
+export interface IWithVirtualizationsRenderProps
+  extends IFetchState<RestDataService[]> {
+  read(): Promise<void>;
+}
+
 export interface IWithVirtualizationsProps {
-  children(props: IFetchState<RestDataService[]>): any;
+  children(props: IWithVirtualizationsRenderProps): any;
 }
 
 export class WithVirtualizations extends React.Component<
@@ -20,7 +25,7 @@ export class WithVirtualizations extends React.Component<
         {({ read, response }) => {
           return (
             <WithPolling read={read} polling={5000}>
-              {() => this.props.children(response)}
+              {() => this.props.children({ ...response, read })}
             </WithPolling>
           );
         }}

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationCreatePage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationCreatePage.tsx
@@ -52,12 +52,14 @@ export class VirtualizationCreatePage extends React.Component {
           <WithVirtualizationHelpers username="developer">
             {({ createVirtualization }) => {
               const handleCreate = async (value: any) => {
-                await createVirtualization(
+                const virtualization = await createVirtualization(
                   value.virtName,
                   value.virtDescription
                 );
                 // TODO: post toast notification
-                history.push(resolvers.data.virtualizations.list());
+                history.push(
+                  resolvers.data.virtualizations.views.root({ virtualization })
+                );
               };
               return (
                 <Translation ns={['data', 'shared']}>

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationViewsPage.tsx
@@ -109,151 +109,155 @@ export class VirtualizationViewsPage extends React.Component<
       >>
         {({ virtualizationId }, { virtualization }, { history }) => {
           return (
-            // TODO need to retrieve real username here
-            <WithVirtualizationHelpers username="developer">
-              {({ deleteView }) => {
-                const handleDeleteView = async (viewName: string) => {
-                  await deleteView(virtualization, viewName);
-                  // TODO: post toast notification
-                };
-                return (
-                  <div>
-                    <HeaderView virtualizationId={virtualizationId} />
-                    <WithViewEditorStates
-                      idPattern={virtualization.serviceVdbName + '*'}
-                    >
-                      {({ data, hasData, error }) => (
-                        <WithListViewToolbarHelpers
-                          defaultFilterType={filterByName}
-                          defaultSortType={sortByName}
-                        >
-                          {helpers => {
-                            const viewDefns = data.map(
-                              (editorState: ViewEditorState) =>
-                                editorState.viewDefinition
-                            );
-                            const filteredAndSorted = getFilteredAndSortedViewDefns(
-                              viewDefns,
-                              helpers.activeFilters,
-                              helpers.currentSortType,
-                              helpers.isSortAscending
-                            );
-                            return (
-                              <Translation ns={['data', 'shared']}>
-                                {t => (
-                                  <>
-                                    <VirtualizationNavBar
-                                      virtualization={virtualization}
-                                    />
-                                    <ViewList
-                                      filterTypes={filterTypes}
-                                      sortTypes={sortTypes}
-                                      {...this.state}
-                                      resultsCount={filteredAndSorted.length}
-                                      {...helpers}
-                                      i18nDescription={t(
-                                        'data:virtualization.viewsPageDescription'
-                                      )}
-                                      i18nEmptyStateInfo={t(
-                                        'data:virtualization.viewEmptyStateInfo'
-                                      )}
-                                      i18nEmptyStateTitle={t(
-                                        'data:virtualization.viewEmptyStateTitle'
-                                      )}
-                                      i18nImportViews={t(
-                                        'data:virtualization.importDataSource'
-                                      )}
-                                      i18nImportViewsTip={t(
-                                        'data:virtualization.importDataSourceTip'
-                                      )}
-                                      i18nCreateView={t(
-                                        'data:virtualization.createView'
-                                      )}
-                                      i18nCreateViewTip={t(
-                                        'data:virtualization.createViewTip'
-                                      )}
-                                      i18nName={t('shared:Name')}
-                                      i18nNameFilterPlaceholder={t(
-                                        'shared:nameFilterPlaceholder'
-                                      )}
-                                      i18nResultsCount={t(
-                                        'shared:resultsCount',
-                                        {
-                                          count: filteredAndSorted.length,
+            <div>
+              <HeaderView virtualizationId={virtualizationId} />
+              <WithViewEditorStates
+                idPattern={virtualization.serviceVdbName + '*'}
+              >
+                {({ data, hasData, error, read }) => {
+                  return (
+                    // TODO need to retrieve real username here
+                    <WithVirtualizationHelpers username="developer">
+                      {({ deleteView }) => {
+                        const handleDeleteView = async (viewName: string) => {
+                          await deleteView(virtualization, viewName).then(read);
+                          // TODO: post toast notification
+                        };
+                        return (
+                          <WithListViewToolbarHelpers
+                            defaultFilterType={filterByName}
+                            defaultSortType={sortByName}
+                          >
+                            {helpers => {
+                              const viewDefns = data.map(
+                                (editorState: ViewEditorState) =>
+                                  editorState.viewDefinition
+                              );
+                              const filteredAndSorted = getFilteredAndSortedViewDefns(
+                                viewDefns,
+                                helpers.activeFilters,
+                                helpers.currentSortType,
+                                helpers.isSortAscending
+                              );
+                              return (
+                                <Translation ns={['data', 'shared']}>
+                                  {t => (
+                                    <>
+                                      <VirtualizationNavBar
+                                        virtualization={virtualization}
+                                      />
+                                      <ViewList
+                                        filterTypes={filterTypes}
+                                        sortTypes={sortTypes}
+                                        {...this.state}
+                                        resultsCount={filteredAndSorted.length}
+                                        {...helpers}
+                                        i18nDescription={t(
+                                          'data:virtualization.viewsPageDescription'
+                                        )}
+                                        i18nEmptyStateInfo={t(
+                                          'data:virtualization.viewEmptyStateInfo'
+                                        )}
+                                        i18nEmptyStateTitle={t(
+                                          'data:virtualization.viewEmptyStateTitle'
+                                        )}
+                                        i18nImportViews={t(
+                                          'data:virtualization.importDataSource'
+                                        )}
+                                        i18nImportViewsTip={t(
+                                          'data:virtualization.importDataSourceTip'
+                                        )}
+                                        i18nCreateView={t(
+                                          'data:virtualization.createView'
+                                        )}
+                                        i18nCreateViewTip={t(
+                                          'data:virtualization.createViewTip'
+                                        )}
+                                        i18nName={t('shared:Name')}
+                                        i18nNameFilterPlaceholder={t(
+                                          'shared:nameFilterPlaceholder'
+                                        )}
+                                        i18nResultsCount={t(
+                                          'shared:resultsCount',
+                                          {
+                                            count: filteredAndSorted.length,
+                                          }
+                                        )}
+                                        // TODO - Point to views.create when available
+                                        linkCreateViewHRef={resolvers.virtualizations.create()}
+                                        linkImportViewsHRef={resolvers.virtualizations.views.importSource.selectConnection(
+                                          { virtualization }
+                                        )}
+                                        onImportView={this.handleImportView}
+                                        hasListData={data.length > 0}
+                                      />
+                                      <WithLoader
+                                        error={error}
+                                        loading={!hasData}
+                                        loaderChildren={
+                                          <ViewListSkeleton
+                                            width={800}
+                                            style={{
+                                              backgroundColor: '#FFF',
+                                              marginTop: 30,
+                                            }}
+                                          />
                                         }
-                                      )}
-                                      // TODO - Point to views.create when available
-                                      linkCreateViewHRef={resolvers.virtualizations.create()}
-                                      linkImportViewsHRef={resolvers.virtualizations.views.importSource.selectConnection(
-                                        { virtualization }
-                                      )}
-                                      onImportView={this.handleImportView}
-                                      hasListData={data.length > 0}
-                                    />
-                                    <WithLoader
-                                      error={error}
-                                      loading={!hasData}
-                                      loaderChildren={
-                                        <ViewListSkeleton
-                                          width={800}
-                                          style={{
-                                            backgroundColor: '#FFF',
-                                            marginTop: 30,
-                                          }}
-                                        />
-                                      }
-                                      errorChildren={<ApiError />}
-                                    >
-                                      {() =>
-                                        filteredAndSorted
-                                          .filter((view: ViewDefinition) =>
-                                            this.filterUndefinedId(view)
-                                          )
-                                          .map(
-                                            (
-                                              view: ViewDefinition,
-                                              index: number
-                                            ) => (
-                                              <ViewListItem
-                                                key={index}
-                                                viewName={view.viewName}
-                                                viewDescription={
-                                                  view.keng__description
-                                                }
-                                                i18nCancelText={t(
-                                                  'shared:Cancel'
-                                                )}
-                                                i18nDelete={t('shared:Delete')}
-                                                i18nDeleteModalMessage={t(
-                                                  'virtualization.deleteViewModalMessage',
-                                                  { name: view.viewName }
-                                                )}
-                                                i18nDeleteModalTitle={t(
-                                                  'virtualization.deleteModalTitle'
-                                                )}
-                                                i18nEdit={t('shared:Edit')}
-                                                i18nEditTip={t(
-                                                  'view.editViewTip'
-                                                )}
-                                                onDelete={handleDeleteView}
-                                                onEdit={this.handleEditView}
-                                              />
+                                        errorChildren={<ApiError />}
+                                      >
+                                        {() =>
+                                          filteredAndSorted
+                                            .filter((view: ViewDefinition) =>
+                                              this.filterUndefinedId(view)
                                             )
-                                          )
-                                      }
-                                    </WithLoader>
-                                  </>
-                                )}
-                              </Translation>
-                            );
-                          }}
-                        </WithListViewToolbarHelpers>
-                      )}
-                    </WithViewEditorStates>
-                  </div>
-                );
-              }}
-            </WithVirtualizationHelpers>
+                                            .map(
+                                              (
+                                                view: ViewDefinition,
+                                                index: number
+                                              ) => (
+                                                <ViewListItem
+                                                  key={index}
+                                                  viewName={view.viewName}
+                                                  viewDescription={
+                                                    view.keng__description
+                                                  }
+                                                  i18nCancelText={t(
+                                                    'shared:Cancel'
+                                                  )}
+                                                  i18nDelete={t(
+                                                    'shared:Delete'
+                                                  )}
+                                                  i18nDeleteModalMessage={t(
+                                                    'virtualization.deleteViewModalMessage',
+                                                    { name: view.viewName }
+                                                  )}
+                                                  i18nDeleteModalTitle={t(
+                                                    'virtualization.deleteModalTitle'
+                                                  )}
+                                                  i18nEdit={t('shared:Edit')}
+                                                  i18nEditTip={t(
+                                                    'view.editViewTip'
+                                                  )}
+                                                  onDelete={handleDeleteView}
+                                                  onEdit={this.handleEditView}
+                                                />
+                                              )
+                                            )
+                                        }
+                                      </WithLoader>
+                                    </>
+                                  )}
+                                </Translation>
+                              );
+                            }}
+                          </WithListViewToolbarHelpers>
+                        );
+                      }}
+                    </WithVirtualizationHelpers>
+                  );
+                }}
+              </WithViewEditorStates>
+            </div>
           );
         }}
       </WithRouteData>

--- a/app/ui-react/syndesis/src/modules/data/pages/VirtualizationsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/data/pages/VirtualizationsPage.tsx
@@ -87,196 +87,198 @@ export class VirtualizationsPage extends React.Component {
 
   public render() {
     return (
-      // TODO need to retrieve real username here
-      <WithVirtualizationHelpers username="developer">
-        {({
-          deleteVirtualization,
-          publishVirtualization,
-          unpublishServiceVdb,
-        }) => {
-          const handleDelete = async (virtualizationName: string) => {
-            await deleteVirtualization(virtualizationName);
-            // TODO: post toast notification
-          };
-          const handlePublish = async (virtualizationName: string) => {
-            await publishVirtualization(virtualizationName);
-            // TODO: post toast notification
-          };
-          const handleUnpublish = async (serviceVdbName: string) => {
-            await unpublishServiceVdb(serviceVdbName);
-            // TODO: post toast notification
-          };
+      <WithVirtualizations>
+        {({ data, hasData, error, read }) => {
           return (
-            <WithVirtualizations>
-              {({ data, hasData, error }) => (
-                <WithListViewToolbarHelpers
-                  defaultFilterType={filterByName}
-                  defaultSortType={sortByName}
-                >
-                  {helpers => {
-                    const filteredAndSorted = getFilteredAndSortedVirtualizations(
-                      data,
-                      helpers.activeFilters,
-                      helpers.currentSortType,
-                      helpers.isSortAscending
-                    );
+            // TODO need to retrieve real username here
+            <WithVirtualizationHelpers username="developer">
+              {({
+                deleteVirtualization,
+                publishVirtualization,
+                unpublishServiceVdb,
+              }) => {
+                const handleDelete = async (virtualizationName: string) => {
+                  await deleteVirtualization(virtualizationName).then(read);
+                  // TODO: post toast notification
+                };
+                const handlePublish = async (virtualizationName: string) => {
+                  await publishVirtualization(virtualizationName);
+                  // TODO: post toast notification
+                };
+                const handleUnpublish = async (serviceVdbName: string) => {
+                  await unpublishServiceVdb(serviceVdbName);
+                  // TODO: post toast notification
+                };
+                return (
+                  <WithListViewToolbarHelpers
+                    defaultFilterType={filterByName}
+                    defaultSortType={sortByName}
+                  >
+                    {helpers => {
+                      const filteredAndSorted = getFilteredAndSortedVirtualizations(
+                        data,
+                        helpers.activeFilters,
+                        helpers.currentSortType,
+                        helpers.isSortAscending
+                      );
 
-                    return (
-                      <Translation ns={['data', 'shared']}>
-                        {t => (
-                          <VirtualizationList
-                            filterTypes={filterTypes}
-                            sortTypes={sortTypes}
-                            resultsCount={filteredAndSorted.length}
-                            {...helpers}
-                            i18nCreateDataVirtualization={t(
-                              'virtualization.createDataVirtualization'
-                            )}
-                            i18nCreateDataVirtualizationTip={t(
-                              'virtualization.createDataVirtualizationTip'
-                            )}
-                            i18nDescription={t(
-                              'virtualization.virtualizationsPageDescription'
-                            )}
-                            i18nEmptyStateInfo={t(
-                              'virtualization.emptyStateInfoMessage'
-                            )}
-                            i18nEmptyStateTitle={t(
-                              'virtualization.emptyStateTitle'
-                            )}
-                            i18nImport={t('shared:Import')}
-                            i18nImportTip={t(
-                              'virtualization.importVirtualizationTip'
-                            )}
-                            i18nLinkCreateVirtualization={t(
-                              'virtualization.createDataVirtualization'
-                            )}
-                            i18nName={t('shared:Name')}
-                            i18nNameFilterPlaceholder={t(
-                              'shared:nameFilterPlaceholder'
-                            )}
-                            i18nResultsCount={t('shared:resultsCount', {
-                              count: filteredAndSorted.length,
-                            })}
-                            i18nTitle={t(
-                              'virtualization.virtualizationsPageTitle'
-                            )}
-                            linkCreateHRef={resolvers.virtualizations.create()}
-                            onImport={this.handleImportVirt}
-                            hasListData={data.length > 0}
-                          >
-                            <WithLoader
-                              error={error}
-                              loading={!hasData}
-                              loaderChildren={
-                                <VirtualizationListSkeleton
-                                  width={800}
-                                  style={{
-                                    backgroundColor: '#FFF',
-                                    marginTop: 30,
-                                  }}
-                                />
-                              }
-                              errorChildren={<ApiError />}
+                      return (
+                        <Translation ns={['data', 'shared']}>
+                          {t => (
+                            <VirtualizationList
+                              filterTypes={filterTypes}
+                              sortTypes={sortTypes}
+                              resultsCount={filteredAndSorted.length}
+                              {...helpers}
+                              i18nCreateDataVirtualization={t(
+                                'virtualization.createDataVirtualization'
+                              )}
+                              i18nCreateDataVirtualizationTip={t(
+                                'virtualization.createDataVirtualizationTip'
+                              )}
+                              i18nDescription={t(
+                                'virtualization.virtualizationsPageDescription'
+                              )}
+                              i18nEmptyStateInfo={t(
+                                'virtualization.emptyStateInfoMessage'
+                              )}
+                              i18nEmptyStateTitle={t(
+                                'virtualization.emptyStateTitle'
+                              )}
+                              i18nImport={t('shared:Import')}
+                              i18nImportTip={t(
+                                'virtualization.importVirtualizationTip'
+                              )}
+                              i18nLinkCreateVirtualization={t(
+                                'virtualization.createDataVirtualization'
+                              )}
+                              i18nName={t('shared:Name')}
+                              i18nNameFilterPlaceholder={t(
+                                'shared:nameFilterPlaceholder'
+                              )}
+                              i18nResultsCount={t('shared:resultsCount', {
+                                count: filteredAndSorted.length,
+                              })}
+                              i18nTitle={t(
+                                'virtualization.virtualizationsPageTitle'
+                              )}
+                              linkCreateHRef={resolvers.virtualizations.create()}
+                              onImport={this.handleImportVirt}
+                              hasListData={data.length > 0}
                             >
-                              {() =>
-                                filteredAndSorted.map(
-                                  (
-                                    virtualization: RestDataService,
-                                    index: number
-                                  ) => {
-                                    const publishingDetails = getPublishingDetails(
-                                      virtualization
-                                    );
-                                    return (
-                                      <VirtualizationListItem
-                                        key={index}
-                                        detailsPageLink={resolvers.virtualizations.views.root(
-                                          { virtualization }
-                                        )}
-                                        virtualizationName={
-                                          virtualization.keng__id
-                                        }
-                                        virtualizationDescription={
-                                          virtualization.tko__description
-                                            ? virtualization.tko__description
-                                            : ''
-                                        }
-                                        serviceVdbName={
-                                          virtualization.serviceVdbName
-                                        }
-                                        i18nCancelText={t('shared:Cancel')}
-                                        i18nDelete={t('shared:Delete')}
-                                        i18nDeleteModalMessage={t(
-                                          'virtualization.deleteModalMessage',
-                                          { name: virtualization.keng__id }
-                                        )}
-                                        i18nDeleteModalTitle={t(
-                                          'virtualization.deleteModalTitle'
-                                        )}
-                                        i18nDraft={t('shared:Draft')}
-                                        i18nEdit={t('shared:Edit')}
-                                        i18nEditTip={t(
-                                          'virtualization.editDataVirtualizationTip'
-                                        )}
-                                        i18nError={t('shared:Error')}
-                                        i18nExport={t('shared:Export')}
-                                        i18nPublish={t('shared:Publish')}
-                                        i18nPublished={t(
-                                          'virtualization.publishedDataVirtualization'
-                                        )}
-                                        i18nUnpublish={t('shared:Unpublish')}
-                                        i18nUnpublishModalMessage={t(
-                                          'virtualization.unpublishModalMessage',
-                                          { name: virtualization.keng__id }
-                                        )}
-                                        i18nUnpublishModalTitle={t(
-                                          'virtualization.unpublishModalTitle'
-                                        )}
-                                        onDelete={handleDelete}
-                                        onExport={
-                                          this.handleExportVirtualization
-                                        }
-                                        onUnpublish={handleUnpublish}
-                                        onPublish={handlePublish}
-                                        currentPublishedState={
-                                          publishingDetails.state
-                                        }
-                                        publishingLogUrl={
-                                          publishingDetails.logUrl
-                                        }
-                                        publishingCurrentStep={
-                                          publishingDetails.stepNumber
-                                        }
-                                        publishingTotalSteps={
-                                          publishingDetails.stepTotal
-                                        }
-                                        publishingStepText={
-                                          publishingDetails.stepText
-                                        }
-                                        i18nPublishInProgress={t(
-                                          'virtualization.publishInProgress'
-                                        )}
-                                        i18nPublishLogUrlText={t(
-                                          'shared:viewLogs'
-                                        )}
-                                      />
-                                    );
-                                  }
-                                )
-                              }
-                            </WithLoader>
-                          </VirtualizationList>
-                        )}
-                      </Translation>
-                    );
-                  }}
-                </WithListViewToolbarHelpers>
-              )}
-            </WithVirtualizations>
+                              <WithLoader
+                                error={error}
+                                loading={!hasData}
+                                loaderChildren={
+                                  <VirtualizationListSkeleton
+                                    width={800}
+                                    style={{
+                                      backgroundColor: '#FFF',
+                                      marginTop: 30,
+                                    }}
+                                  />
+                                }
+                                errorChildren={<ApiError />}
+                              >
+                                {() =>
+                                  filteredAndSorted.map(
+                                    (
+                                      virtualization: RestDataService,
+                                      index: number
+                                    ) => {
+                                      const publishingDetails = getPublishingDetails(
+                                        virtualization
+                                      );
+                                      return (
+                                        <VirtualizationListItem
+                                          key={index}
+                                          detailsPageLink={resolvers.virtualizations.views.root(
+                                            { virtualization }
+                                          )}
+                                          virtualizationName={
+                                            virtualization.keng__id
+                                          }
+                                          virtualizationDescription={
+                                            virtualization.tko__description
+                                              ? virtualization.tko__description
+                                              : ''
+                                          }
+                                          serviceVdbName={
+                                            virtualization.serviceVdbName
+                                          }
+                                          i18nCancelText={t('shared:Cancel')}
+                                          i18nDelete={t('shared:Delete')}
+                                          i18nDeleteModalMessage={t(
+                                            'virtualization.deleteModalMessage',
+                                            { name: virtualization.keng__id }
+                                          )}
+                                          i18nDeleteModalTitle={t(
+                                            'virtualization.deleteModalTitle'
+                                          )}
+                                          i18nDraft={t('shared:Draft')}
+                                          i18nEdit={t('shared:Edit')}
+                                          i18nEditTip={t(
+                                            'virtualization.editDataVirtualizationTip'
+                                          )}
+                                          i18nError={t('shared:Error')}
+                                          i18nExport={t('shared:Export')}
+                                          i18nPublish={t('shared:Publish')}
+                                          i18nPublished={t(
+                                            'virtualization.publishedDataVirtualization'
+                                          )}
+                                          i18nUnpublish={t('shared:Unpublish')}
+                                          i18nUnpublishModalMessage={t(
+                                            'virtualization.unpublishModalMessage',
+                                            { name: virtualization.keng__id }
+                                          )}
+                                          i18nUnpublishModalTitle={t(
+                                            'virtualization.unpublishModalTitle'
+                                          )}
+                                          onDelete={handleDelete}
+                                          onExport={
+                                            this.handleExportVirtualization
+                                          }
+                                          onUnpublish={handleUnpublish}
+                                          onPublish={handlePublish}
+                                          currentPublishedState={
+                                            publishingDetails.state
+                                          }
+                                          publishingLogUrl={
+                                            publishingDetails.logUrl
+                                          }
+                                          publishingCurrentStep={
+                                            publishingDetails.stepNumber
+                                          }
+                                          publishingTotalSteps={
+                                            publishingDetails.stepTotal
+                                          }
+                                          publishingStepText={
+                                            publishingDetails.stepText
+                                          }
+                                          i18nPublishInProgress={t(
+                                            'virtualization.publishInProgress'
+                                          )}
+                                          i18nPublishLogUrlText={t(
+                                            'shared:viewLogs'
+                                          )}
+                                        />
+                                      );
+                                    }
+                                  )
+                                }
+                              </WithLoader>
+                            </VirtualizationList>
+                          )}
+                        </Translation>
+                      );
+                    }}
+                  </WithListViewToolbarHelpers>
+                );
+              }}
+            </WithVirtualizationHelpers>
           );
         }}
-      </WithVirtualizationHelpers>
+      </WithVirtualizations>
     );
   }
 }


### PR DESCRIPTION
- updates WithViewEditorStates and WithVirtualizations to extend IFetchState, same as @gashcrumb did with environments.  Thanks @gashcrumb !
- VirtualizationsPage and VirtualizationViewPage then call the read operation to trigger the list update.  (the nesting of the With components was changed too)
- Separate change was made in VirtualizationCreatePage, to route to details page upon create - instead of back to the summary page.