### PR TITLE
Integration Detail: Metrics tab

### DIFF
--- a/app/ui-react/packages/api/src/WithIntegrationMetrics.tsx
+++ b/app/ui-react/packages/api/src/WithIntegrationMetrics.tsx
@@ -1,0 +1,41 @@
+import { IntegrationMetricsSummary } from '@syndesis/models';
+import * as React from 'react';
+import { IFetchState } from './Fetch';
+import { SyndesisFetch } from './SyndesisFetch';
+import { WithPolling } from './WithPolling';
+
+export interface IWithIntegrationMetricsProps {
+  disableUpdates?: boolean;
+  integrationId: string;
+  children(props: IFetchState<IntegrationMetricsSummary>): any;
+}
+
+export class WithIntegrationMetrics extends React.Component<
+  IWithIntegrationMetricsProps
+> {
+  public render() {
+    return (
+      <SyndesisFetch<IntegrationMetricsSummary>
+        url={`/metrics/integrations/${this.props.integrationId}`}
+        defaultValue={{
+          errors: 0, // int64
+          lastProcessed: `${Date.now()}`, // date-time
+          messages: 0, // int64
+          metricsProvider: 'null',
+          start: `${Date.now()}`, // date-time
+        }}
+      >
+        {({ read, response }) => {
+          if (this.props.disableUpdates) {
+            return this.props.children(response);
+          }
+          return (
+            <WithPolling read={read} polling={5000}>
+              {() => this.props.children(response)}
+            </WithPolling>
+          );
+        }}
+      </SyndesisFetch>
+    );
+  }
+}

--- a/app/ui-react/packages/api/src/index.ts
+++ b/app/ui-react/packages/api/src/index.ts
@@ -20,6 +20,7 @@ export * from './WithIntegrations';
 export * from './WithIntegrationTags';
 export * from './WithMonitoredIntegration';
 export * from './WithMonitoredIntegrations';
+export * from './WithIntegrationMetrics';
 export * from './WithIntegrationsMetrics';
 export * from './WithConnections';
 export * from './WithConnection';

--- a/app/ui-react/packages/ui/src/Integration/IntegrationDetailMetrics.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationDetailMetrics.tsx
@@ -13,17 +13,23 @@ import {
 import * as React from 'react';
 
 export interface IIntegrationDetailMetricsProps {
-  errorMessagesCount?: number;
-  okMessagesCount?: number;
-  totalMessages?: number;
-  uptimeStart: number;
+  i18nLastProcessed: string;
+  i18nSince: string;
+  i18nTotalErrors: string;
+  i18nTotalMessages: string;
+  i18nUptime: string;
+  errors?: number;
+  lastProcessed?: string;
+  messages?: number;
+  start?: string;
 }
 
 export class IntegrationDetailMetrics extends React.Component<
   IIntegrationDetailMetricsProps
 > {
   public render() {
-    const startAsDate = new Date(this.props.uptimeStart);
+    const okMessagesCount = this.props.messages! - this.props.errors!;
+    const startAsDate = new Date(this.props.start!);
     const startAsHuman = startAsDate.toLocaleString();
 
     return (
@@ -33,19 +39,19 @@ export class IntegrationDetailMetrics extends React.Component<
             <Card accented={true} aggregated={true} matchHeight={true}>
               <CardTitle>
                 <Icon type="pf" name="error-circle-o" />
-                {this.props.errorMessagesCount}
+                {this.props.errors}
               </CardTitle>
-              <CardBody>Total Errors</CardBody>
+              <CardBody>{this.props.i18nTotalErrors}</CardBody>
             </Card>
           </Col>
           <Col xs={6} sm={3} md={3}>
             <Card accented={true} aggregated={true} matchHeight={true}>
               <CardTitle>
                 <Icon name="shield" />
-                Last Processed
+                {this.props.i18nLastProcessed}
               </CardTitle>
               <CardBody>
-                <h2>n/a</h2>
+                <h2>{this.props.lastProcessed}</h2>
               </CardBody>
             </Card>
           </Col>
@@ -53,19 +59,19 @@ export class IntegrationDetailMetrics extends React.Component<
             <Card accented={true} aggregated={true} matchHeight={true}>
               <CardTitle>
                 <AggregateStatusCount>
-                  {this.props.totalMessages}&nbsp;
+                  {this.props.messages}&nbsp;
                 </AggregateStatusCount>
-                Total Messages
+                {this.props.i18nTotalMessages}
               </CardTitle>
               <CardBody>
                 <AggregateStatusNotifications>
                   <AggregateStatusNotification>
                     <Icon type="pf" name="ok" />
-                    {this.props.okMessagesCount}&nbsp;
+                    {okMessagesCount}&nbsp;
                   </AggregateStatusNotification>
                   <AggregateStatusNotification>
                     <Icon type="pf" name="error-circle-o" />
-                    {this.props.errorMessagesCount}
+                    {this.props.errors}
                   </AggregateStatusNotification>
                 </AggregateStatusNotifications>
               </CardBody>
@@ -74,8 +80,11 @@ export class IntegrationDetailMetrics extends React.Component<
           <Col xs={6} sm={3} md={3}>
             <Card accented={true} aggregated={true} matchHeight={true}>
               <Card.Title className={'text-left'}>
-                <small className={'pull-right'}>Since {startAsHuman}</small>
-                <div>Uptime</div>
+                <small className={'pull-right'}>
+                  {this.props.i18nSince}
+                  {startAsHuman}
+                </small>
+                <div>{this.props.i18nUptime}</div>
               </Card.Title>
               <Card.Body>
                 <></>

--- a/app/ui-react/packages/ui/stories/Integration/IntegrationDetail.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Integration/IntegrationDetail.stories.tsx
@@ -200,10 +200,15 @@ storiesOf('Integration/Detail', module)
           </TabBar>
         </Container>
         <IntegrationDetailMetrics
-          errorMessagesCount={2}
-          okMessagesCount={2425}
-          totalMessages={26126}
-          uptimeStart={5358454957349}
+          i18nLastProcessed={'Last Processed'}
+          i18nSince={'Since '}
+          i18nTotalErrors={'Total Errors'}
+          i18nTotalMessages={'Total Messages'}
+          i18nUptime={'Uptime'}
+          errors={2}
+          lastProcessed={'2 May 2019 08:19:42 GMT'}
+          messages={26126}
+          start={'2 May 2019 08:19:42 GMT'}
         />
       </>
     </Router>

--- a/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -55,6 +55,13 @@
     "pageTitle": "Integration Summary",
     "replaceDraft": "Replace Draft"
   },
+  "metrics": {
+    "lastProcessed": "Last Processed",
+    "since": "Since ",
+    "totalErrors": "Total Errors",
+    "totalMessages": "Total Messages",
+    "uptime": "Uptime"
+  },
   "alerts": {
     "modified": "A connection associated with this integration has been modified. To incorporate the changes, please edit the integration.",
     "obsolete": "The published integration has become obsolete and its recommended it should be republished."

--- a/app/ui-react/syndesis/src/modules/integrations/pages/detail/DetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/detail/DetailsPage.tsx
@@ -25,10 +25,6 @@ export interface IIntegrationDetailsRouteParams {
   integrationId: string;
 }
 
-export interface IIntegrationDetailsRouteState {
-  integration?: IIntegrationOverviewWithDraft;
-}
-
 /**
  * @integrationId - the ID of the integration for which details are being displayed.
  */

--- a/app/ui-react/syndesis/src/modules/integrations/pages/detail/MetricsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/detail/MetricsPage.tsx
@@ -1,6 +1,9 @@
-import { WithMonitoredIntegration } from '@syndesis/api';
-import { Integration } from '@syndesis/models';
-import { Loader } from '@syndesis/ui';
+import {
+  WithIntegrationMetrics,
+  WithMonitoredIntegration,
+} from '@syndesis/api';
+import { IIntegrationOverviewWithDraft } from '@syndesis/models';
+import { IntegrationDetailMetrics, Loader } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
 import * as React from 'react';
 import { Translation } from 'react-i18next';
@@ -14,12 +17,19 @@ import {
 /**
  * @integrationId - the ID of the integration for which details are being displayed.
  */
-export interface IMetricsPageParams {
+export interface IMetricsRouteParams {
+  integrationId: string;
+}
+
+/**
+ * @integrationId - the ID of the integration for which details are being displayed.
+ */
+export interface IMetricsPageProps {
   integrationId: string;
 }
 
 export interface IMetricsPageState {
-  integration: Integration;
+  integration?: IIntegrationOverviewWithDraft;
 }
 
 /**
@@ -29,61 +39,93 @@ export interface IMetricsPageState {
  * or an integration object set via the state.
  *
  */
-export class MetricsPage extends React.Component {
+export class MetricsPage extends React.Component<
+  IMetricsPageProps,
+  IMetricsPageState
+> {
+  public constructor(props: IMetricsPageProps) {
+    super(props);
+  }
+
   public render() {
     return (
       <Translation ns={['integrations', 'shared']}>
         {t => (
           <AppContext.Consumer>
             {({ getPodLogUrl }) => (
-              <WithRouteData<IMetricsPageParams, IMetricsPageState>>
-                {({ integrationId }, { integration }, { history }) => {
+              <WithRouteData<IMetricsRouteParams, null>>
+                {({ integrationId }) => {
                   return (
                     <WithMonitoredIntegration integrationId={integrationId}>
                       {({ data, hasData, error }) => (
-                        <WithLoader
-                          error={error}
-                          loading={!hasData}
-                          loaderChildren={<Loader />}
-                          errorChildren={<ApiError />}
-                        >
-                          {() => (
-                            <WithIntegrationActions
-                              integration={data.integration}
+                        <WithIntegrationMetrics integrationId={integrationId}>
+                          {({ data: metricsData }) => (
+                            <WithLoader
+                              error={error}
+                              loading={!hasData}
+                              loaderChildren={<Loader />}
+                              errorChildren={<ApiError />}
                             >
-                              {({
-                                ciCdAction,
-                                editAction,
-                                deleteAction,
-                                exportAction,
-                                startAction,
-                                stopAction,
-                              }) => {
-                                return (
-                                  <>
-                                    <PageTitle
-                                      title={t('integrations:detail:pageTitle')}
-                                    />
-                                    <IntegrationDetailHeader
-                                      data={data}
-                                      startAction={startAction}
-                                      stopAction={stopAction}
-                                      deleteAction={deleteAction}
-                                      ciCdAction={ciCdAction}
-                                      editAction={editAction}
-                                      exportAction={exportAction}
-                                      getPodLogUrl={getPodLogUrl}
-                                    />
-                                    <p>
-                                      This is the Integration Detail Metrics
-                                      page.
-                                    </p>
-                                  </>
-                                );
-                              }}
-                            </WithIntegrationActions>
+                              {() => (
+                                <WithIntegrationActions
+                                  integration={data.integration}
+                                >
+                                  {({
+                                    ciCdAction,
+                                    editAction,
+                                    deleteAction,
+                                    exportAction,
+                                    startAction,
+                                    stopAction,
+                                  }) => {
+                                    return (
+                                      <>
+                                        <PageTitle
+                                          title={t(
+                                            'integrations:detail:pageTitle'
+                                          )}
+                                        />
+                                        <IntegrationDetailHeader
+                                          data={data}
+                                          startAction={startAction}
+                                          stopAction={stopAction}
+                                          deleteAction={deleteAction}
+                                          ciCdAction={ciCdAction}
+                                          editAction={editAction}
+                                          exportAction={exportAction}
+                                          getPodLogUrl={getPodLogUrl}
+                                        />
+                                        <IntegrationDetailMetrics
+                                          i18nUptime={t(
+                                            'integrations:metrics:uptime'
+                                          )}
+                                          i18nTotalMessages={t(
+                                            'integrations:metrics:totalMessages'
+                                          )}
+                                          i18nTotalErrors={t(
+                                            'integrations:metrics:totalErrors'
+                                          )}
+                                          i18nSince={t(
+                                            'integrations:metrics:since'
+                                          )}
+                                          i18nLastProcessed={t(
+                                            'integrations:metrics:lastProcessed'
+                                          )}
+                                          errors={metricsData.errors}
+                                          lastProcessed={
+                                            metricsData.lastProcessed
+                                          }
+                                          messages={metricsData.messages}
+                                          start={metricsData.start}
+                                        />
+                                      </>
+                                    );
+                                  }}
+                                </WithIntegrationActions>
+                              )}
+                            </WithLoader>
                           )}
-                        </WithLoader>
+                        </WithIntegrationMetrics>
                       )}
                     </WithMonitoredIntegration>
                   );

--- a/app/ui-react/syndesis/src/modules/integrations/resolvers.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/resolvers.ts
@@ -22,8 +22,7 @@ import {
   IActivityPageParams,
   IActivityPageState,
   IIntegrationDetailsRouteParams,
-  IMetricsPageParams,
-  IMetricsPageState,
+  IMetricsRouteParams,
 } from './pages/detail';
 import routes from './routes';
 
@@ -313,15 +312,12 @@ export const integrationEditSaveAndPublish = makeResolver<
 >(routes.integration.edit.saveAndPublish, configureIndexMapper);
 
 export const metricsResolver = makeResolver<
-  { integration: Integration },
-  IMetricsPageParams,
-  IMetricsPageState
->(routes.integration.metrics, ({ integration }) => ({
+  { integrationId: string },
+  IMetricsRouteParams,
+  null
+>(routes.integration.metrics, ({ integrationId }) => ({
   params: {
-    integrationId: integration.id!,
-  },
-  state: {
-    integration,
+    integrationId,
   },
 }));
 

--- a/app/ui-react/syndesis/src/modules/integrations/shared/IntegrationDetailNavBar.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/shared/IntegrationDetailNavBar.tsx
@@ -53,7 +53,7 @@ export class IntegrationDetailNavBar extends React.Component<
               <TabBarItem
                 label={'Metrics'}
                 to={resolvers.integration.metrics({
-                  integration,
+                  integrationId: integration.id!,
                 })}
               />
             </TabBar>


### PR DESCRIPTION
- incorporates refactoring changes from @gashcrumb 's PR here https://github.com/syndesisio/syndesis-react/pull/220
- adds functionality to metrics tab, using UI component
- updated to correct interface, where date is a string, unlike what the API returns. we need to add `parseInt()` instead of `newDate` but i'm out of time.