### PR TITLE
fix: hide the results bar when there's no filters active

### DIFF
--- a/app/ui-react/packages/ui/src/Shared/ListViewToolbar.tsx
+++ b/app/ui-react/packages/ui/src/Shared/ListViewToolbar.tsx
@@ -82,9 +82,9 @@ export class ListViewToolbar extends React.Component<IListViewToolbarProps> {
         </Sort>
         <Toolbar.RightContent>{this.props.children}</Toolbar.RightContent>
         <Toolbar.Results>
-          <h5>{this.props.i18nResultsCount}</h5>
           {this.props.activeFilters && this.props.activeFilters.length > 0 && (
             <>
+              <h5>{this.props.i18nResultsCount}</h5>
               <Filter.ActiveLabel>Active Filters:</Filter.ActiveLabel>
               <Filter.List>
                 {this.props.activeFilters.map((item: IActiveFilter, index) => (

--- a/app/ui-react/packages/ui/tests/Customization/ExtensionListView.spec.tsx
+++ b/app/ui-react/packages/ui/tests/Customization/ExtensionListView.spec.tsx
@@ -78,9 +78,6 @@ export default describe('ExtensionListView', () => {
       }
     });
 
-    // results message
-    expect(queryAllByText(resultCountMessage)).toHaveLength(1);
-
     // title
     expect(queryAllByText(title)).toHaveLength(1);
 
@@ -150,9 +147,6 @@ export default describe('ExtensionListView', () => {
     // import button in toolbar
     expect(queryAllByText(importText)).toHaveLength(1);
     expect(getByText(importText)).toHaveAttribute('href', importExtensionLink);
-
-    // results message
-    expect(queryAllByText(resultCountMessage)).toHaveLength(1);
 
     // title
     expect(queryAllByText(title)).toHaveLength(1);


### PR DESCRIPTION
fixes #181