### PR TITLE
chore: editor placeholder pages

### DIFF
--- a/app/ui-react/packages/api/src/helpers/integrationFunctions.ts
+++ b/app/ui-react/packages/api/src/helpers/integrationFunctions.ts
@@ -228,10 +228,13 @@ export function getLastPosition(integration: Integration, flowId: string) {
   if (!flow.steps) {
     return undefined;
   }
-  if (flow.steps.length <= 1) {
+  return getStepsLastPosition(flow.steps);
+}
+export function getStepsLastPosition(steps: Step[]) {
+  if (steps.length <= 1) {
     return 1;
   }
-  return flow.steps.length - 1;
+  return steps.length - 1;
 }
 
 /**
@@ -239,18 +242,13 @@ export function getLastPosition(integration: Integration, flowId: string) {
  * @param steps
  * @param position
  */
-export function filterStepsByPosition(
-  integration: Integration,
-  flowId: string,
-  steps: StepKind[],
-  position: number
-) {
+export function filterStepsByPosition(steps: StepKind[], position: number) {
   if (typeof position === 'undefined' || !steps) {
     // safety net
     return steps;
   }
   const atStart = position === 0;
-  const atEnd = getLastPosition(integration, flowId) === position;
+  const atEnd = getStepsLastPosition(steps) === position;
   return steps.filter(step => {
     // Hide steps that are marked as such, and specifically the log connection
     if (
@@ -319,15 +317,10 @@ export function filterStepsByPosition(
  * @param steps
  * @param position
  */
-export function visibleStepsByPosition(
-  integration: Integration,
-  flowId: string,
-  steps: StepKind[],
-  position: number
-) {
-  const previousSteps = getPreviousSteps(integration, flowId, position);
-  const subsequentSteps = getSubsequentSteps(integration, flowId, position);
-  return filterStepsByPosition(integration, flowId, steps, position).filter(s =>
+export function visibleStepsByPosition(steps: StepKind[], position: number) {
+  const previousSteps = steps.slice(0, position);
+  const subsequentSteps = steps.slice(position + 1);
+  return filterStepsByPosition(steps, position).filter(s =>
     s.visible
       ? typeof s.visible === 'function'
         ? s.visible(position, previousSteps, subsequentSteps)

--- a/app/ui-react/packages/ui/src/Integration/IntegrationEditorChooseAction.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationEditorChooseAction.tsx
@@ -27,7 +27,7 @@ export class IntegrationEditorChooseAction extends React.Component<
     return (
       <>
         <Container className="pf-u-my-md">
-          <Title size="xl">{this.props.i18nTitle} - Choose Action</Title>
+          <Title size="xl">{this.props.i18nTitle}</Title>
           <Text>{this.props.i18nSubtitle}</Text>
         </Container>
         <Container>

--- a/app/ui-react/syndesis/src/modules/integrations/IntegrationCreatorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/IntegrationCreatorApp.tsx
@@ -1,3 +1,4 @@
+/* tslint:disable:object-literal-sort-keys */
 import { getConnectionIcon } from '@syndesis/api';
 import {
   Breadcrumb,
@@ -14,6 +15,10 @@ import {
   IntegrationEditorSidebar,
 } from './components';
 import { AddStepPage } from './components/editor/AddStepPage';
+import { ReviewPage } from './components/editor/api-provider/EditPage';
+import { EditPage } from './components/editor/api-provider/ReviewPage';
+import { UploadPage } from './components/editor/api-provider/UploadPage';
+import { EditorApp } from './components/editor/EditorApp';
 import { ConfigureActionPage } from './components/editor/endpoint/ConfigureActionPage';
 import { SelectActionPage } from './components/editor/endpoint/SelectActionPage';
 import { SaveIntegrationPage } from './components/editor/SaveIntegrationPage';
@@ -63,7 +68,7 @@ const startStepSelectConnectionPage = (
   <SelectConnectionPage
     cancelHref={resolvers.list}
     header={<IntegrationCreatorBreadcrumbs step={1} />}
-    apiProviderHref={(p, s) => ({ pathname: 'todo' })}
+    apiProviderHref={resolvers.create.start.apiProvider.upload}
     connectionHref={(connection, params, state) =>
       resolvers.create.start.connection.selectAction({
         connection,
@@ -71,6 +76,11 @@ const startStepSelectConnectionPage = (
         ...state,
       })
     }
+    filterHref={resolvers.create.start.basicFilter}
+    extensionHref={resolvers.create.start.extension}
+    mapperHref={resolvers.create.start.dataMapper}
+    templateHref={resolvers.create.start.template}
+    stepHref={resolvers.create.start.step}
     sidebar={() => (
       <IntegrationVerticalFlow>
         {({ expanded }) => (
@@ -207,7 +217,7 @@ const finishStepSelectConnectionPage = (
   <SelectConnectionPage
     cancelHref={resolvers.list}
     header={<IntegrationCreatorBreadcrumbs step={2} />}
-    apiProviderHref={(p, s) => ({ pathname: 'todo' })}
+    apiProviderHref={resolvers.create.finish.apiProvider.upload}
     connectionHref={(connection, params, state) =>
       resolvers.create.finish.connection.selectAction({
         connection,
@@ -215,6 +225,11 @@ const finishStepSelectConnectionPage = (
         ...state,
       })
     }
+    filterHref={resolvers.create.finish.basicFilter}
+    extensionHref={resolvers.create.finish.extension}
+    mapperHref={resolvers.create.finish.dataMapper}
+    templateHref={resolvers.create.finish.template}
+    stepHref={resolvers.create.finish.step}
     sidebar={({ steps }) => (
       <IntegrationVerticalFlow>
         {({ expanded }) => {
@@ -386,7 +401,7 @@ const addStepSelectConnectionPage = (
   <SelectConnectionPage
     cancelHref={(p, s) => resolvers.create.configure.index({ ...p, ...s })}
     header={<IntegrationCreatorBreadcrumbs step={3} />}
-    apiProviderHref={(p, s) => ({ pathname: 'todo' })}
+    apiProviderHref={resolvers.create.configure.addStep.apiProvider.upload}
     connectionHref={(connection, p, s) =>
       resolvers.create.configure.addStep.connection.selectAction({
         connection,
@@ -394,6 +409,11 @@ const addStepSelectConnectionPage = (
         ...s,
       })
     }
+    filterHref={resolvers.create.configure.addStep.basicFilter}
+    extensionHref={resolvers.create.configure.addStep.extension}
+    mapperHref={resolvers.create.configure.addStep.dataMapper}
+    templateHref={resolvers.create.configure.addStep.template}
+    stepHref={resolvers.create.configure.addStep.step}
     sidebar={({ steps, activeIndex }) => (
       <IntegrationEditorSidebar
         steps={steps}
@@ -521,6 +541,8 @@ const editStepConfigureActionPage = (
   />
 );
 
+const TODO: React.FunctionComponent = () => <>TODO</>;
+
 /**
  * Entry point for the integration creator app. This is shown when an user clicks
  * the "Create integration" button somewhere in the app.
@@ -549,79 +571,194 @@ export const IntegrationCreatorApp: React.FunctionComponent = () => {
         <span>New integration</span>
       </Breadcrumb>
       <Switch>
-        {/* step 1.1 */}
-        <Route
-          path={routes.create.start.selectStep}
-          exact={true}
-          children={startStepSelectConnectionPage}
-        />
-        {/* step 1.2 */}
-        <Route
-          path={routes.create.start.connection.selectAction}
-          exact={true}
-          children={startStepSelectActionPage}
-        />
-        {/* step 1.3 */}
-        <Route
-          path={routes.create.start.connection.configureAction}
-          exact={true}
-          children={startStepConfigureActionPage}
-        />
-        {/* step 2.1 */}
-        <Route
-          path={routes.create.finish.selectStep}
-          exact={true}
-          children={finishStepSelectConnectionPage}
-        />
-        {/* step 2.2 */}
-        <Route
-          path={routes.create.finish.connection.selectAction}
-          exact={true}
-          children={finishStepSelectActionPage}
-        />
-        {/* step 2.3 */}
-        <Route
-          path={routes.create.finish.connection.configureAction}
-          exact={true}
-          children={finishStepConfigureActionPage}
-        />
-        {/* step 3: index */}
+        {/* start step */}
+        <Route path={routes.create.start.selectStep}>
+          <EditorApp
+            selectStepPath={routes.create.start.selectStep}
+            selectStepChildren={startStepSelectConnectionPage}
+            endpointEditor={{
+              selectActionPath: routes.create.start.connection.selectAction,
+              selectActionChildren: startStepSelectActionPage,
+              configureActionPath:
+                routes.create.start.connection.configureAction,
+              configureActionChildren: startStepConfigureActionPage,
+              describeDataPath: routes.create.start.connection.describeData,
+              describeDataChildren: TODO,
+            }}
+            apiProvider={{
+              uploadPath: routes.create.start.apiProvider.upload,
+              uploadChildren: <UploadPage />,
+              reviewPath: routes.create.start.apiProvider.review,
+              reviewChildren: <ReviewPage />,
+              editPath: routes.create.start.apiProvider.edit,
+              editChildren: <EditPage />,
+            }}
+            template={{
+              templatePath: routes.create.start.template,
+              templateChildren: TODO,
+            }}
+            dataMapper={{
+              mapperPath: routes.create.start.dataMapper,
+              mapperChildren: TODO,
+            }}
+            basicFilter={{
+              filterPath: routes.create.start.basicFilter,
+              filterChildren: TODO,
+            }}
+            step={{
+              configurePath: routes.create.start.step,
+              configureChildren: TODO,
+            }}
+            extension={{
+              configurePath: routes.create.start.extension,
+              configureChildren: TODO,
+            }}
+          />
+        </Route>
+
+        {/* finish step */}
+        <Route path={routes.create.finish.selectStep}>
+          <EditorApp
+            selectStepPath={routes.create.finish.selectStep}
+            selectStepChildren={finishStepSelectConnectionPage}
+            endpointEditor={{
+              selectActionPath: routes.create.finish.connection.selectAction,
+              selectActionChildren: finishStepSelectActionPage,
+              configureActionPath:
+                routes.create.finish.connection.configureAction,
+              configureActionChildren: finishStepConfigureActionPage,
+              describeDataPath: routes.create.finish.connection.describeData,
+              describeDataChildren: TODO,
+            }}
+            apiProvider={{
+              uploadPath: routes.create.finish.apiProvider.upload,
+              uploadChildren: <UploadPage />,
+              reviewPath: routes.create.finish.apiProvider.review,
+              reviewChildren: <ReviewPage />,
+              editPath: routes.create.finish.apiProvider.edit,
+              editChildren: <EditPage />,
+            }}
+            template={{
+              templatePath: routes.create.finish.template,
+              templateChildren: TODO,
+            }}
+            dataMapper={{
+              mapperPath: routes.create.finish.dataMapper,
+              mapperChildren: TODO,
+            }}
+            basicFilter={{
+              filterPath: routes.create.finish.basicFilter,
+              filterChildren: TODO,
+            }}
+            step={{
+              configurePath: routes.create.finish.step,
+              configureChildren: TODO,
+            }}
+            extension={{
+              configurePath: routes.create.finish.extension,
+              configureChildren: TODO,
+            }}
+          />
+        </Route>
+
         <Route
           path={routes.create.configure.index}
           exact={true}
           children={addStepPage}
         />
-        {/* step 3: add connection.1 */}
-        <Route
-          path={routes.create.configure.addStep.selectStep}
-          exact={true}
-          children={addStepSelectConnectionPage}
-        />
-        {/* step 3: add connection.2 */}
-        <Route
-          path={routes.create.configure.addStep.connection.selectAction}
-          exact={true}
-          children={addStepSelectActionPage}
-        />
-        {/* step 3: add connection.3 */}
-        <Route
-          path={routes.create.configure.addStep.connection.configureAction}
-          exact={true}
-          children={addStepConfigureActionPage}
-        />
-        {/* step 3: edit connection.2 (this is optional and can be reached only from the configuration page), must be declared before the configure route */}
-        <Route
-          path={routes.create.configure.editStep.connection.selectAction}
-          exact={true}
-          children={editStepSelectActionPage}
-        />
-        {/* step 3: edit connection.1 (when editing we link directly to the configuration step) */}
-        <Route
-          path={routes.create.configure.editStep.connection.configureAction}
-          exact={true}
-          children={editStepConfigureActionPage}
-        />
-        {/* step 4 */}
+
+        {/* add step */}
+        <Route path={routes.create.configure.addStep.selectStep}>
+          <EditorApp
+            selectStepPath={routes.create.configure.addStep.selectStep}
+            selectStepChildren={addStepSelectConnectionPage}
+            endpointEditor={{
+              selectActionPath:
+                routes.create.configure.addStep.connection.selectAction,
+              selectActionChildren: addStepSelectActionPage,
+              configureActionPath:
+                routes.create.configure.addStep.connection.configureAction,
+              configureActionChildren: addStepConfigureActionPage,
+              describeDataPath:
+                routes.create.configure.addStep.connection.describeData,
+              describeDataChildren: TODO,
+            }}
+            apiProvider={{
+              uploadPath: routes.create.configure.addStep.apiProvider.upload,
+              uploadChildren: <UploadPage />,
+              reviewPath: routes.create.configure.addStep.apiProvider.review,
+              reviewChildren: <ReviewPage />,
+              editPath: routes.create.configure.addStep.apiProvider.edit,
+              editChildren: <EditPage />,
+            }}
+            template={{
+              templatePath: routes.create.configure.addStep.template,
+              templateChildren: TODO,
+            }}
+            dataMapper={{
+              mapperPath: routes.create.configure.addStep.dataMapper,
+              mapperChildren: TODO,
+            }}
+            basicFilter={{
+              filterPath: routes.create.configure.addStep.basicFilter,
+              filterChildren: TODO,
+            }}
+            step={{
+              configurePath: routes.create.configure.addStep.step,
+              configureChildren: TODO,
+            }}
+            extension={{
+              configurePath: routes.create.configure.addStep.extension,
+              configureChildren: TODO,
+            }}
+          />
+        </Route>
+
+        {/* edit step */}
+        <Route path={routes.create.configure.editStep.selectStep}>
+          <EditorApp
+            endpointEditor={{
+              selectActionPath:
+                routes.create.configure.editStep.connection.selectAction,
+              selectActionChildren: editStepSelectActionPage,
+              configureActionPath:
+                routes.create.configure.editStep.connection.configureAction,
+              configureActionChildren: editStepConfigureActionPage,
+              describeDataPath:
+                routes.create.configure.editStep.connection.describeData,
+              describeDataChildren: TODO,
+            }}
+            apiProvider={{
+              uploadPath: routes.create.configure.editStep.apiProvider.upload,
+              uploadChildren: <UploadPage />,
+              reviewPath: routes.create.configure.editStep.apiProvider.review,
+              reviewChildren: <ReviewPage />,
+              editPath: routes.create.configure.editStep.apiProvider.edit,
+              editChildren: <EditPage />,
+            }}
+            template={{
+              templatePath: routes.create.configure.editStep.template,
+              templateChildren: TODO,
+            }}
+            dataMapper={{
+              mapperPath: routes.create.configure.editStep.dataMapper,
+              mapperChildren: TODO,
+            }}
+            basicFilter={{
+              filterPath: routes.create.configure.editStep.basicFilter,
+              filterChildren: TODO,
+            }}
+            step={{
+              configurePath: routes.create.configure.editStep.step,
+              configureChildren: TODO,
+            }}
+            extension={{
+              configurePath: routes.create.configure.editStep.extension,
+              configureChildren: TODO,
+            }}
+          />
+        </Route>
+
         <Route
           path={routes.create.configure.saveAndPublish}
           exact={true}

--- a/app/ui-react/syndesis/src/modules/integrations/IntegrationEditorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/IntegrationEditorApp.tsx
@@ -1,3 +1,4 @@
+/* tslint:disable:object-literal-sort-keys */
 import { getConnectionIcon } from '@syndesis/api';
 import { Integration } from '@syndesis/models';
 import { Breadcrumb } from '@syndesis/ui';
@@ -11,6 +12,10 @@ import {
   IntegrationEditorSidebar,
 } from './components';
 import { AddStepPage } from './components/editor/AddStepPage';
+import { ReviewPage } from './components/editor/api-provider/EditPage';
+import { EditPage } from './components/editor/api-provider/ReviewPage';
+import { UploadPage } from './components/editor/api-provider/UploadPage';
+import { EditorApp } from './components/editor/EditorApp';
 import { ConfigureActionPage } from './components/editor/endpoint/ConfigureActionPage';
 import { SelectActionPage } from './components/editor/endpoint/SelectActionPage';
 import { SaveIntegrationPage } from './components/editor/SaveIntegrationPage';
@@ -59,6 +64,11 @@ const selectConnectionPage = (
         ...s,
       })
     }
+    filterHref={resolvers.integration.edit.addStep.basicFilter}
+    extensionHref={resolvers.integration.edit.addStep.extension}
+    mapperHref={resolvers.integration.edit.addStep.dataMapper}
+    templateHref={resolvers.integration.edit.addStep.template}
+    stepHref={resolvers.integration.edit.addStep.step}
     sidebar={({ steps, activeIndex }) => (
       <IntegrationEditorSidebar
         steps={steps}
@@ -199,6 +209,8 @@ export interface IIntegrationEditorAppRouteState {
   integration: Integration;
 }
 
+const TODO: React.FunctionComponent = () => <>TODO</>;
+
 /**
  * Entry point for the integration editor app. This is shown when an user clicks
  * on the "Edit" button for any existing integration.
@@ -241,31 +253,103 @@ export const IntegrationEditorApp: React.FunctionComponent = () => {
               exact={true}
               children={addStepPage}
             />
-            <Route
-              path={routes.integration.edit.addStep.selectStep}
-              exact={true}
-              children={selectConnectionPage}
-            />
-            <Route
-              path={routes.integration.edit.addStep.connection.selectAction}
-              exact={true}
-              children={addStepSelectActionPage}
-            />
-            <Route
-              path={routes.integration.edit.addStep.connection.configureAction}
-              exact={true}
-              children={addStepConfigureActionPage}
-            />
-            <Route
-              path={routes.integration.edit.editStep.connection.selectAction}
-              exact={true}
-              children={editStepSelectActionPage}
-            />
-            <Route
-              path={routes.integration.edit.editStep.connection.configureAction}
-              exact={true}
-              children={editStepConfigureActionPage}
-            />
+
+            {/* add step */}
+            <Route path={routes.integration.edit.addStep.selectStep}>
+              <EditorApp
+                selectStepPath={routes.integration.edit.addStep.selectStep}
+                selectStepChildren={selectConnectionPage}
+                endpointEditor={{
+                  selectActionPath:
+                    routes.integration.edit.addStep.connection.selectAction,
+                  selectActionChildren: addStepSelectActionPage,
+                  configureActionPath:
+                    routes.integration.edit.addStep.connection.configureAction,
+                  configureActionChildren: addStepConfigureActionPage,
+                  describeDataPath:
+                    routes.integration.edit.addStep.connection.describeData,
+                  describeDataChildren: TODO,
+                }}
+                apiProvider={{
+                  uploadPath:
+                    routes.integration.edit.addStep.apiProvider.upload,
+                  uploadChildren: <UploadPage />,
+                  reviewPath:
+                    routes.integration.edit.addStep.apiProvider.review,
+                  reviewChildren: <ReviewPage />,
+                  editPath: routes.integration.edit.addStep.apiProvider.edit,
+                  editChildren: <EditPage />,
+                }}
+                template={{
+                  templatePath: routes.integration.edit.addStep.template,
+                  templateChildren: TODO,
+                }}
+                dataMapper={{
+                  mapperPath: routes.integration.edit.addStep.dataMapper,
+                  mapperChildren: TODO,
+                }}
+                basicFilter={{
+                  filterPath: routes.integration.edit.addStep.basicFilter,
+                  filterChildren: TODO,
+                }}
+                step={{
+                  configurePath: routes.integration.edit.addStep.step,
+                  configureChildren: TODO,
+                }}
+                extension={{
+                  configurePath: routes.integration.edit.addStep.step,
+                  configureChildren: TODO,
+                }}
+              />
+            </Route>
+
+            {/* edit step */}
+            <Route path={routes.integration.edit.editStep.selectStep}>
+              <EditorApp
+                endpointEditor={{
+                  selectActionPath:
+                    routes.integration.edit.editStep.connection.selectAction,
+                  selectActionChildren: editStepSelectActionPage,
+                  configureActionPath:
+                    routes.integration.edit.editStep.connection.configureAction,
+                  configureActionChildren: editStepConfigureActionPage,
+                  describeDataPath:
+                    routes.integration.edit.editStep.connection.describeData,
+                  describeDataChildren: TODO,
+                }}
+                apiProvider={{
+                  uploadPath:
+                    routes.integration.edit.editStep.apiProvider.upload,
+                  uploadChildren: <UploadPage />,
+                  reviewPath:
+                    routes.integration.edit.editStep.apiProvider.review,
+                  reviewChildren: <ReviewPage />,
+                  editPath: routes.integration.edit.editStep.apiProvider.edit,
+                  editChildren: <EditPage />,
+                }}
+                template={{
+                  templatePath: routes.integration.edit.editStep.template,
+                  templateChildren: TODO,
+                }}
+                dataMapper={{
+                  mapperPath: routes.integration.edit.editStep.dataMapper,
+                  mapperChildren: TODO,
+                }}
+                basicFilter={{
+                  filterPath: routes.integration.edit.editStep.basicFilter,
+                  filterChildren: TODO,
+                }}
+                step={{
+                  configurePath: routes.integration.edit.editStep.step,
+                  configureChildren: TODO,
+                }}
+                extension={{
+                  configurePath: routes.integration.edit.editStep.extension,
+                  configureChildren: TODO,
+                }}
+              />
+            </Route>
+
             <Route
               path={routes.integration.edit.saveAndPublish}
               exact={true}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/EditorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/EditorApp.tsx
@@ -1,0 +1,231 @@
+import * as React from 'react';
+import { Route, Switch } from 'react-router';
+import { ReviewPage } from './api-provider/EditPage';
+import { EditPage } from './api-provider/ReviewPage';
+import { UploadPage } from './api-provider/UploadPage';
+import { ConfigureActionPage } from './endpoint/ConfigureActionPage';
+import { SelectActionPage } from './endpoint/SelectActionPage';
+
+export interface IEndpointEditorAppProps {
+  selectActionPath: string;
+  selectActionChildren: React.ReactElement<SelectActionPage>;
+  configureActionPath: string;
+  configureActionChildren: React.ReactElement<ConfigureActionPage>;
+  describeDataPath: string;
+  describeDataChildren: React.ReactNode;
+}
+export const EndpointEditorApp: React.FunctionComponent<
+  IEndpointEditorAppProps
+> = props => {
+  return (
+    <Switch>
+      <Route
+        path={props.selectActionPath}
+        exact={true}
+        children={props.selectActionChildren}
+      />
+      <Route
+        path={props.configureActionPath}
+        exact={true}
+        children={props.configureActionChildren}
+      />
+      <Route
+        path={props.describeDataPath}
+        exact={true}
+        children={props.describeDataChildren}
+      />
+    </Switch>
+  );
+};
+
+export interface IApiProviderAppProps {
+  uploadPath: string;
+  uploadChildren: React.ReactElement<UploadPage>;
+  reviewPath: string;
+  reviewChildren: React.ReactElement<ReviewPage>;
+  editPath: string;
+  editChildren: React.ReactElement<EditPage>;
+}
+export const ApiProviderApp: React.FunctionComponent<
+  IApiProviderAppProps
+> = props => {
+  return (
+    <Switch>
+      <Route
+        path={props.uploadPath}
+        exact={true}
+        children={props.uploadChildren}
+      />
+      <Route
+        path={props.reviewPath}
+        exact={true}
+        children={props.reviewChildren}
+      />
+      <Route path={props.editPath} exact={true} children={props.editChildren} />
+    </Switch>
+  );
+};
+
+export interface ITemplateAppProps {
+  templatePath: string;
+  templateChildren: React.ReactNode;
+}
+export const TemplateApp: React.FunctionComponent<
+  ITemplateAppProps
+> = props => {
+  return (
+    <Switch>
+      <Route
+        path={props.templatePath}
+        exact={true}
+        children={props.templateChildren}
+      />
+    </Switch>
+  );
+};
+
+export interface IBasicFilterAppProps {
+  filterPath: string;
+  filterChildren: React.ReactNode;
+}
+export const BasicFilterApp: React.FunctionComponent<
+  IBasicFilterAppProps
+> = props => {
+  return (
+    <Switch>
+      <Route
+        path={props.filterPath}
+        exact={true}
+        children={props.filterChildren}
+      />
+    </Switch>
+  );
+};
+
+export interface IDataMapperAppProps {
+  mapperPath: string;
+  mapperChildren: React.ReactNode;
+}
+export const DataMapperApp: React.FunctionComponent<
+  IDataMapperAppProps
+> = props => {
+  return (
+    <Switch>
+      <Route
+        path={props.mapperPath}
+        exact={true}
+        children={props.mapperChildren}
+      />
+    </Switch>
+  );
+};
+
+export interface IStepAppProps {
+  configurePath: string;
+  configureChildren: React.ReactNode;
+}
+export const StepApp: React.FunctionComponent<IStepAppProps> = props => {
+  return (
+    <Switch>
+      <Route
+        path={props.configurePath}
+        exact={true}
+        children={props.configureChildren}
+      />
+    </Switch>
+  );
+};
+
+export interface IExtensionAppProps {
+  configurePath: string;
+  configureChildren: React.ReactNode;
+}
+export const ExtensionApp: React.FunctionComponent<
+  IExtensionAppProps
+> = props => {
+  return (
+    <Switch>
+      <Route
+        path={props.configurePath}
+        exact={true}
+        children={props.configureChildren}
+      />
+    </Switch>
+  );
+};
+
+export interface IEditorAppProps {
+  selectStepPath?: string;
+  selectStepChildren?: React.ReactNode;
+  endpointEditor: IEndpointEditorAppProps;
+  apiProvider: IApiProviderAppProps;
+  template: ITemplateAppProps;
+  dataMapper: IDataMapperAppProps;
+  basicFilter: IBasicFilterAppProps;
+  step: IStepAppProps;
+  extension: IExtensionAppProps;
+}
+export const EditorApp: React.FunctionComponent<IEditorAppProps> = props => {
+  return (
+    <Switch>
+      {props.selectStepPath && props.selectStepChildren ? (
+        <Route
+          path={props.selectStepPath}
+          exact={true}
+          children={props.selectStepChildren}
+        />
+      ) : null}
+
+      <Route path={props.endpointEditor.selectActionPath}>
+        <EndpointEditorApp
+          selectActionPath={props.endpointEditor.selectActionPath}
+          selectActionChildren={props.endpointEditor.selectActionChildren}
+          configureActionPath={props.endpointEditor.configureActionPath}
+          configureActionChildren={props.endpointEditor.configureActionChildren}
+          describeDataPath={props.endpointEditor.describeDataPath}
+          describeDataChildren={props.endpointEditor.describeDataChildren}
+        />
+      </Route>
+      <Route path={props.apiProvider.uploadPath}>
+        <ApiProviderApp
+          uploadPath={props.apiProvider.uploadPath}
+          uploadChildren={props.apiProvider.uploadChildren}
+          reviewPath={props.apiProvider.reviewPath}
+          reviewChildren={props.apiProvider.reviewChildren}
+          editPath={props.apiProvider.editPath}
+          editChildren={props.apiProvider.editChildren}
+        />
+      </Route>
+      <Route path={props.template.templatePath}>
+        <TemplateApp
+          templatePath={props.template.templatePath}
+          templateChildren={props.template.templateChildren}
+        />
+      </Route>
+      <Route path={props.dataMapper.mapperPath}>
+        <DataMapperApp
+          mapperPath={props.dataMapper.mapperPath}
+          mapperChildren={props.dataMapper.mapperChildren}
+        />
+      </Route>
+      <Route path={props.basicFilter.filterPath}>
+        <BasicFilterApp
+          filterPath={props.basicFilter.filterPath}
+          filterChildren={props.basicFilter.filterChildren}
+        />
+      </Route>
+      <Route path={props.step.configurePath}>
+        <StepApp
+          configurePath={props.step.configurePath}
+          configureChildren={props.step.configureChildren}
+        />
+      </Route>
+      <Route path={props.extension.configurePath}>
+        <ExtensionApp
+          configurePath={props.extension.configurePath}
+          configureChildren={props.extension.configureChildren}
+        />
+      </Route>
+    </Switch>
+  );
+};

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/api-provider/EditPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/api-provider/EditPage.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { PageTitle } from '../../../../../shared';
+
+export class ReviewPage extends React.Component {
+  public render() {
+    return (
+      <>
+        <PageTitle title={'Review actions'} />
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit. Blanditiis
+          illo, iusto nesciunt nostrum omnis pariatur rerum vero voluptates.
+          Accusamus aliquid corporis deleniti ea earum ipsa optio, quidem quod
+          ut! Placeat.
+        </p>
+      </>
+    );
+  }
+}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/api-provider/ReviewPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/api-provider/ReviewPage.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { PageTitle } from '../../../../../shared';
+
+export class EditPage extends React.Component {
+  public render() {
+    return (
+      <>
+        <PageTitle title={'Provide API Definition'} />
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit. Blanditiis
+          illo, iusto nesciunt nostrum omnis pariatur rerum vero voluptates.
+          Accusamus aliquid corporis deleniti ea earum ipsa optio, quidem quod
+          ut! Placeat.
+        </p>
+      </>
+    );
+  }
+}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/api-provider/UploadPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/api-provider/UploadPage.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { PageTitle } from '../../../../../shared';
+
+export class UploadPage extends React.Component {
+  public render() {
+    return (
+      <>
+        <PageTitle title={'Start integration with an API call'} />
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit. Blanditiis
+          illo, iusto nesciunt nostrum omnis pariatur rerum vero voluptates.
+          Accusamus aliquid corporis deleniti ea earum ipsa optio, quidem quod
+          ut! Placeat.
+        </p>
+      </>
+    );
+  }
+}

--- a/app/ui-react/syndesis/src/modules/integrations/index.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/index.tsx
@@ -39,7 +39,7 @@ export class IntegrationsModule extends React.Component {
           exact={true}
           component={ManageCiCdPage}
         />
-        <Route path={routes.import.root} exact={true} component={ImportPage} />
+        <Route path={routes.import} exact={true} component={ImportPage} />
         <Route path={routes.create.root} component={IntegrationCreatorApp} />
         <Route
           path={routes.integration.edit.root}

--- a/app/ui-react/syndesis/src/modules/integrations/pages/IntegrationsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/IntegrationsPage.tsx
@@ -131,7 +131,7 @@ export class IntegrationsPage extends React.Component {
                         <>
                           <PageTitle title={t('shared:Integrations')} />
                           <IntegrationsListView
-                            linkToIntegrationImport={'/integrations/import'}
+                            linkToIntegrationImport={resolvers.import()}
                             linkToManageCiCd={resolvers.manageCicd.root()}
                             linkToIntegrationCreation={resolvers.create.start.selectStep()}
                             filterTypes={getFilterTypes(

--- a/app/ui-react/syndesis/src/modules/integrations/resolvers.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/resolvers.ts
@@ -230,15 +230,10 @@ export const createConfigureEditStepConfigureActionResolver = makeResolver<
 );
 
 export const createConfigureEditStepSaveAndPublishResolver = makeResolver<
-  { integration: Integration },
-  null,
+  IEditorIndex,
+  ISaveIntegrationRouteParams,
   ISaveIntegrationRouteState
->(routes.create.configure.saveAndPublish, ({ integration }) => ({
-  params: null,
-  state: {
-    integration,
-  },
-}));
+>(routes.create.configure.saveAndPublish, configureIndexMapper);
 
 export const integrationActivityResolver = makeResolver<
   { integration: Integration },
@@ -330,7 +325,11 @@ export const metricsResolver = makeResolver<
   },
 }));
 
-export default {
+type RouteResolver<T> = {
+  [K in keyof T]: T[K] extends string ? any : RouteResolver<T[K]>
+};
+
+const resolvers: RouteResolver<typeof routes> = {
   list: listResolver,
   manageCicd: {
     root: manageCicdResolver,
@@ -342,55 +341,139 @@ export default {
       connection: {
         selectAction: createStartSelectActionResolver,
         configureAction: createStartConfigureActionResolver,
+        describeData: () => 'describeData',
       },
+      apiProvider: {
+        upload: makeResolverNoParams(routes.create.start.apiProvider.upload),
+        review: () => 'review',
+        edit: () => 'edit',
+      },
+      basicFilter: () => 'basicFilter',
+      dataMapper: () => 'dataMapper',
+      template: () => 'template',
+      step: () => 'step',
+      extension: () => 'extension',
     },
     finish: {
       selectStep: createFinishSelectStepResolver,
       connection: {
         selectAction: createFinishSelectActionResolver,
         configureAction: createFinishConfigureActionResolver,
+        describeData: () => 'describeData',
       },
+      apiProvider: {
+        upload: makeResolverNoParams(routes.create.finish.apiProvider.upload),
+        review: () => 'review',
+        edit: () => 'edit',
+      },
+      basicFilter: () => 'basicFilter',
+      dataMapper: () => 'dataMapper',
+      template: () => 'template',
+      step: () => 'step',
+      extension: () => 'extension',
     },
     configure: {
+      root: createRootResolver,
       index: createConfigureIndexResolver,
       addStep: {
         selectStep: createConfigureAddStepSelectStepResolver,
         connection: {
           selectAction: createConfigureAddStepSelectActionResolver,
           configureAction: createConfigureAddStepConfigureActionResolver,
+          describeData: () => 'describeData',
         },
+        apiProvider: {
+          upload: makeResolverNoParams(
+            routes.create.configure.addStep.apiProvider.upload
+          ),
+          review: () => 'review',
+          edit: () => 'edit',
+        },
+        basicFilter: () => 'basicFilter',
+        dataMapper: () => 'dataMapper',
+        template: () => 'template',
+        step: () => 'step',
+        extension: () => 'extension',
       },
       editStep: {
-        index: 'todo',
+        selectStep: () => {
+          throw new Error('this route should not be used');
+        },
         connection: {
           selectAction: createConfigureEditStepSelectActionResolver,
           configureAction: createConfigureEditStepConfigureActionResolver,
+          describeData: () => 'describeData',
         },
+        apiProvider: {
+          upload: makeResolverNoParams(
+            routes.create.configure.editStep.apiProvider.upload
+          ),
+          review: () => 'review',
+          edit: () => 'edit',
+        },
+        basicFilter: () => 'basicFilter',
+        dataMapper: () => 'dataMapper',
+        template: () => 'template',
+        step: () => 'step',
+        extension: () => 'extension',
       },
       saveAndPublish: createConfigureEditStepSaveAndPublishResolver,
     },
   },
   integration: {
+    root: createRootResolver,
     activity: integrationActivityResolver,
     details: integrationDetailsResolver,
     edit: {
+      root: createRootResolver,
       index: integrationEditIndexResolver,
       addStep: {
         selectStep: integrationEditAddStepSelectStepResolver,
         connection: {
           selectAction: integrationEditAddStepSelectActionResolver,
           configureAction: integrationEditAddStepConfigureActionResolver,
+          describeData: () => 'describeData',
         },
+        apiProvider: {
+          upload: makeResolverNoParams(
+            routes.integration.edit.addStep.apiProvider.upload
+          ),
+          review: () => 'review',
+          edit: () => 'edit',
+        },
+        basicFilter: () => 'basicFilter',
+        dataMapper: () => 'dataMapper',
+        template: () => 'template',
+        step: () => 'step',
+        extension: () => 'extension',
       },
       editStep: {
-        index: 'todo',
+        selectStep: () => {
+          throw new Error('this route should not be used');
+        },
         connection: {
           selectAction: integrationEditEditStepSelectActionResolver,
           configureAction: integrationEditEditStepConfigureActionResolver,
+          describeData: () => 'describeData',
         },
+        apiProvider: {
+          upload: makeResolverNoParams(
+            routes.integration.edit.editStep.apiProvider.upload
+          ),
+          review: () => 'review',
+          edit: () => 'edit',
+        },
+        basicFilter: () => 'basicFilter',
+        dataMapper: () => 'dataMapper',
+        template: () => 'template',
+        step: () => 'step',
+        extension: () => 'extension',
       },
       saveAndPublish: integrationEditSaveAndPublish,
     },
     metrics: metricsResolver,
   },
+  import: makeResolverNoParams(routes.import),
 };
+
+export default resolvers;

--- a/app/ui-react/syndesis/src/modules/integrations/routes.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/routes.ts
@@ -6,10 +6,9 @@ const stepRoutes = {
   selectStep: '',
   // if selected step is api provider
   apiProvider: include('api-provider', {
-    specification: 'specification',
+    upload: '',
     review: 'review',
     edit: 'edit',
-    save: 'save',
   }),
   // if selected step kind is data mapper
   dataMapper: 'mapper',
@@ -19,10 +18,12 @@ const stepRoutes = {
   template: 'template',
   // if selected step kind is step
   step: 'step',
+  // if selected step kind is step
+  extension: 'extension',
   // if selected step kind is endpoint
   connection: include('connection/:connectionId', {
-    selectAction: 'action',
-    configureAction: 'action/:actionId/step/:step',
+    selectAction: '',
+    configureAction: ':actionId/:step',
     // if 'any' data shape
     describeData: 'describe-data/:position/:direction(input|output)',
   }),
@@ -32,10 +33,10 @@ const stepRoutes = {
  * Both the integration creator and editor share the same routes when the creator
  * reaches the third step in the wizard. This object is to keep them DRY.
  */
-const editorRoutes = include('flow/:flowId', {
+const editorRoutes = include(':flowId', {
   index: 'add-step',
-  addStep: include('position/:position/connection', stepRoutes),
-  editStep: include('position/:position/edit-connection', stepRoutes),
+  addStep: include(':position/add', stepRoutes),
+  editStep: include(':position/edit', stepRoutes),
   saveAndPublish: 'save',
   root: '',
 });
@@ -43,10 +44,10 @@ const editorRoutes = include('flow/:flowId', {
 export default include('/integrations', {
   list: '',
   manageCicd: include('manageCicd', { root: '' }),
-  import: include('import', { root: '' }),
+  import: 'import',
   create: include('create', {
-    start: include('start/flow/:flowId/position/:position', stepRoutes),
-    finish: include('finish/flow/:flowId/position/:position', stepRoutes),
+    start: include('start/:flowId/:position', stepRoutes),
+    finish: include('finish/:flowId/:position', stepRoutes),
     configure: include('configure', editorRoutes),
     root: '',
   }),


### PR DESCRIPTION
This introduces the `EditorApp` component, a pluggable "app" that will handle the routes required to handle adding/editing a step to an integration.

Its main goal is to make sure that regardless of where the app has been plugged, all the required routes and sub-components will be set. This together with the previous PR #163 should remove the risk of extending the editor with new features forgetting to do it everywhere is needed.

There are a lot of `TODO` placeholders for the pages right now, but the basic routing and wiring should be in place. Clicking on any step object when adding a step to an integration should never give an error, but redirect to the right URL and show a "TODO" as the page content.

I'm not super happy about how the whole thing looks right now, there is _a lot_ of code that needs to be written to wire a page to the editor "only" for being able to do this in a typesafe way. I hope this will pay in the long run.