### PR TITLE
bugfix: don't crash editing an integration with steps other than endpoints

### DIFF
--- a/app/ui-react/packages/api/src/helpers/integrationFunctions.ts
+++ b/app/ui-react/packages/api/src/helpers/integrationFunctions.ts
@@ -151,7 +151,7 @@ export function getStep(
  */
 export function getStartIcon(apiUri: string, integration: Integration) {
   const flow = integration.flows![0];
-  return getStepIcon(apiUri, integration, flow.id!, 0);
+  return getIntegrationStepIcon(apiUri, integration, flow.id!, 0);
 }
 
 /**
@@ -160,7 +160,12 @@ export function getStartIcon(apiUri: string, integration: Integration) {
  */
 export function getFinishIcon(apiUri: string, integration: Integration) {
   const flow = integration.flows![0];
-  return getStepIcon(apiUri, integration, flow.id!, flow.steps!.length - 1);
+  return getIntegrationStepIcon(
+    apiUri,
+    integration,
+    flow.id!,
+    flow.steps!.length - 1
+  );
 }
 
 export function getExtensionIcon(extension: Extension) {
@@ -178,14 +183,22 @@ export function getStepKindIcon(stepKind: Step['stepKind']) {
  * @param flowId
  * @param stepIndex
  */
-export function getStepIcon(
+export function getIntegrationStepIcon(
   apiUri: string,
   integration: Integration,
   flowId: string,
   stepIndex: number
 ): string {
   const step = getStep(integration, flowId, stepIndex);
-  // The step is a connection
+  return getStepIcon(apiUri, step);
+}
+
+/**
+ * Returns the icon for the supplied step
+ * @param apiUri
+ * @param step
+ */
+export function getStepIcon(apiUri: string, step: Step): string {
   if (step.connection) {
     const connection = step.connection as IConnectionWithIconFile;
     return getConnectionIcon(apiUri, connection);

--- a/app/ui-react/packages/api/tests/helpers/integrationFunctions.spec.tsx
+++ b/app/ui-react/packages/api/tests/helpers/integrationFunctions.spec.tsx
@@ -1,4 +1,4 @@
-import { getEmptyIntegration, getStepIcon } from '../../src';
+import { getEmptyIntegration, getIntegrationStepIcon } from '../../src';
 import { IConnectionWithIconFile, Integration, Step } from '@syndesis/models';
 import expect = require('expect');
 
@@ -27,7 +27,7 @@ export default describe('integrationFunctions', () => {
         },
       ],
     } as Integration;
-    const iconPath = getStepIcon('', integration, 'id', 0);
+    const iconPath = getIntegrationStepIcon('', integration, 'id', 0);
     expect(iconPath).toBe('data:blah');
   });
   it('Should return a valid icon URL for a legacy connection', () => {
@@ -46,7 +46,7 @@ export default describe('integrationFunctions', () => {
         },
       ],
     } as Integration;
-    const iconPath = getStepIcon('', integration, 'id', 0);
+    const iconPath = getIntegrationStepIcon('', integration, 'id', 0);
     expect(iconPath).toBe('./../../icons/blah.connection.png');
   });
   it('Should return a valid icon URL for a connection that references a db entity', () => {
@@ -66,7 +66,7 @@ export default describe('integrationFunctions', () => {
         },
       ],
     } as Integration;
-    const iconPath = getStepIcon('', integration, 'id', 0);
+    const iconPath = getIntegrationStepIcon('', integration, 'id', 0);
     expect(iconPath).toBe('/connectors/foo/icon?db:blah');
   });
   it('Should return a valid icon URL for a connection that references a db entity', () => {
@@ -86,7 +86,7 @@ export default describe('integrationFunctions', () => {
         },
       ],
     } as Integration;
-    const iconPath = getStepIcon('', integration, 'id', 0);
+    const iconPath = getIntegrationStepIcon('', integration, 'id', 0);
     expect(iconPath).toBe('/connectors/foo/icon?db:blah');
   });
   it('Should return a valid icon URL for a connection that references a db entity', () => {
@@ -106,7 +106,7 @@ export default describe('integrationFunctions', () => {
         },
       ],
     } as Integration;
-    const iconPath = getStepIcon('', integration, 'id', 0);
+    const iconPath = getIntegrationStepIcon('', integration, 'id', 0);
     expect(iconPath).toBe('/connectors/foo/icon?extension:blah');
   });
   it('Should return a valid icon URL for a connection with an icon file', () => {
@@ -126,7 +126,7 @@ export default describe('integrationFunctions', () => {
         },
       ],
     } as Integration;
-    const iconPath = getStepIcon('', integration, 'id', 0);
+    const iconPath = getIntegrationStepIcon('', integration, 'id', 0);
     expect(iconPath).toBe('foo');
   });
   it('Should return a valid icon URL for an extension step', () => {
@@ -145,7 +145,7 @@ export default describe('integrationFunctions', () => {
         },
       ],
     } as Integration;
-    const iconPath = getStepIcon('', integration, 'id', 0);
+    const iconPath = getIntegrationStepIcon('', integration, 'id', 0);
     expect(iconPath).toBe('blah');
   });
   it('Should return a valid icon URL for a step', () => {
@@ -162,7 +162,7 @@ export default describe('integrationFunctions', () => {
         },
       ],
     } as Integration;
-    const iconPath = getStepIcon('', integration, 'id', 0);
+    const iconPath = getIntegrationStepIcon('', integration, 'id', 0);
     expect(iconPath).toBe('/icons/steps/log.svg');
   });
 });

--- a/app/ui-react/syndesis/src/modules/integrations/IntegrationCreatorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/IntegrationCreatorApp.tsx
@@ -36,15 +36,20 @@ const addStepPage = (
         ...s,
       })
     }
-    getEditConfigureStepHrefCallback={(stepIdx, step, p, s) =>
+    apiProviderHref={resolvers.create.configure.editStep.apiProvider.review}
+    connectionHref={(step, params, state) =>
       resolvers.create.configure.editStep.connection.configureAction({
         actionId: step.action!.id!,
         connection: step.connection!,
-        position: `${stepIdx}`,
-        ...p,
-        ...s,
+        ...params,
+        ...state,
       })
     }
+    filterHref={resolvers.create.configure.editStep.basicFilter}
+    extensionHref={resolvers.create.configure.editStep.extension}
+    mapperHref={resolvers.create.configure.editStep.dataMapper}
+    templateHref={resolvers.create.configure.editStep.template}
+    stepHref={resolvers.create.configure.editStep.step}
     header={<IntegrationCreatorBreadcrumbs step={3} />}
     nextHref={(p, s) =>
       resolvers.create.configure.saveAndPublish({

--- a/app/ui-react/syndesis/src/modules/integrations/IntegrationEditorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/IntegrationEditorApp.tsx
@@ -33,15 +33,20 @@ const addStepPage = (
         ...s,
       })
     }
-    getEditConfigureStepHrefCallback={(stepIdx, step, p, s) =>
+    apiProviderHref={resolvers.integration.edit.editStep.apiProvider.review}
+    connectionHref={(step, params, state) =>
       resolvers.integration.edit.editStep.connection.configureAction({
         actionId: step.action!.id!,
         connection: step.connection!,
-        position: `${stepIdx}`,
-        ...p,
-        ...s,
+        ...params,
+        ...state,
       })
     }
+    filterHref={resolvers.integration.edit.editStep.basicFilter}
+    extensionHref={resolvers.integration.edit.editStep.extension}
+    mapperHref={resolvers.integration.edit.editStep.dataMapper}
+    templateHref={resolvers.integration.edit.editStep.template}
+    stepHref={resolvers.integration.edit.editStep.step}
     header={<IntegrationEditorBreadcrumbs step={1} />}
     nextHref={(p, s) =>
       resolvers.integration.edit.saveAndPublish({

--- a/app/ui-react/syndesis/src/modules/integrations/components/IntegrationDetailSteps.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/IntegrationDetailSteps.tsx
@@ -1,4 +1,4 @@
-import { getStepIcon, getSteps } from '@syndesis/api';
+import { getIntegrationStepIcon, getSteps } from '@syndesis/api';
 import { Integration } from '@syndesis/models';
 import {
   IntegrationStepsHorizontalItem,
@@ -29,7 +29,7 @@ export class IntegrationDetailSteps extends React.Component<
             <React.Fragment key={idx}>
               <IntegrationStepsHorizontalItem
                 name={stepName}
-                icon={getStepIcon(
+                icon={getIntegrationStepIcon(
                   process.env.PUBLIC_URL,
                   this.props.integration,
                   flowId,

--- a/app/ui-react/syndesis/src/modules/integrations/components/IntegrationEditorStepAdder.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/IntegrationEditorStepAdder.tsx
@@ -1,3 +1,4 @@
+import { getStepIcon } from '@syndesis/api';
 import { Step } from '@syndesis/models';
 import {
   ButtonLink,
@@ -51,9 +52,15 @@ export class IntegrationEditorStepAdder extends React.Component<
           return (
             <React.Fragment key={idx}>
               <IntegrationEditorStepsListItem
-                stepName={s.connection!.connector!.name}
-                stepDescription={s.action!.name}
-                icon={<img src={s.connection!.icon} width={24} height={24} />}
+                stepName={s.name!}
+                stepDescription={s.action ? s.action.name : ''}
+                icon={
+                  <img
+                    src={getStepIcon(process.env.PUBLIC_URL, s)}
+                    width={24}
+                    height={24}
+                  />
+                }
                 actions={
                   <>
                     <ButtonLink href={this.props.configureStepHref(idx, s)}>

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
@@ -7,17 +7,12 @@ import * as React from 'react';
 import { PageTitle } from '../../../../shared';
 import { IntegrationEditorStepAdder } from '../IntegrationEditorStepAdder';
 import { IBaseRouteParams, IBaseRouteState } from './interfaces';
+import { getStepHref, IGetStepHrefs } from './utils';
 
-export interface IAddStepPageProps {
+export interface IAddStepPageProps extends IGetStepHrefs {
   cancelHref: (p: IBaseRouteParams, s: IBaseRouteState) => H.LocationDescriptor;
   getEditAddStepHref: (
     position: number,
-    p: IBaseRouteParams,
-    s: IBaseRouteState
-  ) => H.LocationDescriptor;
-  getEditConfigureStepHrefCallback: (
-    stepIdx: number,
-    step: Step,
     p: IBaseRouteParams,
     s: IBaseRouteState
   ) => H.LocationDescriptor;
@@ -63,12 +58,12 @@ export class AddStepPage extends React.Component<IAddStepPageProps> {
                         { integration }
                       )
                     }
-                    configureStepHref={(stepIdx: number, step: Step) =>
-                      this.props.getEditConfigureStepHrefCallback(
-                        stepIdx,
+                    configureStepHref={(position: number, step: Step) =>
+                      getStepHref(
                         step,
-                        { flowId },
-                        { integration }
+                        { flowId, position: `${position}` },
+                        { integration },
+                        this.props
                       )
                     }
                   />

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/interfaces.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/interfaces.tsx
@@ -1,4 +1,4 @@
-import { ConnectionOverview, Integration } from '@syndesis/models';
+import { ConnectionOverview, Integration, StepKind } from '@syndesis/models';
 
 /**
  * @param actionId - the ID of the action selected in the previous step.
@@ -94,4 +94,9 @@ export interface ISaveIntegrationForm {
  */
 export interface ISaveIntegrationRouteState {
   integration: Integration;
+}
+
+export interface IUIStep extends StepKind {
+  icon: string;
+  uiStepKind: 'api-provider' | StepKind['stepKind'];
 }

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
@@ -1,0 +1,132 @@
+import {
+  getConnectionIcon,
+  getExtensionIcon,
+  getStepKindIcon,
+} from '@syndesis/api';
+import {
+  ConnectionOverview,
+  Extension,
+  Step,
+  StepKind,
+} from '@syndesis/models';
+import * as H from 'history';
+import { IAddStepPageProps } from './AddStepPage';
+import {
+  ISelectConnectionRouteParams,
+  ISelectConnectionRouteState,
+  IUIStep,
+} from './interfaces';
+
+type StepKindHrefCallback = (
+  step: Step,
+  p: ISelectConnectionRouteParams | IAddStepPageProps,
+  s: ISelectConnectionRouteState | undefined
+) => H.LocationDescriptorObject;
+
+export function toUIStepKind(step: Step): IUIStep['uiStepKind'] {
+  if ((step as ConnectionOverview).connectorId === 'api-provider') {
+    return 'api-provider';
+  }
+  return step.stepKind;
+}
+
+export interface IGetStepHrefs {
+  apiProviderHref: StepKindHrefCallback;
+  connectionHref: StepKindHrefCallback;
+  filterHref: StepKindHrefCallback;
+  extensionHref: StepKindHrefCallback;
+  mapperHref: StepKindHrefCallback;
+  templateHref: StepKindHrefCallback;
+  stepHref: StepKindHrefCallback;
+}
+export const getStepHref = (
+  step: Step,
+  params: ISelectConnectionRouteParams | IAddStepPageProps,
+  state: ISelectConnectionRouteState | undefined,
+  hrefs: IGetStepHrefs
+) => {
+  switch (toUIStepKind(step)) {
+    case 'api-provider':
+      return hrefs.apiProviderHref(step, params, state);
+    case 'expressionFilter':
+    case 'ruleFilter':
+      return hrefs.filterHref(step, params, state);
+    case 'extension':
+      return hrefs.extensionHref(step, params, state);
+    case 'mapper':
+      return hrefs.mapperHref(step, params, state);
+    case 'headers':
+      throw new Error(`Can't handle stepKind ${step.stepKind}`);
+    case 'template':
+      return hrefs.templateHref(step, params, state);
+    case 'choice':
+    case 'split':
+    case 'aggregate':
+    case 'log':
+      return hrefs.stepHref(step, params, state);
+    case 'endpoint':
+    case 'connector':
+    default:
+      return hrefs.connectionHref(step as ConnectionOverview, params, state);
+  }
+};
+
+export function toStepKindCollection(
+  connections: ConnectionOverview[],
+  extensions: Extension[],
+  steps: StepKind[]
+): IUIStep[] {
+  return [
+    ...connections.map(
+      c =>
+        ({
+          ...c,
+          description: c.description || '',
+          icon: getConnectionIcon(process.env.PUBLIC_URL, c),
+          properties: undefined,
+          uiStepKind:
+            c.connectorId === 'api-provider' ? 'api-provider' : 'endpoint',
+        } as IUIStep)
+    ),
+    ...extensions.reduce(
+      (extentionsByAction, extension) => {
+        extension.actions.forEach(a => {
+          let properties = {};
+          if (
+            a.descriptor &&
+            Array.isArray(a.descriptor.propertyDefinitionSteps)
+          ) {
+            properties = a.descriptor.propertyDefinitionSteps.reduce(
+              (acc, current) => {
+                return { ...acc, ...current.properties };
+              },
+              {}
+            );
+          }
+          if (a.actionType === 'step') {
+            extentionsByAction.push({
+              action: a,
+              configuredProperties: undefined,
+              description: a.description || '',
+              extension,
+              icon: `${process.env.PUBLIC_URL}${getExtensionIcon(extension)}`,
+              name: a.name,
+              properties,
+              stepKind: 'extension',
+              uiStepKind: 'extension',
+            });
+          }
+        });
+        return extentionsByAction;
+      },
+      [] as IUIStep[]
+    ),
+    ...steps.map(s => ({
+      ...s,
+      icon: `${process.env.PUBLIC_URL}${getStepKindIcon(s.stepKind)}`,
+      uiStepKind: s.stepKind,
+    })),
+  ]
+    .filter(s => !!s.uiStepKind) // this should never happen
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/app/ui-react/syndesis/src/modules/integrations/resolvers.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/resolvers.ts
@@ -116,7 +116,7 @@ export const configureConfigureActionMapper = ({
     state: {
       ...state,
       updatedIntegration,
-      configuredProperties: stepObject.configuredProperties,
+      configuredProperties: stepObject.configuredProperties || {},
     } as IConfigureActionRouteState,
   };
 };


### PR DESCRIPTION
The href selection logic is now shared between the SelectConnection and AddStep components.

Clicking on anything but an endpoint will still crash the app btw.