### PR TITLE
feat: show steps based on the integration and position; switch to flow id instead of idx

### DIFF
--- a/app/ui-react/packages/api/src/WithIntegrationHelpers.tsx
+++ b/app/ui-react/packages/api/src/WithIntegrationHelpers.tsx
@@ -16,7 +16,7 @@ type UpdateOrAddConnection = (
   integration: Integration,
   connection: Connection,
   action: Action,
-  flow: number,
+  flowId: string,
   position: number,
   configuredProperties: any
 ) => Promise<Integration>;
@@ -171,7 +171,7 @@ export class WithIntegrationHelpersWrapped extends React.Component<
     integration: Integration,
     connection: Connection,
     action: Action,
-    flow: number,
+    flowId: string,
     position: number,
     configuredProperties: any
   ): Promise<Integration> {
@@ -185,13 +185,18 @@ export class WithIntegrationHelpersWrapped extends React.Component<
         action,
         configuredProperties,
         connection,
-        id: draft.flows![flow].id,
+        id: flowId,
       };
       if (actionDescriptor) {
         step.action!.descriptor = actionDescriptor;
       }
       step.stepKind = 'endpoint';
-      draft.flows![flow].steps!.splice(position, 0, step);
+      draft.flows = draft.flows!.map(f => {
+        if (f.id === flowId) {
+          f.steps!.splice(position, 0, step);
+        }
+        return f;
+      });
       draft.tags = Array.from(new Set([...(draft.tags || []), connection.id!]));
     });
   }
@@ -267,7 +272,7 @@ export class WithIntegrationHelpersWrapped extends React.Component<
     integration: Integration,
     connection: Connection,
     action: Action,
-    flow: number,
+    flowId: string,
     position: number,
     configuredProperties: any
   ): Promise<Integration> {
@@ -281,20 +286,25 @@ export class WithIntegrationHelpersWrapped extends React.Component<
         action,
         configuredProperties,
         connection,
-        id: draft.flows![flow].id,
+        id: flowId,
       };
       if (actionDescriptor) {
         step.action!.descriptor = actionDescriptor;
       }
       step.stepKind = 'endpoint';
-      draft.flows![flow].steps![position] = step;
+      draft.flows = draft.flows!.map(f => {
+        if (f.id === flowId) {
+          f.steps![position] = step;
+        }
+        return f;
+      });
     });
   }
   public async updateOrAddConnection(
     integration: Integration,
     connection: Connection,
     action: Action,
-    flow: number,
+    flowId: string,
     position: number,
     configuredProperties: any
   ): Promise<Integration> {
@@ -308,20 +318,25 @@ export class WithIntegrationHelpersWrapped extends React.Component<
         action,
         configuredProperties,
         connection,
-        id: draft.flows![flow].id,
+        id: flowId,
       };
       if (actionDescriptor) {
         step.action!.descriptor = actionDescriptor;
       }
       step.stepKind = 'endpoint';
-      if (draft.flows![flow].steps![position]) {
-        draft.flows![flow].steps![position] = step;
-      } else {
-        draft.flows![flow].steps!.splice(position, 0, step);
-        draft.tags = Array.from(
-          new Set([...(draft.tags || []), connection.id!])
-        );
-      }
+      draft.flows = draft.flows!.map(f => {
+        if (f.id === flowId) {
+          if (f.steps![position]) {
+            f.steps![position] = step;
+          } else {
+            f.steps!.splice(position, 0, step);
+            draft.tags = Array.from(
+              new Set([...(draft.tags || []), connection.id!])
+            );
+          }
+        }
+        return f;
+      });
     });
   }
 

--- a/app/ui-react/packages/api/src/helpers/integrationFunctions.ts
+++ b/app/ui-react/packages/api/src/helpers/integrationFunctions.ts
@@ -104,37 +104,44 @@ export function canDeactivate(integration: IntegrationOverview) {
 /**
  * returns the list of steps of the provided integration.
  *
- * @param value
- * @param flow
+ * @param integration
+ * @param flowId
  *
  * @todo make the returned object immutable to avoid uncontrolled changes
  */
-export function getSteps(integration: Integration, flow: number): Step[] {
+export function getSteps(integration: Integration, flowId: string): Step[] {
   try {
-    return integration.flows![flow].steps!;
+    const flow = getFlow(integration, flowId);
+    return flow!.steps!;
   } catch (e) {
-    throw new Error(`Can't find steps in position flow:${flow}`);
+    return [];
   }
 }
 
 /**
  * returns a specific step of the provided integration.
  *
- * @param value
- * @param flow
+ * @param integration
+ * @param flowId
+ * @param step
  *
  * @todo make the returned object immutable to avoid uncontrolled changes
  */
 
 export function getStep(
   integration: Integration,
-  flow: number,
+  flowId: string,
   step: number
 ): Step {
   try {
-    return integration.flows![flow].steps![step];
+    const flow = getFlow(integration, flowId);
+    return flow!.steps![step];
   } catch (e) {
-    throw new Error(`Can't find a step in position flow:${flow} step:${step}`);
+    throw new Error(
+      `Can't find a step ${step} for flow ${flowId} in integration ${
+        integration.id
+      }`
+    );
   }
 }
 
@@ -143,7 +150,8 @@ export function getStep(
  * @param integration
  */
 export function getStartIcon(apiUri: string, integration: Integration) {
-  return getStepIcon(apiUri, integration, 0, 0);
+  const flow = integration.flows![0];
+  return getStepIcon(apiUri, integration, flow.id!, 0);
 }
 
 /**
@@ -152,7 +160,7 @@ export function getStartIcon(apiUri: string, integration: Integration) {
  */
 export function getFinishIcon(apiUri: string, integration: Integration) {
   const flow = integration.flows![0];
-  return getStepIcon(apiUri, integration, 0, flow.steps!.length - 1);
+  return getStepIcon(apiUri, integration, flow.id!, flow.steps!.length - 1);
 }
 
 export function getExtensionIcon(extension: Extension) {
@@ -165,17 +173,18 @@ export function getStepKindIcon(stepKind: Step['stepKind']) {
 
 /**
  * Returns the icon for the supplied step index of the supplied flow index
+ * @param apiUri
  * @param integration
- * @param flowIndex
+ * @param flowId
  * @param stepIndex
  */
 export function getStepIcon(
   apiUri: string,
   integration: Integration,
-  flowIndex: number,
+  flowId: string,
   stepIndex: number
 ): string {
-  const step = getStep(integration, flowIndex, stepIndex);
+  const step = getStep(integration, flowId, stepIndex);
   // The step is a connection
   if (step.connection) {
     const connection = step.connection as IConnectionWithIconFile;

--- a/app/ui-react/packages/api/src/helpers/integrationFunctions.ts
+++ b/app/ui-react/packages/api/src/helpers/integrationFunctions.ts
@@ -5,8 +5,19 @@ import {
   IntegrationOverview,
   Step,
 } from '@syndesis/models';
+import { Connection, ConnectorAction, StepKind } from '@syndesis/models/src';
 import { key } from '@syndesis/utils';
 import produce from 'immer';
+import {
+  ADVANCED_FILTER,
+  AGGREGATE,
+  BASIC_FILTER,
+  DATA_MAPPER,
+  ENDPOINT,
+  HIDE_FROM_STEP_SELECT,
+  SPLIT,
+  TEMPLATE,
+} from '../constants';
 import { getConnectionIcon } from './connectionFunctions';
 
 export const NEW_INTEGRATION = {
@@ -176,4 +187,180 @@ export function getStepIcon(
   }
   // It's just a step
   return getStepKindIcon(step.stepKind);
+}
+
+/**
+ * Returns the flow object with the given ID
+ * @param integration
+ * @param flowId
+ */
+export function getFlow(integration: Integration, flowId: string) {
+  // TODO some code relies on these semantics
+  if (!integration || !integration.flows || !flowId) {
+    return undefined;
+  }
+  return integration.flows.find(flow => flow.id === flowId);
+}
+
+/**
+ * Returns the last index of the step array of the given flow or undefined if it hasn't been created
+ * @param integration
+ * @param flowId
+ */
+export function getLastPosition(integration: Integration, flowId: string) {
+  if (!flowId) {
+    return undefined;
+  }
+  const flow = getFlow(integration, flowId);
+  if (!flow) {
+    return undefined;
+  }
+  // TODO preserve this block for now
+  if (!flow.steps) {
+    return undefined;
+  }
+  if (flow.steps.length <= 1) {
+    return 1;
+  }
+  return flow.steps.length - 1;
+}
+
+/**
+ * Filters connections based on the supplied position in the step array
+ * @param steps
+ * @param position
+ */
+export function filterStepsByPosition(
+  integration: Integration,
+  flowId: string,
+  steps: StepKind[],
+  position: number
+) {
+  if (typeof position === 'undefined' || !steps) {
+    // safety net
+    return steps;
+  }
+  const atStart = position === 0;
+  const atEnd = getLastPosition(integration, flowId) === position;
+  return steps.filter(step => {
+    // Hide steps that are marked as such, and specifically the log connection
+    if (
+      (typeof step.connection !== 'undefined' &&
+        typeof step.connection.metadata !== 'undefined' &&
+        step.connection.metadata[HIDE_FROM_STEP_SELECT]) ||
+      (typeof step.metadata !== 'undefined' &&
+        step.metadata[HIDE_FROM_STEP_SELECT]) ||
+      (step as Connection).connectorId === 'log'
+    ) {
+      return false;
+    }
+    // Special handling for the beginning of a flow
+    if (atStart) {
+      // At the moment only endpoints can be at the start
+      if (step.stepKind) {
+        return false;
+      }
+      if ((step as Connection).connector) {
+        return (step as Connection).connector!.actions.some(
+          (action: ConnectorAction) => {
+            return action.pattern === 'From';
+          }
+        );
+      }
+      // it's not a connection
+      return true;
+    }
+    // Special handling for the end of a flow
+    if (atEnd) {
+      // Several step kinds aren't usable at the end of a flow
+      switch ((step as Step).stepKind) {
+        case DATA_MAPPER:
+        case BASIC_FILTER:
+        case ADVANCED_FILTER:
+        case SPLIT:
+        case AGGREGATE:
+        case TEMPLATE:
+          return false;
+        default:
+      }
+    }
+    if ((step as Connection).connectorId === 'api-provider') {
+      // api provider can be used only for From actions
+      return false;
+    }
+    // All non-connection steps can be shown, except the above
+    if (step.stepKind !== ENDPOINT) {
+      return true;
+    }
+    // Only show connections that have at least one action that accepts data
+    if ((step as Connection).connector) {
+      return (step as Connection).connector!.actions.some(
+        (action: ConnectorAction) => {
+          return action.pattern === 'To';
+        }
+      );
+    }
+    return true;
+  });
+}
+
+/**
+ * Filters connections based on the supplied position in the step array and their
+ * visibility status
+ * @param steps
+ * @param position
+ */
+export function visibleStepsByPosition(
+  integration: Integration,
+  flowId: string,
+  steps: StepKind[],
+  position: number
+) {
+  const previousSteps = getPreviousSteps(integration, flowId, position);
+  const subsequentSteps = getSubsequentSteps(integration, flowId, position);
+  return filterStepsByPosition(integration, flowId, steps, position).filter(s =>
+    s.visible
+      ? typeof s.visible === 'function'
+        ? s.visible(position, previousSteps, subsequentSteps)
+        : s.visible
+      : true
+  );
+}
+
+/**
+ * Get an array of steps from the flow before the given position
+ * @param integration
+ * @param flowId
+ * @param position
+ */
+export function getPreviousSteps(
+  integration: Integration,
+  flowId: string,
+  position: number
+) {
+  const flow = getFlow(integration, flowId);
+  if (!flow || !flow.steps) {
+    // TODO following semantics for now, this should throw an error
+    return [];
+  }
+  return flow.steps.slice(0, position);
+}
+
+/**
+ * Get an array of steps from the flow after the given position
+ * @param integration
+ * @param flowId
+ * @param position
+ */
+export function getSubsequentSteps(
+  integration: Integration,
+  flowId: string,
+  position: number
+) {
+  const flow = getFlow(integration, flowId);
+  if (!flow || !flow.steps) {
+    // TODO following semantics for now, this should throw an error
+    return [];
+  }
+  return flow.steps.slice(position + 1);
 }

--- a/app/ui-react/packages/api/tests/helpers/integrationFunctions.spec.tsx
+++ b/app/ui-react/packages/api/tests/helpers/integrationFunctions.spec.tsx
@@ -1,5 +1,5 @@
 import { getEmptyIntegration, getStepIcon } from '../../src';
-import { Integration, IConnectionWithIconFile, Step } from '@syndesis/models';
+import { IConnectionWithIconFile, Integration, Step } from '@syndesis/models';
 import expect = require('expect');
 
 export default describe('integrationFunctions', () => {
@@ -16,7 +16,7 @@ export default describe('integrationFunctions', () => {
       ...getEmptyIntegration(),
       flows: [
         {
-          id: '',
+          id: 'id',
           steps: [
             {
               connection: {
@@ -27,7 +27,7 @@ export default describe('integrationFunctions', () => {
         },
       ],
     } as Integration;
-    const iconPath = getStepIcon('', integration, 0, 0);
+    const iconPath = getStepIcon('', integration, 'id', 0);
     expect(iconPath).toBe('data:blah');
   });
   it('Should return a valid icon URL for a legacy connection', () => {
@@ -35,7 +35,7 @@ export default describe('integrationFunctions', () => {
       ...getEmptyIntegration(),
       flows: [
         {
-          id: '',
+          id: 'id',
           steps: [
             {
               connection: {
@@ -46,7 +46,7 @@ export default describe('integrationFunctions', () => {
         },
       ],
     } as Integration;
-    const iconPath = getStepIcon('', integration, 0, 0);
+    const iconPath = getStepIcon('', integration, 'id', 0);
     expect(iconPath).toBe('./../../icons/blah.connection.png');
   });
   it('Should return a valid icon URL for a connection that references a db entity', () => {
@@ -54,19 +54,19 @@ export default describe('integrationFunctions', () => {
       ...getEmptyIntegration(),
       flows: [
         {
-          id: '',
+          id: 'id',
           steps: [
             {
               connection: {
-                id: 'foo',
                 icon: 'db:blah',
+                id: 'foo',
               },
             },
           ],
         },
       ],
     } as Integration;
-    const iconPath = getStepIcon('', integration, 0, 0);
+    const iconPath = getStepIcon('', integration, 'id', 0);
     expect(iconPath).toBe('/connectors/foo/icon?db:blah');
   });
   it('Should return a valid icon URL for a connection that references a db entity', () => {
@@ -74,19 +74,19 @@ export default describe('integrationFunctions', () => {
       ...getEmptyIntegration(),
       flows: [
         {
-          id: '',
+          id: 'id',
           steps: [
             {
               connection: {
-                id: 'foo',
                 icon: 'db:blah',
+                id: 'foo',
               },
             },
           ],
         },
       ],
     } as Integration;
-    const iconPath = getStepIcon('', integration, 0, 0);
+    const iconPath = getStepIcon('', integration, 'id', 0);
     expect(iconPath).toBe('/connectors/foo/icon?db:blah');
   });
   it('Should return a valid icon URL for a connection that references a db entity', () => {
@@ -94,19 +94,19 @@ export default describe('integrationFunctions', () => {
       ...getEmptyIntegration(),
       flows: [
         {
-          id: '',
+          id: 'id',
           steps: [
             {
               connection: {
-                id: 'foo',
                 icon: 'extension:blah',
+                id: 'foo',
               },
             },
           ],
         },
       ],
     } as Integration;
-    const iconPath = getStepIcon('', integration, 0, 0);
+    const iconPath = getStepIcon('', integration, 'id', 0);
     expect(iconPath).toBe('/connectors/foo/icon?extension:blah');
   });
   it('Should return a valid icon URL for a connection with an icon file', () => {
@@ -114,19 +114,19 @@ export default describe('integrationFunctions', () => {
       ...getEmptyIntegration(),
       flows: [
         {
-          id: '',
+          id: 'id',
           steps: [
             {
               connection: {
-                iconFile: new File([], 'foo'),
                 icon: '',
+                iconFile: new File([], 'foo'),
               } as IConnectionWithIconFile,
             },
           ],
         },
       ],
     } as Integration;
-    const iconPath = getStepIcon('', integration, 0, 0);
+    const iconPath = getStepIcon('', integration, 'id', 0);
     expect(iconPath).toBe('foo');
   });
   it('Should return a valid icon URL for an extension step', () => {
@@ -134,7 +134,7 @@ export default describe('integrationFunctions', () => {
       ...getEmptyIntegration(),
       flows: [
         {
-          id: '',
+          id: 'id',
           steps: [
             {
               extension: {
@@ -145,7 +145,7 @@ export default describe('integrationFunctions', () => {
         },
       ],
     } as Integration;
-    const iconPath = getStepIcon('', integration, 0, 0);
+    const iconPath = getStepIcon('', integration, 'id', 0);
     expect(iconPath).toBe('blah');
   });
   it('Should return a valid icon URL for a step', () => {
@@ -153,7 +153,7 @@ export default describe('integrationFunctions', () => {
       ...getEmptyIntegration(),
       flows: [
         {
-          id: '',
+          id: 'id',
           steps: [
             {
               stepKind: 'log',
@@ -162,7 +162,7 @@ export default describe('integrationFunctions', () => {
         },
       ],
     } as Integration;
-    const iconPath = getStepIcon('', integration, 0, 0);
+    const iconPath = getStepIcon('', integration, 'id', 0);
     expect(iconPath).toBe('/icons/steps/log.svg');
   });
 });

--- a/app/ui-react/packages/models/src/models-internal.d.ts
+++ b/app/ui-react/packages/models/src/models-internal.d.ts
@@ -1,0 +1,734 @@
+export interface APISummary {
+  actionsSummary?: ActionsSummary;
+  icon?: string;
+  description?: string;
+  errors?: Violation[];
+  warnings?: Violation[];
+  name: string;
+  properties?: {
+    [name: string]: ConfigurationProperty;
+  };
+  configuredProperties?: {
+    [name: string]: string;
+  };
+}
+export interface AcquisitionMethod {
+  icon?: string;
+  type?: 'OAUTH1' | 'OAUTH2';
+  label?: string;
+  description?: string;
+}
+export interface Action {
+  id?: string;
+  name: string;
+  description?: string;
+  descriptor?: ActionDescriptor;
+  tags?: string[];
+  actionType?: string;
+  pattern?: 'From' | 'Pipe' | 'To';
+  metadata?: {
+    [name: string]: string;
+  };
+}
+export interface ActionDescriptor {
+  propertyDefinitionSteps?: ActionDescriptorStep[];
+  outputDataShape?: DataShape;
+  inputDataShape?: DataShape;
+}
+export interface ActionDescriptorStep {
+  description?: string;
+  name: string;
+  properties?: {
+    [name: string]: ConfigurationProperty;
+  };
+  configuredProperties?: {
+    [name: string]: string;
+  };
+}
+export interface ActionsSummary {
+  actionCountByTags?: {
+    [name: string]: number; // int32
+  };
+  totalActions?: number; // int32
+}
+export interface ConfigurationProperty {
+  javaType?: string;
+  componentProperty?: boolean;
+  connectorValue?: string;
+  controlHint?: string;
+  labelHint?: string;
+  placeholder?: string;
+  relation?: PropertyRelation[];
+  required?: boolean;
+  multiple?: boolean;
+  generator?: string;
+  secret?: boolean;
+  raw?: boolean;
+  type?: string;
+  defaultValue?: string;
+  displayName?: string;
+  label?: string;
+  description?: string;
+  deprecated?: boolean;
+  group?: string;
+  kind?: string;
+  enum?: PropertyValue[];
+  tags?: string[];
+  order?: OptionalInt;
+}
+export interface Connection {
+  id?: string;
+  connectorId?: string;
+  createdDate?: string; // date-time
+  organizationId?: string;
+  derived?: boolean;
+  connector?: Connector;
+  icon?: string;
+  options?: {
+    [name: string]: string;
+  };
+  description?: string;
+  organization?: Organization;
+  lastUpdated?: string; // date-time
+  userId?: string;
+  tags?: string[];
+  name: string;
+  configuredProperties?: {
+    [name: string]: string;
+  };
+  metadata?: {
+    [name: string]: string;
+  };
+  readonly uses?: number; // int32
+}
+export interface ConnectionBulletinBoard {
+  id?: string;
+  targetResourceId?: string;
+  notices?: OptionalInt;
+  errors?: OptionalInt;
+  warnings?: OptionalInt;
+  metadata?: {
+    [name: string]: string;
+  };
+  messages?: LeveledMessage[];
+  createdAt?: number; // int64
+  updatedAt?: number; // int64
+}
+export interface ConnectionOverview {
+  board?: ConnectionBulletinBoard;
+  id?: string;
+  connectorId?: string;
+  createdDate?: string; // date-time
+  organizationId?: string;
+  derived?: boolean;
+  connector?: Connector;
+  icon?: string;
+  options?: {
+    [name: string]: string;
+  };
+  description?: string;
+  organization?: Organization;
+  lastUpdated?: string; // date-time
+  userId?: string;
+  tags?: string[];
+  name: string;
+  configuredProperties?: {
+    [name: string]: string;
+  };
+  metadata?: {
+    [name: string]: string;
+  };
+  readonly uses?: number; // int32
+}
+export interface Connector {
+  connectorGroup?: ConnectorGroup;
+  connectorGroupId?: string;
+  componentScheme?: string;
+  connectorFactory?: string;
+  connectorCustomizers?: string[];
+  actionsSummary?: ActionsSummary;
+  icon?: string;
+  description?: string;
+  readonly uses?: OptionalInt;
+  id?: string;
+  version?: number; // int32
+  actions: ConnectorAction[];
+  tags?: string[];
+  name: string;
+  properties?: {
+    [name: string]: ConfigurationProperty;
+  };
+  configuredProperties?: {
+    [name: string]: string;
+  };
+  dependencies?: Dependency[];
+  metadata?: {
+    [name: string]: string;
+  };
+}
+export interface ConnectorAction {
+  id?: string;
+  name: string;
+  description?: string;
+  descriptor?: ConnectorDescriptor;
+  tags?: string[];
+  actionType?: string;
+  dependencies?: Dependency[];
+  pattern?: 'From' | 'Pipe' | 'To';
+  metadata?: {
+    [name: string]: string;
+  };
+}
+export interface ConnectorDescriptor {
+  connectorId?: string;
+  camelConnectorGAV?: string;
+  camelConnectorPrefix?: string;
+  componentScheme?: string;
+  connectorFactory?: string;
+  connectorCustomizers?: string[];
+  propertyDefinitionSteps?: ActionDescriptorStep[];
+  outputDataShape?: DataShape;
+  inputDataShape?: DataShape;
+  configuredProperties?: {
+    [name: string]: string;
+  };
+}
+export interface ConnectorGroup {
+  id?: string;
+  name: string;
+}
+export interface ConnectorTemplate {
+  connectorProperties?: {
+    [name: string]: ConfigurationProperty;
+  };
+  connectorGroup?: ConnectorGroup;
+  componentScheme?: string;
+  icon?: string;
+  description?: string;
+  id?: string;
+  name: string;
+  properties?: {
+    [name: string]: ConfigurationProperty;
+  };
+  configuredProperties?: {
+    [name: string]: string;
+  };
+}
+export interface ContinuousDeliveryEnvironment {
+  lastTaggedAt?: string; // date-time
+  releaseTag?: string;
+  lastExportedAt?: string; // date-time
+  lastImportedAt?: string; // date-time
+  name: string;
+}
+export interface DataManager {}
+export interface DataShape {
+  collectionType?: string;
+  specification?: string;
+  collectionClassName?: string;
+  exemplar?: string /* byte */[];
+  name: string;
+  type?: string;
+  variants?: DataShape[];
+  description?: string;
+  metadata?: {
+    [name: string]: string;
+  };
+  kind?:
+    | 'ANY'
+    | 'JAVA'
+    | 'JSON_SCHEMA'
+    | 'JSON_INSTANCE'
+    | 'XML_SCHEMA'
+    | 'XML_SCHEMA_INSPECTED'
+    | 'XML_INSTANCE'
+    | 'NONE';
+}
+export interface Dependency {
+  id?: string;
+  type?: 'MAVEN' | 'EXTENSION' | 'EXTENSION_TAG' | 'ICON';
+}
+export interface Environment {
+  id?: string;
+  name: string;
+}
+export interface EventMessage {
+  event?: string;
+  data?: {};
+}
+export interface Extension {
+  schemaVersion: string;
+  name: string;
+  description?: string;
+  icon?: string;
+  extensionId?: string;
+  version?: string;
+  tags?: string[];
+  actions: Action[];
+  dependencies?: Dependency[];
+  extensionType: 'Steps' | 'Connectors' | 'Libraries';
+  createdDate?: string; // date-time
+  lastUpdated?: string; // date-time
+  status?: 'Draft' | 'Installed' | 'Deleted';
+  userId?: string;
+  id?: string;
+  properties?: {
+    [name: string]: ConfigurationProperty;
+  };
+  configuredProperties?: {
+    [name: string]: string;
+  };
+  metadata?: {
+    [name: string]: string;
+  };
+  readonly uses?: number; // int32
+}
+export interface FilterOptions {
+  ops?: Op[];
+  paths?: string[];
+}
+export interface Flow {
+  connections?: Connection[];
+  scheduler?: Scheduler;
+  description?: string;
+  name: string;
+  id?: string;
+  tags?: string[];
+  steps?: Step[];
+  metadata?: {
+    [name: string]: string;
+  };
+}
+export interface ImmutableConnectorAction {
+  readonly id?: string;
+  readonly name: string;
+  readonly description?: string;
+  readonly descriptor?: ConnectorDescriptor;
+  readonly tags?: string[];
+  readonly actionType?: string;
+  readonly pattern?: 'From' | 'Pipe' | 'To';
+  readonly metadata?: {
+    [name: string]: string;
+  };
+  dependencies?: Dependency[];
+}
+export interface ImmutableStepAction {
+  readonly id?: string;
+  readonly name: string;
+  readonly description?: string;
+  readonly descriptor?: StepDescriptor;
+  readonly tags?: string[];
+  readonly actionType?: string;
+  readonly pattern?: 'From' | 'Pipe' | 'To';
+  readonly metadata?: {
+    [name: string]: string;
+  };
+}
+export interface Integration {
+  id?: string;
+  continuousDeliveryState?: {
+    [name: string]: ContinuousDeliveryEnvironment;
+  };
+  flows?: Flow[];
+  connections?: Connection[];
+  deleted?: boolean;
+  description?: string;
+  steps?: Step[];
+  properties?: {
+    [name: string]: ConfigurationProperty;
+  };
+  configuredProperties?: {
+    [name: string]: string;
+  };
+  version?: number; // int32
+  createdAt?: number; // int64
+  updatedAt?: number; // int64
+  tags?: string[];
+  name: string;
+  resources?: ResourceIdentifier[];
+}
+export interface IntegrationBulletinBoard {
+  targetResourceId?: string;
+  notices?: OptionalInt;
+  errors?: OptionalInt;
+  warnings?: OptionalInt;
+  id?: string;
+  metadata?: {
+    [name: string]: string;
+  };
+  messages?: LeveledMessage[];
+  createdAt?: number; // int64
+  updatedAt?: number; // int64
+}
+export interface IntegrationDeployment {
+  spec?: Integration;
+  integrationId?: string;
+  stepsDone?: {
+    [name: string]: string;
+  };
+  currentState?: 'Published' | 'Unpublished' | 'Error' | 'Pending';
+  targetState?: 'Published' | 'Unpublished' | 'Error' | 'Pending';
+  statusMessage?: string;
+  error?: IntegrationDeploymentError;
+  userId?: string;
+  id?: string;
+  version?: number; // int32
+  createdAt?: number; // int64
+  updatedAt?: number; // int64
+}
+export interface IntegrationDeploymentError {
+  message?: string;
+  type?: string;
+}
+export interface IntegrationDeploymentMetrics {
+  lastProcessed?: string; // date-time
+  version?: string;
+  errors?: number; // int64
+  messages?: number; // int64
+  start?: string; // date-time
+}
+export interface IntegrationDeploymentOverview {
+  stepsDone?: {
+    [name: string]: string;
+  };
+  currentState?: 'Published' | 'Unpublished' | 'Error' | 'Pending';
+  targetState?: 'Published' | 'Unpublished' | 'Error' | 'Pending';
+  statusMessage?: string;
+  error?: IntegrationDeploymentError;
+  userId?: string;
+  id?: string;
+  version?: number; // int32
+  createdAt?: number; // int64
+  updatedAt?: number; // int64
+}
+export interface IntegrationMetricsSummary {
+  metricsProvider?: string;
+  integrationDeploymentMetrics?: IntegrationDeploymentMetrics[];
+  topIntegrations?: {
+    [name: string]: number; // int64
+  };
+  lastProcessed?: string; // date-time
+  errors?: number; // int64
+  messages?: number; // int64
+  start?: string; // date-time
+  id?: string;
+}
+export interface IntegrationOverview {
+  draft?: boolean;
+  deployments?: IntegrationDeploymentOverview[];
+  board?: IntegrationBulletinBoard;
+  deploymentVersion?: number; // int32
+  currentState?: 'Published' | 'Unpublished' | 'Error' | 'Pending';
+  targetState?: 'Published' | 'Unpublished' | 'Error' | 'Pending';
+  url?: string;
+  id?: string;
+  continuousDeliveryState?: {
+    [name: string]: ContinuousDeliveryEnvironment;
+  };
+  flows?: Flow[];
+  connections?: Connection[];
+  deleted?: boolean;
+  description?: string;
+  steps?: Step[];
+  properties?: {
+    [name: string]: ConfigurationProperty;
+  };
+  configuredProperties?: {
+    [name: string]: string;
+  };
+  version?: number; // int32
+  createdAt?: number; // int64
+  updatedAt?: number; // int64
+  tags?: string[];
+  name: string;
+  resources?: ResourceIdentifier[];
+}
+export interface LeveledMessage {
+  message?: string;
+  level?: 'INFO' | 'WARN' | 'ERROR';
+  detail?: string;
+  code?:
+    | 'SYNDESIS000'
+    | 'SYNDESIS001'
+    | 'SYNDESIS002'
+    | 'SYNDESIS003'
+    | 'SYNDESIS004'
+    | 'SYNDESIS005'
+    | 'SYNDESIS006'
+    | 'SYNDESIS007'
+    | 'SYNDESIS008'
+    | 'SYNDESIS009'
+    | 'SYNDESIS010'
+    | 'SYNDESIS011'
+    | 'SYNDESIS012';
+  metadata?: {
+    [name: string]: string;
+  };
+}
+export interface ListResult {
+  items?: {}[];
+  totalCount?: number; // int32
+}
+export interface ListResultConnectionOverview {
+  items?: ConnectionOverview[];
+  totalCount?: number; // int32
+}
+export interface ListResultConnector {
+  items?: Connector[];
+  totalCount?: number; // int32
+}
+export interface ListResultConnectorAction {
+  items?: ConnectorAction[];
+  totalCount?: number; // int32
+}
+export interface ListResultConnectorTemplate {
+  items?: ConnectorTemplate[];
+  totalCount?: number; // int32
+}
+export interface ListResultExtension {
+  items?: Extension[];
+  totalCount?: number; // int32
+}
+export interface ListResultIntegrationDeployment {
+  items?: IntegrationDeployment[];
+  totalCount?: number; // int32
+}
+export interface ListResultIntegrationOverview {
+  items?: IntegrationOverview[];
+  totalCount?: number; // int32
+}
+export interface ListResultOAuthApp {
+  items?: OAuthApp[];
+  totalCount?: number; // int32
+}
+export interface ListResultString {
+  items?: string[];
+  totalCount?: number; // int32
+}
+export interface ListResultWithIdObject {
+  items?: WithIdObject[];
+  totalCount?: number; // int32
+}
+export interface ModelData {
+  kind?:
+    | 'Action'
+    | 'Connection'
+    | 'ConnectionOverview'
+    | 'Connector'
+    | 'ConnectorAction'
+    | 'ConnectorGroup'
+    | 'ConnectorTemplate'
+    | 'Icon'
+    | 'Environment'
+    | 'EnvironmentType'
+    | 'Extension'
+    | 'StepAction'
+    | 'Organization'
+    | 'Integration'
+    | 'IntegrationOverview'
+    | 'IntegrationDeployment'
+    | 'IntegrationDeploymentStateDetails'
+    | 'IntegrationMetricsSummary'
+    | 'IntegrationRuntime'
+    | 'IntegrationEndpoint'
+    | 'Step'
+    | 'Permission'
+    | 'Role'
+    | 'User'
+    | 'ConnectionBulletinBoard'
+    | 'IntegrationBulletinBoard'
+    | 'OpenApi';
+  data?: string;
+}
+export interface ModelDataObject {
+  kind?:
+    | 'Action'
+    | 'Connection'
+    | 'ConnectionOverview'
+    | 'Connector'
+    | 'ConnectorAction'
+    | 'ConnectorGroup'
+    | 'ConnectorTemplate'
+    | 'Icon'
+    | 'Environment'
+    | 'EnvironmentType'
+    | 'Extension'
+    | 'StepAction'
+    | 'Organization'
+    | 'Integration'
+    | 'IntegrationOverview'
+    | 'IntegrationDeployment'
+    | 'IntegrationDeploymentStateDetails'
+    | 'IntegrationMetricsSummary'
+    | 'IntegrationRuntime'
+    | 'IntegrationEndpoint'
+    | 'Step'
+    | 'Permission'
+    | 'Role'
+    | 'User'
+    | 'ConnectionBulletinBoard'
+    | 'IntegrationBulletinBoard'
+    | 'OpenApi';
+  data?: string;
+}
+export interface OAuthApp {
+  derived?: boolean;
+  icon?: string;
+  id?: string;
+  name: string;
+  properties?: {
+    [name: string]: ConfigurationProperty;
+  };
+  configuredProperties?: {
+    [name: string]: string;
+  };
+}
+export interface Op {
+  label?: string;
+  operator?: string;
+}
+export interface OptionalInt {
+  present?: boolean;
+  asInt?: number; // int32
+}
+export interface Organization {
+  environments?: Environment[];
+  users?: User[];
+  id?: string;
+  name: string;
+}
+export interface Principal {
+  name?: string;
+}
+export interface PropertyRelation {
+  action?: string;
+  when?: When[];
+}
+export interface PropertyValue {
+  value?: string;
+  label?: string;
+}
+export interface Quota {
+  maxIntegrationsPerUser?: number; // int32
+  maxDeploymentsPerUser?: number; // int32
+  usedIntegrationsPerUser?: number; // int32
+  usedDeploymentsPerUser?: number; // int32
+}
+export interface Reservation {
+  principal?: Principal;
+  createdAt?: number; // int64
+}
+export interface ResourceIdentifier {
+  version?: number; // int32
+  kind?:
+    | 'Action'
+    | 'Connection'
+    | 'ConnectionOverview'
+    | 'Connector'
+    | 'ConnectorAction'
+    | 'ConnectorGroup'
+    | 'ConnectorTemplate'
+    | 'Icon'
+    | 'Environment'
+    | 'EnvironmentType'
+    | 'Extension'
+    | 'StepAction'
+    | 'Organization'
+    | 'Integration'
+    | 'IntegrationOverview'
+    | 'IntegrationDeployment'
+    | 'IntegrationDeploymentStateDetails'
+    | 'IntegrationMetricsSummary'
+    | 'IntegrationRuntime'
+    | 'IntegrationEndpoint'
+    | 'Step'
+    | 'Permission'
+    | 'Role'
+    | 'User'
+    | 'ConnectionBulletinBoard'
+    | 'IntegrationBulletinBoard'
+    | 'OpenApi';
+  id?: string;
+}
+export interface Result {
+  errors?: VerifierError[];
+  scope?: 'PARAMETERS' | 'CONNECTIVITY';
+  status?: 'OK' | 'ERROR' | 'UNSUPPORTED';
+}
+export interface Scheduler {
+  type?: 'timer' | 'cron';
+  expression?: string;
+}
+export interface Step {
+  stepKind?:
+    | 'endpoint'
+    | 'connector'
+    | 'expressionFilter'
+    | 'ruleFilter'
+    | 'extension'
+    | 'mapper'
+    | 'choice'
+    | 'split'
+    | 'aggregate'
+    | 'log'
+    | 'headers'
+    | 'template';
+  connection?: Connection;
+  name?: string;
+  extension?: Extension;
+  action?: Action;
+  id?: string;
+  configuredProperties?: {
+    [name: string]: string;
+  };
+  dependencies?: Dependency[];
+  metadata?: {
+    [name: string]: string;
+  };
+}
+export interface StepDescriptor {
+  entrypoint?: string;
+  resource?: string;
+  kind?: 'STEP' | 'BEAN' | 'ENDPOINT';
+  propertyDefinitionSteps?: ActionDescriptorStep[];
+  outputDataShape?: DataShape;
+  inputDataShape?: DataShape;
+}
+export interface StreamingOutput {}
+export interface TargetStateRequest {
+  targetState?: 'Published' | 'Unpublished' | 'Error' | 'Pending';
+}
+export interface User {
+  firstName?: string;
+  integrations?: Integration[];
+  lastName?: string;
+  roleId?: string;
+  organizationId?: string;
+  fullName?: string;
+  name?: string;
+  username?: string;
+  id?: string;
+}
+export interface Validator {}
+export interface VerifierError {
+  parameters?: string[];
+  attributes?: {
+    [name: string]: {};
+  };
+  description?: string;
+  code?: string;
+}
+export interface Violation {}
+export interface When {
+  value?: string;
+  id?: string;
+}
+export interface WithId {
+  id?: string;
+}
+export interface WithIdObject {
+  id?: string;
+}
+export interface WithResourceId {
+  id?: string;
+}

--- a/app/ui-react/syndesis/src/modules/integrations/IntegrationCreatorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/IntegrationCreatorApp.tsx
@@ -1,8 +1,4 @@
-import {
-  getConnectionIcon,
-  getEmptyIntegration,
-  getSteps,
-} from '@syndesis/api';
+import { getConnectionIcon } from '@syndesis/api';
 import {
   Breadcrumb,
   IntegrationFlowStepGeneric,
@@ -197,28 +193,18 @@ const startStepConfigureActionPage = (
         )}
       </IntegrationVerticalFlow>
     )}
-    postConfigureHref={(integration, params) =>
-      resolvers.create.finish.selectStep({
+    postConfigureHref={(integration, params, state) => {
+      return resolvers.create.finish.selectStep({
         integration,
         ...params,
         position: '1',
-      })
-    }
+      });
+    }}
   />
 );
 
 const finishStepSelectConnectionPage = (
   <SelectConnectionPage
-    backHref={(p, s) => {
-      const startStep = getSteps(s.integration, 0)[0];
-      return resolvers.create.start.connection.configureAction({
-        ...p,
-        ...s,
-        actionId: startStep.action!.id!,
-        connection: startStep.connection!,
-        integration: getEmptyIntegration(), // reset the integration object to force a re-add of the step, to avoid multiple steps being appended
-      });
-    }}
     cancelHref={resolvers.list}
     header={<IntegrationCreatorBreadcrumbs step={2} />}
     apiProviderHref={(p, s) => ({ pathname: 'todo' })}

--- a/app/ui-react/syndesis/src/modules/integrations/components/Integrations.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/Integrations.tsx
@@ -156,7 +156,7 @@ export class Integrations extends React.Component<
                               try {
                                 const editAction: IIntegrationAction = {
                                   href: resolvers.integration.edit.index({
-                                    flow: '0',
+                                    flowId: mi.integration.flows![0].id!,
                                     integration: mi.integration,
                                   }),
                                   label: 'Edit',

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
@@ -42,7 +42,7 @@ export class AddStepPage extends React.Component<IAddStepPageProps> {
   public render() {
     return (
       <WithRouteData<IBaseRouteParams, IBaseRouteState>>
-        {({ flow }, { integration }) => (
+        {({ flowId }, { integration }) => (
           <IntegrationEditorLayout
             header={this.props.header}
             content={
@@ -55,11 +55,11 @@ export class AddStepPage extends React.Component<IAddStepPageProps> {
                     integration as well.
                   </p>
                   <IntegrationEditorStepAdder
-                    steps={getSteps(integration, 0)}
+                    steps={getSteps(integration, flowId)}
                     addStepHref={position =>
                       this.props.getEditAddStepHref(
                         position,
-                        { flow },
+                        { flowId },
                         { integration }
                       )
                     }
@@ -67,7 +67,7 @@ export class AddStepPage extends React.Component<IAddStepPageProps> {
                       this.props.getEditConfigureStepHrefCallback(
                         stepIdx,
                         step,
-                        { flow },
+                        { flowId },
                         { integration }
                       )
                     }
@@ -75,8 +75,8 @@ export class AddStepPage extends React.Component<IAddStepPageProps> {
                 </Container>
               </>
             }
-            cancelHref={this.props.cancelHref({ flow }, { integration })}
-            nextHref={this.props.nextHref({ flow }, { integration })}
+            cancelHref={this.props.cancelHref({ flowId }, { integration })}
+            nextHref={this.props.nextHref({ flowId }, { integration })}
           />
         )}
       </WithRouteData>

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/SaveIntegrationPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/SaveIntegrationPage.tsx
@@ -43,7 +43,7 @@ export class SaveIntegrationPage extends React.Component<
   public render() {
     return (
       <WithRouteData<ISaveIntegrationRouteParams, ISaveIntegrationRouteState>>
-        {({ flow }, { integration }, { history }) => (
+        {({ flowId }, { integration }, { history }) => (
           <WithIntegrationHelpers>
             {({ saveIntegration }) => {
               const onSave = async (
@@ -111,10 +111,13 @@ export class SaveIntegrationPage extends React.Component<
                         </>
                       }
                       cancelHref={this.props.cancelHref(
-                        { flow },
+                        { flowId },
                         { integration }
                       )}
-                      backHref={this.props.backHref({ flow }, { integration })}
+                      backHref={this.props.backHref(
+                        { flowId },
+                        { integration }
+                      )}
                       onNext={submitForm}
                       isNextDisabled={dirty && !isValid}
                       isNextLoading={isSubmitting}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/SelectConnectionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/SelectConnectionPage.tsx
@@ -1,10 +1,10 @@
 import {
-  visibleStepsByPosition,
   getConnectionIcon,
   getEmptyIntegration,
   getExtensionIcon,
   getStepKindIcon,
   getSteps,
+  visibleStepsByPosition,
   WithConnections,
   WithExtensions,
   WithSteps,
@@ -136,9 +136,8 @@ export class SelectConnectionPage extends React.Component<
     return (
       <WithRouteData<ISelectConnectionRouteParams, ISelectConnectionRouteState>>
         {(params, state, { history }) => {
-          const { flow, position } = params;
+          const { flowId, position } = params;
           const { integration = getEmptyIntegration() } = state;
-          const flowAsNumber = parseInt(flow, 10) || 0;
           const positionAsNumber = parseInt(position, 10) || 0;
           const onStepClick = (connectionOrStep: ConnectionOverview | Step) => {
             const stepKind = getStepKind(connectionOrStep);
@@ -146,18 +145,20 @@ export class SelectConnectionPage extends React.Component<
               case 'api-provider':
                 history.push(this.props.apiProviderHref(params, state));
                 break;
-              default:
+              case 'endpoint':
                 history.push(
                   this.props.connectionHref(
                     connectionOrStep as ConnectionOverview,
-                    params,
+                    {
+                      ...params,
+                    },
                     state
                   )
                 );
                 break;
             }
           };
-          const integrationSteps = getSteps(integration, flowAsNumber);
+          const integrationSteps = getSteps(integration, flowId);
           return (
             <>
               <PageTitle title={'Choose a connection'} />
@@ -200,7 +201,7 @@ export class SelectConnectionPage extends React.Component<
                                     <>
                                       {(visibleStepsByPosition(
                                         integration,
-                                        flow,
+                                        flowId,
                                         toStepKindCollection(
                                           positionAsNumber === 0
                                             ? connectionsData.connectionsWithFromAction

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigureActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigureActionPage.tsx
@@ -67,7 +67,7 @@ export class ConfigureActionPage extends React.Component<
             IConfigureActionRouteState
           >>
             {(
-              { actionId, flow, step = '0', position },
+              { actionId, flowId, step = '0', position },
               {
                 configuredProperties,
                 connection,
@@ -77,7 +77,6 @@ export class ConfigureActionPage extends React.Component<
               { history }
             ) => {
               const stepAsNumber = parseInt(step, 10);
-              const flowAsNumber = parseInt(flow, 10);
               const positionAsNumber = parseInt(position, 10);
               const onUpdatedIntegration = async ({
                 action,
@@ -91,7 +90,7 @@ export class ConfigureActionPage extends React.Component<
                   updatedIntegration || integration,
                   connection,
                   action,
-                  flowAsNumber,
+                  flowId,
                   positionAsNumber,
                   values
                 );
@@ -100,7 +99,7 @@ export class ConfigureActionPage extends React.Component<
                     this.props.nextStepHref(
                       {
                         actionId,
-                        flow,
+                        flowId,
                         position,
                         step: `${stepAsNumber + 1}`,
                       },
@@ -116,7 +115,7 @@ export class ConfigureActionPage extends React.Component<
                   history.push(
                     this.props.postConfigureHref(
                       updatedIntegration,
-                      { actionId, flow, step, position },
+                      { actionId, flowId, step, position },
                       {
                         configuredProperties,
                         connection,
@@ -144,11 +143,14 @@ export class ConfigureActionPage extends React.Component<
                         sidebar={this.props.sidebar({
                           activeIndex: positionAsNumber,
                           connection,
-                          steps: getSteps(updatedIntegration || integration, 0),
+                          steps: getSteps(
+                            updatedIntegration || integration,
+                            flowId
+                          ),
                         })}
                         content={form}
                         backHref={this.props.backHref(
-                          { actionId, flow, step, position },
+                          { actionId, flowId, step, position },
                           {
                             configuredProperties,
                             connection,
@@ -157,7 +159,7 @@ export class ConfigureActionPage extends React.Component<
                           }
                         )}
                         cancelHref={this.props.cancelHref(
-                          { actionId, flow, step, position },
+                          { actionId, flowId, step, position },
                           {
                             configuredProperties,
                             connection,

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/SelectActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/SelectActionPage.tsx
@@ -53,8 +53,7 @@ export class SelectActionPage extends React.Component<ISelectActionPageProps> {
   public render() {
     return (
       <WithRouteData<ISelectActionRouteParams, ISelectActionRouteState>>
-        {({ connectionId, flow, position }, { connection, integration }) => {
-          const flowAsNumber = parseInt(flow, 10);
+        {({ connectionId, flowId, position }, { connection, integration }) => {
           const positionAsNumber = parseInt(position, 10);
           return (
             <WithConnection id={connectionId} initialValue={connection}>
@@ -73,7 +72,7 @@ export class SelectActionPage extends React.Component<ISelectActionPageProps> {
                         sidebar={this.props.sidebar({
                           activeIndex: positionAsNumber,
                           connection: connection as IConnectionWithIconFile,
-                          steps: getSteps(integration, flowAsNumber),
+                          steps: getSteps(integration, flowId),
                         })}
                         content={
                           <IntegrationEditorChooseAction
@@ -98,7 +97,7 @@ export class SelectActionPage extends React.Component<ISelectActionPageProps> {
                                     <ButtonLink
                                       href={this.props.selectHref(
                                         a.id!,
-                                        { connectionId, flow, position },
+                                        { connectionId, flowId, position },
                                         { connection, integration }
                                       )}
                                     >
@@ -112,13 +111,13 @@ export class SelectActionPage extends React.Component<ISelectActionPageProps> {
                         backHref={
                           this.props.backHref
                             ? this.props.backHref(
-                                { connectionId, flow, position },
+                                { connectionId, flowId, position },
                                 { connection, integration }
                               )
                             : undefined
                         }
                         cancelHref={this.props.cancelHref(
-                          { connectionId, flow, position },
+                          { connectionId, flowId, position },
                           { connection, integration }
                         )}
                       />

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/interfaces.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/interfaces.tsx
@@ -7,7 +7,7 @@ import { ConnectionOverview, Integration } from '@syndesis/models';
  * @param step - the configuration step when configuring a multi-page connection.
  */
 export interface IConfigureActionRouteParams {
-  flow: string;
+  flowId: string;
   position: string;
   actionId: string;
   step: string;
@@ -34,7 +34,7 @@ export interface IConfigureActionRouteState {
  * flow.
  */
 export interface ISelectActionRouteParams {
-  flow: string;
+  flowId: string;
   connectionId: string;
   position: string;
 }
@@ -54,7 +54,7 @@ export interface ISelectActionRouteState {
  * flow.
  */
 export interface ISelectConnectionRouteParams {
-  flow: string;
+  flowId: string;
   position: string;
 }
 
@@ -67,7 +67,7 @@ export interface ISelectConnectionRouteState {
 }
 
 export interface IBaseRouteParams {
-  flow: string;
+  flowId: string;
 }
 
 export interface IBaseRouteState {
@@ -81,7 +81,7 @@ export interface IBaseRouteState {
  * @param integration - the integration object.
  */
 export interface ISaveIntegrationRouteParams {
-  flow: string;
+  flowId: string;
 }
 
 export interface ISaveIntegrationForm {

--- a/app/ui-react/syndesis/src/modules/integrations/resolvers.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/resolvers.ts
@@ -29,7 +29,7 @@ import {
 import routes from './routes';
 
 interface IEditorIndex {
-  flow: string;
+  flowId: string;
   integration: Integration;
 }
 
@@ -47,9 +47,12 @@ interface IEditorConfigureAction extends IEditorSelectAction {
   updatedIntegration?: Integration;
 }
 
-export const configureIndexMapper = ({ flow, integration }: IEditorIndex) => ({
+export const configureIndexMapper = ({
+  flowId,
+  integration,
+}: IEditorIndex) => ({
   params: {
-    flow,
+    flowId,
     ...(integration && integration.id ? { integrationId: integration.id } : {}),
   } as IBaseRouteParams,
   state: {
@@ -90,6 +93,7 @@ export const configureSelectActionMapper = ({
 
 export const configureConfigureActionMapper = ({
   actionId,
+  flowId,
   step,
   integration,
   updatedIntegration,
@@ -98,11 +102,12 @@ export const configureConfigureActionMapper = ({
 }: IEditorConfigureAction) => {
   const { params, state } = configureSelectActionMapper({
     ...rest,
+    flowId,
     integration,
     position,
   });
   const positionAsNumber = parseInt(position, 10);
-  const stepObject = getStep(integration, 0, positionAsNumber) || {};
+  const stepObject = getStep(integration, flowId, positionAsNumber) || {};
   return {
     params: {
       ...params,
@@ -129,13 +134,14 @@ export const createStartSelectStepResolver = makeResolverNoParamsWithDefaults<
   ISelectConnectionRouteParams,
   ISelectConnectionRouteState
 >(routes.create.start.selectStep, () => {
+  const integration = getEmptyIntegration();
   return {
     params: {
-      flow: '0',
+      flowId: integration.flows![0].id!,
       position: '0',
     },
     state: {
-      integration: getEmptyIntegration(),
+      integration,
     },
   };
 });

--- a/app/ui-react/syndesis/src/modules/integrations/routes.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/routes.ts
@@ -32,7 +32,7 @@ const stepRoutes = {
  * Both the integration creator and editor share the same routes when the creator
  * reaches the third step in the wizard. This object is to keep them DRY.
  */
-const editorRoutes = include('flow/:flow', {
+const editorRoutes = include('flow/:flowId', {
   index: 'add-step',
   addStep: include('position/:position/connection', stepRoutes),
   editStep: include('position/:position/edit-connection', stepRoutes),
@@ -45,8 +45,8 @@ export default include('/integrations', {
   manageCicd: include('manageCicd', { root: '' }),
   import: include('import', { root: '' }),
   create: include('create', {
-    start: include('start/flow/:flow/position/:position', stepRoutes),
-    finish: include('finish/flow/:flow/position/:position', stepRoutes),
+    start: include('start/flow/:flowId/position/:position', stepRoutes),
+    finish: include('finish/flow/:flowId/position/:position', stepRoutes),
     configure: include('configure', editorRoutes),
     root: '',
   }),


### PR DESCRIPTION
Ported the logic from the Angular codebase, steps should now be filtered based on the current integration object and the position.

Also switched to flow ids instead of the positional index, to align to how the functions work.