### PR TITLE
bugfix: fork the history package to set state on the sessionStorage

### DIFF
--- a/app/ui-react/packages/history/.browserslistrc
+++ b/app/ui-react/packages/history/.browserslistrc
@@ -1,0 +1,7 @@
+# Browsers we support
+last 2 versions
+> 0.5%
+ie >= 10
+safari >= 9
+firefox >= 43
+iOS >= 8

--- a/app/ui-react/packages/history/.github/lock.yml
+++ b/app/ui-react/packages/history/.github/lock.yml
@@ -1,0 +1,25 @@
+# Configuration for lock-threads - https://github.com/dessant/lock-threads
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 60
+
+# Issues and pull requests with these labels will not be locked. Set to `[]` to disable
+exemptLabels: []
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: false
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: false
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings just for `issues` or `pulls`
+# issues:
+#   exemptLabels:
+#     - help-wanted
+#   lockLabel: outdated
+
+# pulls:
+#   daysUntilLock: 30

--- a/app/ui-react/packages/history/.gitignore
+++ b/app/ui-react/packages/history/.gitignore
@@ -1,0 +1,5 @@
+/node_modules/
+/es/
+/esm/
+/cjs/
+/umd/

--- a/app/ui-react/packages/history/.prettierignore
+++ b/app/ui-react/packages/history/.prettierignore
@@ -1,0 +1,3 @@
+.travis.yml
+package.json
+package-lock.json

--- a/app/ui-react/packages/history/.prettierrc
+++ b/app/ui-react/packages/history/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/app/ui-react/packages/history/.size-snapshot.json
+++ b/app/ui-react/packages/history/.size-snapshot.json
@@ -1,0 +1,50 @@
+{
+  "esm/history.js": {
+    "bundled": 28557,
+    "minified": 12544,
+    "gzipped": 3664,
+    "treeshaked": {
+      "rollup": {
+        "code": 208,
+        "import_statements": 132
+      },
+      "webpack": {
+        "code": 1324
+      }
+    }
+  },
+  "umd/history.js": {
+    "bundled": 33516,
+    "minified": 12134,
+    "gzipped": 4006
+  },
+  "umd/history.min.js": {
+    "bundled": 30879,
+    "minified": 10184,
+    "gzipped": 3592
+  },
+  "esm/@syndesis/history.js": {
+    "bundled": 28122,
+    "minified": 12371,
+    "gzipped": 3583,
+    "treeshaked": {
+      "rollup": {
+        "code": 208,
+        "import_statements": 132
+      },
+      "webpack": {
+        "code": 1324
+      }
+    }
+  },
+  "umd/@syndesis/history.js": {
+    "bundled": 33067,
+    "minified": 11961,
+    "gzipped": 3925
+  },
+  "umd/@syndesis/history.min.js": {
+    "bundled": 30430,
+    "minified": 10011,
+    "gzipped": 3510
+  }
+}

--- a/app/ui-react/packages/history/.travis.yml
+++ b/app/ui-react/packages/history/.travis.yml
@@ -1,0 +1,26 @@
+language: node_js
+node_js: node
+cache: npm
+env:
+- TEST_ENV=cjs BUILD_ENV=cjs
+- TEST_ENV=umd BUILD_ENV=umd
+- TEST_ENV=source
+before_script:
+- ([[ -z "$BUILD_ENV" ]] || npm run build)
+script:
+- npm run lint
+- npm test
+jobs:
+  include:
+  - stage: Release
+    if: tag =~ ^v[0-9]
+    env: NPM_TAG=$([[ "$TRAVIS_TAG" == *-* ]] && echo "next" || echo "latest")
+    script: echo "Releasing $TRAVIS_TAG to npm with tag \"$NPM_TAG\" ..."
+    deploy:
+      provider: npm
+      skip_cleanup: true
+      tag: "$NPM_TAG"
+      email: npm@mjackson.me
+      api_key: "$NPM_TOKEN"
+      on:
+        tags: true

--- a/app/ui-react/packages/history/CONTRIBUTING.md
+++ b/app/ui-react/packages/history/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+All development happens on GitHub. When [creating a pull request](https://help.github.com/articles/creating-a-pull-request/), please make sure that all of the following apply:
+
+- If you're adding a new feature or "fixing" a bug, please go into detail about your use case and why you think you need that feature or that bug fixed. This library has lots and lots of dependents, and we can't afford to make changes lightly without understanding why.
+- The tests pass. The test suite will automatically run when you create the PR. All you need to do is wait a few minutes to see the result in the PR.
+- Each commit in your PR should describe a significant piece of work. Work that was done in one commit and then undone later should be squashed into a single commit.
+
+If your PR fails to meet these guidelines, it may be closed without much of an explanation besides a link to this document.
+
+Thank you for your contribution!

--- a/app/ui-react/packages/history/DOMUtils.js
+++ b/app/ui-react/packages/history/DOMUtils.js
@@ -1,0 +1,3 @@
+'use strict';
+require('./warnAboutDeprecatedCJSRequire.js')('DOMUtils');
+module.exports = require('./index.js').DOMUtils;

--- a/app/ui-react/packages/history/ExecutionEnvironment.js
+++ b/app/ui-react/packages/history/ExecutionEnvironment.js
@@ -1,0 +1,3 @@
+'use strict';
+require('./warnAboutDeprecatedCJSRequire.js')('ExecutionEnvironment');
+module.exports = require('./index.js').ExecutionEnvironment;

--- a/app/ui-react/packages/history/LICENSE
+++ b/app/ui-react/packages/history/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) React Training 2016-2018
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app/ui-react/packages/history/LocationUtils.js
+++ b/app/ui-react/packages/history/LocationUtils.js
@@ -1,0 +1,3 @@
+'use strict';
+require('./warnAboutDeprecatedCJSRequire.js')('LocationUtils');
+module.exports = require('./index.js').LocationUtils;

--- a/app/ui-react/packages/history/PathUtils.js
+++ b/app/ui-react/packages/history/PathUtils.js
@@ -1,0 +1,3 @@
+'use strict';
+require('./warnAboutDeprecatedCJSRequire.js')('PathUtils');
+module.exports = require('./index.js').PathUtils;

--- a/app/ui-react/packages/history/README.md
+++ b/app/ui-react/packages/history/README.md
@@ -1,0 +1,288 @@
+# history [![Travis][build-badge]][build] [![npm package][npm-badge]][npm]
+
+[build-badge]: https://img.shields.io/travis/ReactTraining/history/master.svg?style=flat-square
+[build]: https://travis-ci.org/ReactTraining/history
+[npm-badge]: https://img.shields.io/npm/v/history.svg?style=flat-square
+[npm]: https://www.npmjs.org/package/history
+
+[`history`](https://www.npmjs.com/package/history) is a JavaScript library that lets you easily manage session history anywhere JavaScript runs. `history` abstracts away the differences in various environments and provides a minimal API that lets you manage the history stack, navigate, confirm navigation, and persist state between sessions.
+
+## Installation
+
+Using [npm](https://www.npmjs.com/):
+
+    $ npm install --save history
+
+Then with a module bundler like [webpack](https://webpack.github.io/), use as you would anything else:
+
+```js
+// using ES6 modules
+import { createBrowserHistory } from 'history';
+
+// using CommonJS modules
+var createBrowserHistory = require('history').createBrowserHistory;
+```
+
+The UMD build is also available on [unpkg](https://unpkg.com):
+
+```html
+<script src="https://unpkg.com/history"></script>
+```
+
+You can find the library on `window.History`.
+
+## Usage
+
+`history` provides 3 different methods for creating a `history` object, depending on your environment.
+
+- `createBrowserHistory` is for use in modern web browsers that support the [HTML5 history API](http://diveintohtml5.info/history.html) (see [cross-browser compatibility](http://caniuse.com/#feat=history))
+- `createMemoryHistory` is used as a reference implementation and may also be used in non-DOM environments, like [React Native](https://facebook.github.io/react-native/) or tests
+- `createHashHistory` is for use in legacy web browsers
+
+Depending on the method you want to use to keep track of history, you'll `import` (or `require`) one of these methods directly from the package root (i.e. `history/createBrowserHistory`). The remainder of this document uses the term `createHistory` to refer to any of these implementations.
+
+Basic usage looks like this:
+
+```js
+import { createBrowserHistory } from 'history';
+
+const history = createBrowserHistory();
+
+// Get the current location.
+const location = history.location;
+
+// Listen for changes to the current location.
+const unlisten = history.listen((location, action) => {
+  // location is an object like window.location
+  console.log(action, location.pathname, location.state);
+});
+
+// Use push, replace, and go to navigate around.
+history.push('/home', { some: 'state' });
+
+// To stop listening, call the function returned from listen().
+unlisten();
+```
+
+The options that each `create` method takes, along with its default values, are:
+
+```js
+createBrowserHistory({
+  basename: '', // The base URL of the app (see below)
+  forceRefresh: false, // Set true to force full page refreshes
+  keyLength: 6, // The length of location.key
+  // A function to use to confirm navigation with the user (see below)
+  getUserConfirmation: (message, callback) => callback(window.confirm(message))
+});
+
+createMemoryHistory({
+  initialEntries: ['/'], // The initial URLs in the history stack
+  initialIndex: 0, // The starting index in the history stack
+  keyLength: 6, // The length of location.key
+  // A function to use to confirm navigation with the user. Required
+  // if you return string prompts from transition hooks (see below)
+  getUserConfirmation: null
+});
+
+createHashHistory({
+  basename: '', // The base URL of the app (see below)
+  hashType: 'slash', // The hash type to use (see below)
+  // A function to use to confirm navigation with the user (see below)
+  getUserConfirmation: (message, callback) => callback(window.confirm(message))
+});
+```
+
+### Properties
+
+Each `history` object has the following properties:
+
+- `history.length` - The number of entries in the history stack
+- `history.location` - The current location (see below)
+- `history.action` - The current navigation action (see below)
+
+Additionally, `createMemoryHistory` provides `history.index` and `history.entries` properties that let you inspect the history stack.
+
+### Listening
+
+You can listen for changes to the current location using `history.listen`:
+
+```js
+history.listen((location, action) => {
+  console.log(
+    `The current URL is ${location.pathname}${location.search}${location.hash}`
+  );
+  console.log(`The last navigation action was ${action}`);
+});
+```
+
+The `location` object implements a subset of [the `window.location` interface](https://developer.mozilla.org/en-US/docs/Web/API/Location), including:
+
+- `location.pathname` - The path of the URL
+- `location.search` - The URL query string
+- `location.hash` - The URL hash fragment
+
+Locations may also have the following properties:
+
+- `location.state` - Some extra state for this location that does not reside in the URL (supported in `createBrowserHistory` and `createMemoryHistory`)
+- `location.key` - A unique string representing this location (supported in `createBrowserHistory` and `createMemoryHistory`)
+
+The `action` is one of `PUSH`, `REPLACE`, or `POP` depending on how the user got to the current URL.
+
+#### Cleaning up
+
+When you attach a listener using `history.listen`, it returns a function that can be used to remove the listener, which can then be invoked in cleanup logic:
+
+```js
+const unlisten = history.listen(myListener);
+// ...
+unlisten();
+```
+
+### Navigation
+
+`history` objects may be used to programmatically change the current location using the following methods:
+
+- `history.push(path, [state])`
+- `history.replace(path, [state])`
+- `history.go(n)`
+- `history.goBack()`
+- `history.goForward()`
+- `history.canGo(n)` (only in `createMemoryHistory`)
+
+When using `push` or `replace` you can either specify both the URL path and state as separate arguments or include everything in a single location-like object as the first argument.
+
+1. A URL path _or_
+2. A location-like object with `{ pathname, search, hash, state }`
+
+```js
+// Push a new entry onto the history stack.
+history.push('/home');
+
+// Push a new entry onto the history stack with a query string
+// and some state. Location state does not appear in the URL.
+history.push('/home?the=query', { some: 'state' });
+
+// If you prefer, use a single location-like object to specify both
+// the URL and state. This is equivalent to the example above.
+history.push({
+  pathname: '/home',
+  search: '?the=query',
+  state: { some: 'state' }
+});
+
+// Go back to the previous history entry. The following
+// two lines are synonymous.
+history.go(-1);
+history.goBack();
+```
+
+**Note:** Location state is only supported in `createBrowserHistory` and `createMemoryHistory`.
+
+### Blocking Transitions
+
+`history` lets you register a prompt message that will be shown to the user before location listeners are notified. This allows you to make sure the user wants to leave the current page before they navigate away.
+
+```js
+// Register a simple prompt message that will be shown the
+// user before they navigate away from the current page.
+const unblock = history.block('Are you sure you want to leave this page?');
+
+// Or use a function that returns the message when it's needed.
+history.block((location, action) => {
+  // The location and action arguments indicate the location
+  // we're transitioning to and how we're getting there.
+
+  // A common use case is to prevent the user from leaving the
+  // page if there's a form they haven't submitted yet.
+  if (input.value !== '') return 'Are you sure you want to leave this page?';
+});
+
+// To stop blocking transitions, call the function returned from block().
+unblock();
+```
+
+**Note:** You'll need to provide a `getUserConfirmation` function to use this feature with `createMemoryHistory` (see below).
+
+### Customizing the Confirm Dialog
+
+By default, [`window.confirm`](https://developer.mozilla.org/en-US/docs/Web/API/Window/confirm) is used to show prompt messages to the user. If you need to override this behavior (or if you're using `createMemoryHistory`, which doesn't assume a DOM environment), provide a `getUserConfirmation` function when you create your history object.
+
+```js
+const history = createHistory({
+  getUserConfirmation(message, callback) {
+    // Show some custom dialog to the user and call
+    // callback(true) to continue the transiton, or
+    // callback(false) to abort it.
+  }
+});
+```
+
+### Using a Base URL
+
+If all the URLs in your app are relative to some other "base" URL, use the `basename` option. This option transparently adds the given string to the front of all URLs you use.
+
+```js
+const history = createHistory({
+  basename: '/the/base'
+});
+
+history.listen(location => {
+  console.log(location.pathname); // /home
+});
+
+history.push('/home'); // URL is now /the/base/home
+```
+
+**Note:** `basename` is not supported in `createMemoryHistory`.
+
+### Forcing Full Page Refreshes in createBrowserHistory
+
+By default `createBrowserHistory` uses HTML5 `pushState` and `replaceState` to prevent reloading the entire page from the server while navigating around. If instead you would like to reload as the URL changes, use the `forceRefresh` option.
+
+```js
+const history = createBrowserHistory({
+  forceRefresh: true
+});
+```
+
+### Modifying the Hash Type in createHashHistory
+
+By default `createHashHistory` uses a leading slash in hash-based URLs. You can use the `hashType` option to use a different hash formatting.
+
+```js
+const history = createHashHistory({
+  hashType: 'slash' // the default
+});
+
+history.push('/home'); // window.location.hash is #/home
+
+const history = createHashHistory({
+  hashType: 'noslash' // Omit the leading slash
+});
+
+history.push('/home'); // window.location.hash is #home
+
+const history = createHashHistory({
+  hashType: 'hashbang' // Google's legacy AJAX URL format
+});
+
+history.push('/home'); // window.location.hash is #!/home
+```
+
+## Changes
+
+To see the changes that were made in a given release, please lookup the tag on [the releases page](https://github.com/ReactTraining/history/releases).
+
+For changes released in version 4.6.3 and earlier, please see [the `CHANGES.md` file](https://github.com/ReactTraining/history/blob/845d690c5576c7f55ecbe14babe0092e8e5bc2bb/CHANGES.md).
+
+## About
+
+`history` is developed and maintained by [React Training](https://reacttraining.com). If
+you're interested in learning more about what React can do for your company, please
+[get in touch](mailto:hello@reacttraining.com)!
+
+## Thanks
+
+A big thank-you to [BrowserStack](https://www.browserstack.com/) for providing the infrastructure that allows us to run our build in real browsers.
+
+Also, thanks to [Dan Shaw](https://www.npmjs.com/~dshaw) for letting us use the `history` npm package name. Thanks Dan!

--- a/app/ui-react/packages/history/createBrowserHistory.js
+++ b/app/ui-react/packages/history/createBrowserHistory.js
@@ -1,0 +1,3 @@
+'use strict';
+require('./warnAboutDeprecatedCJSRequire.js')('createBrowserHistory');
+module.exports = require('./index.js').createBrowserHistory;

--- a/app/ui-react/packages/history/createHashHistory.js
+++ b/app/ui-react/packages/history/createHashHistory.js
@@ -1,0 +1,3 @@
+'use strict';
+require('./warnAboutDeprecatedCJSRequire.js')('createHashHistory');
+module.exports = require('./index.js').createHashHistory;

--- a/app/ui-react/packages/history/createMemoryHistory.js
+++ b/app/ui-react/packages/history/createMemoryHistory.js
@@ -1,0 +1,3 @@
+'use strict';
+require('./warnAboutDeprecatedCJSRequire.js')('createMemoryHistory');
+module.exports = require('./index.js').createMemoryHistory;

--- a/app/ui-react/packages/history/createTransitionManager.js
+++ b/app/ui-react/packages/history/createTransitionManager.js
@@ -1,0 +1,3 @@
+'use strict';
+require('./warnAboutDeprecatedCJSRequire.js')('createTransitionManager');
+module.exports = require('./index.js').createTransitionManager;

--- a/app/ui-react/packages/history/index.html
+++ b/app/ui-react/packages/history/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="/bundle.js"></script>
+    <script>
+      var createHistory = History.createBrowserHistory
+
+      var page = 0
+      var h = createHistory()
+
+      h.block(function (location, action) {
+        return 'Are you sure you want to go to ' + location.path + '?'
+      })
+
+      h.listen(function (location) {
+        console.log(location)
+      })
+    </script>
+  </head>
+  <body>
+    <p>Use the two buttons below to test normal transitions.</p>
+    <p>
+      <button onclick="page++; h.push('/' + page, { page: page })">history.push</button>
+      <button onclick="h.goBack()">history.goBack</button>
+    </p>
+  </body>
+</html>

--- a/app/ui-react/packages/history/index.js
+++ b/app/ui-react/packages/history/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./cjs/history.min.js');
+} else {
+  module.exports = require('./cjs/history.js');
+}

--- a/app/ui-react/packages/history/karma.conf.js
+++ b/app/ui-react/packages/history/karma.conf.js
@@ -1,0 +1,127 @@
+var path = require('path');
+var webpack = require('webpack');
+var projectName = require('./package').name;
+
+module.exports = function(config) {
+  var customLaunchers = {
+    BS_Chrome: {
+      base: 'BrowserStack',
+      os: 'Windows',
+      os_version: '10',
+      browser: 'chrome',
+      browser_version: '47.0'
+    },
+    BS_Firefox: {
+      base: 'BrowserStack',
+      os: 'Windows',
+      os_version: '10',
+      browser: 'firefox',
+      browser_version: '43.0'
+    },
+    BS_Safari: {
+      base: 'BrowserStack',
+      os: 'OS X',
+      os_version: 'El Capitan',
+      browser: 'safari',
+      browser_version: '9.0'
+    },
+    BS_MobileSafari8: {
+      base: 'BrowserStack',
+      os: 'ios',
+      os_version: '8.3',
+      browser: 'iphone',
+      real_mobile: false
+    },
+    BS_MobileSafari9: {
+      base: 'BrowserStack',
+      os: 'ios',
+      os_version: '9.1',
+      browser: 'iphone',
+      real_mobile: false
+    },
+    BS_InternetExplorer10: {
+      base: 'BrowserStack',
+      os: 'Windows',
+      os_version: '8',
+      browser: 'ie',
+      browser_version: '10.0'
+    },
+    BS_InternetExplorer11: {
+      base: 'BrowserStack',
+      os: 'Windows',
+      os_version: '10',
+      browser: 'ie',
+      browser_version: '11.0'
+    }
+  };
+
+  var historyAlias;
+  switch (process.env.TEST_ENV) {
+    case 'cjs':
+      historyAlias = 'cjs/history.js';
+      break;
+    case 'umd':
+      historyAlias = 'umd/history.js';
+      break;
+    case 'source':
+    default:
+      historyAlias = 'modules/index.js';
+  }
+
+  config.set({
+    customLaunchers: customLaunchers,
+    browsers: ['Chrome' /*, 'Firefox'*/],
+    frameworks: ['mocha'],
+    reporters: ['mocha'],
+    files: ['tests.webpack.js'],
+    preprocessors: {
+      'tests.webpack.js': ['webpack', 'sourcemap']
+    },
+    webpack: {
+      devtool: 'inline-source-map',
+      module: {
+        loaders: [
+          {
+            test: /\.js$/,
+            exclude: /node_modules/,
+            loader: 'babel-loader'
+          }
+        ]
+      },
+      resolve: {
+        alias: {
+          history$: path.resolve(__dirname, historyAlias)
+        }
+      },
+      plugins: [
+        new webpack.DefinePlugin({
+          'process.env.NODE_ENV': JSON.stringify('test')
+        })
+      ]
+    },
+    webpackServer: {
+      noInfo: true
+    }
+  });
+
+  if (process.env.USE_CLOUD) {
+    config.browsers = Object.keys(customLaunchers);
+    config.reporters = ['dots'];
+    config.concurrency = 2;
+    config.browserDisconnectTimeout = 10000;
+    config.browserDisconnectTolerance = 3;
+
+    if (process.env.TRAVIS) {
+      config.singleRun = true;
+      config.browserStack = {
+        project: projectName,
+        build: process.env.TRAVIS_BUILD_NUMBER,
+        name: process.env.TRAVIS_JOB_NUMBER
+      };
+    } else {
+      config.browserStack = {
+        project: projectName
+      };
+    }
+  }
+};

--- a/app/ui-react/packages/history/modules/.babelrc
+++ b/app/ui-react/packages/history/modules/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": [["@babel/env", { "loose": true }]],
+  "plugins": ["dev-expression", "@babel/transform-object-assign"]
+}

--- a/app/ui-react/packages/history/modules/.eslintrc
+++ b/app/ui-react/packages/history/modules/.eslintrc
@@ -1,0 +1,11 @@
+{
+  "parser": "babel-eslint",
+  "plugins": ["import"],
+  "env": {
+    "browser": true
+  },
+  "extends": ["eslint:recommended", "plugin:import/errors"],
+  "rules": {
+    "prefer-arrow-callback": 2
+  }
+}

--- a/app/ui-react/packages/history/modules/DOMUtils.js
+++ b/app/ui-react/packages/history/modules/DOMUtils.js
@@ -1,0 +1,56 @@
+export const canUseDOM = !!(
+  typeof window !== 'undefined' &&
+  window.document &&
+  window.document.createElement
+);
+
+export function getConfirmation(message, callback) {
+  callback(window.confirm(message)); // eslint-disable-line no-alert
+}
+
+/**
+ * Returns true if the HTML5 history API is supported. Taken from Modernizr.
+ *
+ * https://github.com/Modernizr/Modernizr/blob/master/LICENSE
+ * https://github.com/Modernizr/Modernizr/blob/master/feature-detects/history.js
+ * changed to avoid false negatives for Windows Phones: https://github.com/reactjs/react-router/issues/586
+ */
+export function supportsHistory() {
+  const ua = window.navigator.userAgent;
+
+  if (
+    (ua.indexOf('Android 2.') !== -1 || ua.indexOf('Android 4.0') !== -1) &&
+    ua.indexOf('Mobile Safari') !== -1 &&
+    ua.indexOf('Chrome') === -1 &&
+    ua.indexOf('Windows Phone') === -1
+  )
+    return false;
+
+  return window.history && 'pushState' in window.history;
+}
+
+/**
+ * Returns true if browser fires popstate on hash change.
+ * IE10 and IE11 do not.
+ */
+export function supportsPopStateOnHashChange() {
+  return window.navigator.userAgent.indexOf('Trident') === -1;
+}
+
+/**
+ * Returns false if using go(n) with hash history causes a full page reload.
+ */
+export function supportsGoWithoutReloadUsingHash() {
+  return window.navigator.userAgent.indexOf('Firefox') === -1;
+}
+
+/**
+ * Returns true if a given popstate event is an extraneous WebKit event.
+ * Accounts for the fact that Chrome on iOS fires real popstate events
+ * containing undefined state when pressing the back button.
+ */
+export function isExtraneousPopstateEvent(event) {
+  return (
+    event.state === undefined && navigator.userAgent.indexOf('CriOS') === -1
+  );
+}

--- a/app/ui-react/packages/history/modules/LocationUtils.js
+++ b/app/ui-react/packages/history/modules/LocationUtils.js
@@ -1,0 +1,66 @@
+import resolvePathname from 'resolve-pathname';
+import valueEqual from 'value-equal';
+
+import { parsePath } from './PathUtils';
+
+export function createLocation(path, state, key, currentLocation) {
+  let location;
+  if (typeof path === 'string') {
+    // Two-arg form: push(path, state)
+    location = parsePath(path);
+    location.state = state;
+  } else {
+    // One-arg form: push(location)
+    location = { ...path };
+
+    if (location.pathname === undefined) location.pathname = '';
+
+    if (location.search) {
+      if (location.search.charAt(0) !== '?')
+        location.search = '?' + location.search;
+    } else {
+      location.search = '';
+    }
+
+    if (location.hash) {
+      if (location.hash.charAt(0) !== '#') location.hash = '#' + location.hash;
+    } else {
+      location.hash = '';
+    }
+
+    if (state !== undefined && location.state === undefined)
+      location.state = state;
+  }
+
+  if (key) location.key = key;
+
+  if (currentLocation) {
+    // Resolve incomplete/relative pathname relative to current location.
+    if (!location.pathname) {
+      location.pathname = currentLocation.pathname;
+    } else if (location.pathname.charAt(0) !== '/') {
+      location.pathname = resolvePathname(
+        location.pathname,
+        currentLocation.pathname
+      );
+    }
+  } else {
+    // When there is no prior location and pathname is empty, set it to /
+    if (!location.pathname) {
+      location.pathname = '/';
+    }
+  }
+
+  location.state = location.state || JSON.parse(sessionStorage.getItem(key));
+  return location;
+}
+
+export function locationsAreEqual(a, b) {
+  return (
+    a.pathname === b.pathname &&
+    a.search === b.search &&
+    a.hash === b.hash &&
+    a.key === b.key &&
+    valueEqual(a.state, b.state)
+  );
+}

--- a/app/ui-react/packages/history/modules/PathUtils.js
+++ b/app/ui-react/packages/history/modules/PathUtils.js
@@ -1,0 +1,59 @@
+export function addLeadingSlash(path) {
+  return path.charAt(0) === '/' ? path : '/' + path;
+}
+
+export function stripLeadingSlash(path) {
+  return path.charAt(0) === '/' ? path.substr(1) : path;
+}
+
+export function hasBasename(path, prefix) {
+  return (
+    path.toLowerCase().indexOf(prefix.toLowerCase()) === 0 &&
+    '/?#'.indexOf(path.charAt(prefix.length)) !== -1
+  );
+}
+
+export function stripBasename(path, prefix) {
+  return hasBasename(path, prefix) ? path.substr(prefix.length) : path;
+}
+
+export function stripTrailingSlash(path) {
+  return path.charAt(path.length - 1) === '/' ? path.slice(0, -1) : path;
+}
+
+export function parsePath(path) {
+  let pathname = path || '/';
+  let search = '';
+  let hash = '';
+
+  const hashIndex = pathname.indexOf('#');
+  if (hashIndex !== -1) {
+    hash = pathname.substr(hashIndex);
+    pathname = pathname.substr(0, hashIndex);
+  }
+
+  const searchIndex = pathname.indexOf('?');
+  if (searchIndex !== -1) {
+    search = pathname.substr(searchIndex);
+    pathname = pathname.substr(0, searchIndex);
+  }
+
+  return {
+    pathname,
+    search: search === '?' ? '' : search,
+    hash: hash === '#' ? '' : hash
+  };
+}
+
+export function createPath(location) {
+  const { pathname, search, hash } = location;
+
+  let path = pathname || '/';
+
+  if (search && search !== '?')
+    path += search.charAt(0) === '?' ? search : `?${search}`;
+
+  if (hash && hash !== '#') path += hash.charAt(0) === '#' ? hash : `#${hash}`;
+
+  return path;
+}

--- a/app/ui-react/packages/history/modules/__tests__/.eslintrc
+++ b/app/ui-react/packages/history/modules/__tests__/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "rules": {
+    "import/no-unresolved": [2, { "ignore": ["history"] }]
+  }
+}

--- a/app/ui-react/packages/history/modules/__tests__/BrowserHistory-test.js
+++ b/app/ui-react/packages/history/modules/__tests__/BrowserHistory-test.js
@@ -1,0 +1,220 @@
+import expect from 'expect';
+
+import { createBrowserHistory as createHistory } from 'history';
+
+import * as TestSequences from './TestSequences';
+
+describe('a browser history', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, null, '/');
+  });
+
+  describe('by default', () => {
+    let history;
+    beforeEach(() => {
+      history = createHistory();
+    });
+
+    describe('listen', () => {
+      it('does not immediately call listeners', done => {
+        TestSequences.Listen(history, done);
+      });
+    });
+
+    describe('the initial location', () => {
+      it('does not have a key', done => {
+        TestSequences.InitialLocationNoKey(history, done);
+      });
+    });
+
+    describe('push a new path', () => {
+      it('calls change listeners with the new location', done => {
+        TestSequences.PushNewLocation(history, done);
+      });
+    });
+
+    describe('push the same path', () => {
+      it('calls change listeners with the new location', done => {
+        TestSequences.PushSamePath(history, done);
+      });
+    });
+
+    describe('push state', () => {
+      it('calls change listeners with the new location', done => {
+        TestSequences.PushState(history, done);
+      });
+    });
+
+    describe('push with no pathname', () => {
+      it('calls change listeners with the normalized location', done => {
+        TestSequences.PushMissingPathname(history, done);
+      });
+    });
+
+    describe('push with a relative pathname', () => {
+      it('calls change listeners with the normalized location', done => {
+        TestSequences.PushRelativePathname(history, done);
+      });
+    });
+
+    describe('push with a unicode path string', () => {
+      it('creates a location with decoded properties', done => {
+        TestSequences.PushUnicodeLocation(history, done);
+      });
+    });
+
+    describe('push with an encoded path string', () => {
+      it('creates a location object with encoded pathname', done => {
+        TestSequences.PushEncodedLocation(history, done);
+      });
+    });
+
+    describe('replace a new path', () => {
+      it('calls change listeners with the new location', done => {
+        TestSequences.ReplaceNewLocation(history, done);
+      });
+    });
+
+    describe('replace the same path', () => {
+      it('calls change listeners with the new location', done => {
+        TestSequences.ReplaceSamePath(history, done);
+      });
+    });
+
+    describe('replace state', () => {
+      it('calls change listeners with the new location', done => {
+        TestSequences.ReplaceState(history, done);
+      });
+    });
+
+    describe('location created by encoded and unencoded pathname', () => {
+      it('produces the same location.pathname', done => {
+        TestSequences.LocationPathnameAlwaysSame(history, done);
+      });
+    });
+
+    describe('location created with encoded/unencoded reserved characters', () => {
+      it('produces different location objects', done => {
+        TestSequences.EncodedReservedCharacters(history, done);
+      });
+    });
+
+    describe('goBack', () => {
+      it('calls change listeners with the previous location', done => {
+        TestSequences.GoBack(history, done);
+      });
+    });
+
+    describe('goForward', () => {
+      it('calls change listeners with the next location', done => {
+        TestSequences.GoForward(history, done);
+      });
+    });
+
+    describe('block', () => {
+      it('blocks all transitions', done => {
+        TestSequences.BlockEverything(history, done);
+      });
+    });
+
+    describe('block a POP without listening', () => {
+      it('receives the next location and action as arguments', done => {
+        TestSequences.BlockPopWithoutListening(history, done);
+      });
+    });
+  });
+
+  describe('that denies all transitions', () => {
+    const getUserConfirmation = (_, callback) => callback(false);
+
+    let history;
+    beforeEach(() => {
+      history = createHistory({
+        getUserConfirmation
+      });
+    });
+
+    describe('clicking on a link (push)', () => {
+      it('does not update the location', done => {
+        TestSequences.DenyPush(history, done);
+      });
+    });
+
+    describe('clicking the back button (goBack)', () => {
+      it('does not update the location', done => {
+        TestSequences.DenyGoBack(history, done);
+      });
+    });
+
+    describe('clicking the forward button (goForward)', () => {
+      it('does not update the location', done => {
+        TestSequences.DenyGoForward(history, done);
+      });
+    });
+  });
+
+  describe('a transition hook', () => {
+    const getUserConfirmation = (_, callback) => callback(true);
+
+    let history;
+    beforeEach(() => {
+      history = createHistory({
+        getUserConfirmation
+      });
+    });
+
+    it('receives the next location and action as arguments', done => {
+      TestSequences.TransitionHookArgs(history, done);
+    });
+
+    it('cancels the transition when it returns false', done => {
+      TestSequences.ReturnFalseTransitionHook(history, done);
+    });
+
+    it('is called when the back button is clicked', done => {
+      TestSequences.BackButtonTransitionHook(history, done);
+    });
+
+    it('is called on the hashchange event', done => {
+      TestSequences.HashChangeTransitionHook(history, done);
+    });
+  });
+
+  describe('basename', () => {
+    it('strips the basename from the pathname', () => {
+      window.history.replaceState(null, null, '/prefix/pathname');
+      const history = createHistory({ basename: '/prefix' });
+      expect(history.location.pathname).toEqual('/pathname');
+    });
+
+    it('is not case-sensitive', () => {
+      window.history.replaceState(null, null, '/PREFIX/pathname');
+      const history = createHistory({ basename: '/prefix' });
+      expect(history.location.pathname).toEqual('/pathname');
+    });
+
+    it('does not strip partial prefix matches', () => {
+      window.history.replaceState(null, null, '/prefixed/pathname');
+      const history = createHistory({ basename: '/prefix' });
+      expect(history.location.pathname).toEqual('/prefixed/pathname');
+    });
+
+    it('strips when path is only the prefix', () => {
+      window.history.replaceState(null, null, '/prefix');
+      const history = createHistory({ basename: '/prefix' });
+      expect(history.location.pathname).toEqual('/');
+    });
+
+    it('strips with no pathname, but with a search string', () => {
+      window.history.replaceState(null, null, '/prefix?a=b');
+      const history = createHistory({ basename: '/prefix' });
+      expect(history.location.pathname).toEqual('/');
+    });
+
+    it('strips with no pathname, but with a hash string', () => {
+      window.history.replaceState(null, null, '/prefix#rest');
+      const history = createHistory({ basename: '/prefix' });
+      expect(history.location.pathname).toEqual('/');
+    });
+  });
+});

--- a/app/ui-react/packages/history/modules/__tests__/HashHistory-test.js
+++ b/app/ui-react/packages/history/modules/__tests__/HashHistory-test.js
@@ -1,0 +1,258 @@
+import expect from 'expect';
+
+import { createHashHistory as createHistory } from 'history';
+
+import * as TestSequences from './TestSequences';
+
+const canGoWithoutReload = window.navigator.userAgent.indexOf('Firefox') === -1;
+const describeGo = canGoWithoutReload ? describe : describe.skip;
+
+describe('a hash history', () => {
+  beforeEach(() => {
+    if (window.location.hash !== '') window.location.hash = '';
+  });
+
+  describe('by default', () => {
+    let history;
+    beforeEach(() => {
+      history = createHistory();
+    });
+
+    describe('listen', () => {
+      it('does not immediately call listeners', done => {
+        TestSequences.Listen(history, done);
+      });
+    });
+
+    describe('the initial location', () => {
+      it('does not have a key', done => {
+        TestSequences.InitialLocationNoKey(history, done);
+      });
+    });
+
+    describe('push a new path', () => {
+      it('calls change listeners with the new location', done => {
+        TestSequences.PushNewLocation(history, done);
+      });
+    });
+
+    describe('push the same path', () => {
+      it('calls change listeners with the same location and emits a warning', done => {
+        TestSequences.PushSamePathWarning(history, done);
+      });
+    });
+
+    describe('push state', () => {
+      it('calls change listeners with the new location and emits a warning', done => {
+        TestSequences.PushStateWarning(history, done);
+      });
+    });
+
+    describe('push with no pathname', () => {
+      it('calls change listeners with the normalized location', done => {
+        TestSequences.PushMissingPathname(history, done);
+      });
+    });
+
+    describe('push with a relative pathname', () => {
+      it('calls change listeners with the normalized location', done => {
+        TestSequences.PushRelativePathname(history, done);
+      });
+    });
+
+    describe('push with a unicode path string', () => {
+      it('creates a location with decoded properties', done => {
+        TestSequences.PushUnicodeLocation(history, done);
+      });
+    });
+
+    describe('push with an encoded path string', () => {
+      it('creates a location object with encoded pathname', done => {
+        TestSequences.PushEncodedLocation(history, done);
+      });
+    });
+
+    describe('replace a new path', () => {
+      it('calls change listeners with the new location', done => {
+        TestSequences.ReplaceNewLocation(history, done);
+      });
+    });
+
+    describe('replace the same path', () => {
+      it('calls change listeners with the new location', done => {
+        TestSequences.ReplaceSamePath(history, done);
+      });
+    });
+
+    describe('replace state', () => {
+      it('calls change listeners with the new location and emits a warning', done => {
+        TestSequences.ReplaceStateWarning(history, done);
+      });
+    });
+
+    describe('location created by encoded and unencoded pathname', () => {
+      it('produces the same location.pathname', done => {
+        TestSequences.LocationPathnameAlwaysSame(history, done);
+      });
+    });
+
+    describe('location created with encoded/unencoded reserved characters', () => {
+      it('produces different location objects', done => {
+        TestSequences.EncodedReservedCharacters(history, done);
+      });
+    });
+
+    describeGo('goBack', () => {
+      it('calls change listeners with the previous location', done => {
+        TestSequences.GoBack(history, done);
+      });
+    });
+
+    describeGo('goForward', () => {
+      it('calls change listeners with the next location', done => {
+        TestSequences.GoForward(history, done);
+      });
+    });
+
+    describe('block', () => {
+      it('blocks all transitions', done => {
+        TestSequences.BlockEverything(history, done);
+      });
+    });
+
+    describeGo('block a POP without listening', () => {
+      it('receives the next location and action as arguments', done => {
+        TestSequences.BlockPopWithoutListening(history, done);
+      });
+    });
+  });
+
+  describe('that denies all transitions', () => {
+    const getUserConfirmation = (_, callback) => callback(false);
+
+    let history;
+    beforeEach(() => {
+      history = createHistory({
+        getUserConfirmation
+      });
+    });
+
+    describe('clicking on a link (push)', () => {
+      it('does not update the location', done => {
+        TestSequences.DenyPush(history, done);
+      });
+    });
+
+    describeGo('clicking the back button (goBack)', () => {
+      it('does not update the location', done => {
+        TestSequences.DenyGoBack(history, done);
+      });
+    });
+
+    describeGo('clicking the forward button (goForward)', () => {
+      it('does not update the location', done => {
+        TestSequences.DenyGoForward(history, done);
+      });
+    });
+  });
+
+  describe('a transition hook', () => {
+    const getUserConfirmation = (_, callback) => callback(true);
+
+    let history;
+    beforeEach(() => {
+      history = createHistory({ getUserConfirmation });
+    });
+
+    it('receives the next location and action as arguments', done => {
+      TestSequences.TransitionHookArgs(history, done);
+    });
+
+    const itBackButton = canGoWithoutReload ? it : it.skip;
+
+    itBackButton('is called when the back button is clicked', done => {
+      TestSequences.BackButtonTransitionHook(history, done);
+    });
+
+    it('cancels the transition when it returns false', done => {
+      TestSequences.ReturnFalseTransitionHook(history, done);
+    });
+  });
+
+  describe('"hashbang" hash path coding', () => {
+    let history;
+    beforeEach(() => {
+      history = createHistory({ hashType: 'hashbang' });
+    });
+
+    it('properly encodes and decodes window.location.hash', done => {
+      TestSequences.HashbangHashPathCoding(history, done);
+    });
+  });
+
+  describe('"noslash" hash path coding', () => {
+    let history;
+    beforeEach(() => {
+      history = createHistory({ hashType: 'noslash' });
+    });
+
+    it('properly encodes and decodes window.location.hash', done => {
+      TestSequences.NoslashHashPathCoding(history, done);
+    });
+  });
+
+  describe('"slash" hash path coding', () => {
+    let history;
+    beforeEach(() => {
+      history = createHistory({ hashType: 'slash' });
+    });
+
+    it('properly encodes and decodes window.location.hash', done => {
+      TestSequences.SlashHashPathCoding(history, done);
+    });
+  });
+
+  describe('basename', () => {
+    it('strips the basename from the pathname', () => {
+      window.location.hash = '#/prefix/pathname';
+      const history = createHistory({ basename: '/prefix' });
+      expect(history.location.pathname).toEqual('/pathname');
+    });
+
+    it('is not case-sensitive', () => {
+      window.location.hash = '#/PREFIX/pathname';
+      const history = createHistory({ basename: '/prefix' });
+      expect(history.location.pathname).toEqual('/pathname');
+    });
+
+    it('does not strip partial prefix matches', () => {
+      window.location.hash = '#/prefixed/pathname';
+      const history = createHistory({ basename: '/prefix' });
+      expect(history.location.pathname).toEqual('/prefixed/pathname');
+    });
+
+    it('strips when path is only the prefix', () => {
+      window.location.hash = '#/prefix';
+      const history = createHistory({ basename: '/prefix' });
+      expect(history.location.pathname).toEqual('/');
+    });
+
+    it('strips with no pathname, but with a search string', () => {
+      window.location.hash = '#/prefix?a=b';
+      const history = createHistory({ basename: '/prefix' });
+      expect(history.location.pathname).toEqual('/');
+    });
+
+    it('strips with no pathname, but with a hash string', () => {
+      window.location.hash = '#/prefix#rest';
+      const history = createHistory({ basename: '/prefix' });
+      expect(history.location.pathname).toEqual('/');
+    });
+
+    it('allows URL with regex special characters', () => {
+      window.location.hash = '/prefix$special/hello';
+      const history = createHistory({ basename: '/prefix$special' });
+      expect(history.location.pathname).toEqual('/hello');
+    });
+  });
+});

--- a/app/ui-react/packages/history/modules/__tests__/LocationUtils-test.js
+++ b/app/ui-react/packages/history/modules/__tests__/LocationUtils-test.js
@@ -1,0 +1,145 @@
+import expect from 'expect';
+
+import { createLocation } from 'history';
+
+describe('createLocation', () => {
+  describe('with a full path', () => {
+    describe('given as a string', () => {
+      it('has the correct properties', () => {
+        expect(createLocation('/the/path?the=query#the-hash')).toMatchObject({
+          pathname: '/the/path',
+          search: '?the=query',
+          hash: '#the-hash'
+        });
+      });
+    });
+
+    describe('given as an object', () => {
+      it('has the correct properties', () => {
+        expect(
+          createLocation({
+            pathname: '/the/path',
+            search: '?the=query',
+            hash: '#the-hash'
+          })
+        ).toMatchObject({
+          pathname: '/the/path',
+          search: '?the=query',
+          hash: '#the-hash'
+        });
+      });
+    });
+  });
+
+  describe('with a relative path', () => {
+    describe('given as a string', () => {
+      it('has the correct properties', () => {
+        expect(createLocation('the/path?the=query#the-hash')).toMatchObject({
+          pathname: 'the/path',
+          search: '?the=query',
+          hash: '#the-hash'
+        });
+      });
+    });
+
+    describe('given as an object', () => {
+      it('has the correct properties', () => {
+        expect(
+          createLocation({
+            pathname: 'the/path',
+            search: '?the=query',
+            hash: '#the-hash'
+          })
+        ).toMatchObject({
+          pathname: 'the/path',
+          search: '?the=query',
+          hash: '#the-hash'
+        });
+      });
+    });
+  });
+
+  describe('with a path with no pathname', () => {
+    describe('given as a string', () => {
+      it('has the correct properties', () => {
+        expect(createLocation('?the=query#the-hash')).toMatchObject({
+          pathname: '/',
+          search: '?the=query',
+          hash: '#the-hash'
+        });
+      });
+    });
+
+    describe('given as an object', () => {
+      it('has the correct properties', () => {
+        expect(
+          createLocation({ search: '?the=query', hash: '#the-hash' })
+        ).toMatchObject({
+          pathname: '/',
+          search: '?the=query',
+          hash: '#the-hash'
+        });
+      });
+    });
+  });
+
+  describe('with a path with no search', () => {
+    describe('given as a string', () => {
+      it('has the correct properties', () => {
+        expect(createLocation('/the/path#the-hash')).toMatchObject({
+          pathname: '/the/path',
+          search: '',
+          hash: '#the-hash'
+        });
+      });
+    });
+
+    describe('given as an object', () => {
+      it('has the correct properties', () => {
+        expect(
+          createLocation({ pathname: '/the/path', hash: '#the-hash' })
+        ).toMatchObject({
+          pathname: '/the/path',
+          search: '',
+          hash: '#the-hash'
+        });
+      });
+    });
+  });
+
+  describe('with a path with no hash', () => {
+    describe('given as a string', () => {
+      it('has the correct properties', () => {
+        expect(createLocation('/the/path?the=query')).toMatchObject({
+          pathname: '/the/path',
+          search: '?the=query',
+          hash: ''
+        });
+      });
+    });
+
+    describe('given as an object', () => {
+      it('has the correct properties', () => {
+        expect(
+          createLocation({ pathname: '/the/path', search: '?the=query' })
+        ).toMatchObject({
+          pathname: '/the/path',
+          search: '?the=query',
+          hash: ''
+        });
+      });
+    });
+  });
+
+  describe('key', () => {
+    it('has a key property if a key is provided', () => {
+      const location = createLocation('/the/path', undefined, 'key');
+      expect(Object.keys(location)).toContain('key');
+    });
+
+    it('has no key property if no key is provided', () => {
+      const location = createLocation('/the/path');
+      expect(Object.keys(location)).not.toContain('key');
+    });
+  });
+});

--- a/app/ui-react/packages/history/modules/__tests__/MemoryHistory-test.js
+++ b/app/ui-react/packages/history/modules/__tests__/MemoryHistory-test.js
@@ -1,0 +1,168 @@
+import { createMemoryHistory as createHistory } from 'history';
+
+import * as TestSequences from './TestSequences';
+
+describe('a memory history', () => {
+  describe('by default', () => {
+    let history;
+    beforeEach(() => {
+      history = createHistory();
+    });
+
+    describe('listen', () => {
+      it('does not immediately call listeners', done => {
+        TestSequences.Listen(history, done);
+      });
+    });
+
+    describe('the initial location', () => {
+      it('has a key', done => {
+        TestSequences.InitialLocationHasKey(history, done);
+      });
+    });
+
+    describe('push a new path', () => {
+      it('calls change listeners with the new location', done => {
+        TestSequences.PushNewLocation(history, done);
+      });
+    });
+
+    describe('push the same path', () => {
+      it('calls change listeners with the new location', done => {
+        TestSequences.PushSamePath(history, done);
+      });
+    });
+
+    describe('push state', () => {
+      it('calls change listeners with the new location', done => {
+        TestSequences.PushState(history, done);
+      });
+    });
+
+    describe('push with no pathname', () => {
+      it('calls change listeners with the normalized location', done => {
+        TestSequences.PushMissingPathname(history, done);
+      });
+    });
+
+    describe('push with a relative pathname', () => {
+      it('calls change listeners with the normalized location', done => {
+        TestSequences.PushRelativePathname(history, done);
+      });
+    });
+
+    describe('push with a unicode path string', () => {
+      it('creates a location with decoded properties', done => {
+        TestSequences.PushUnicodeLocation(history, done);
+      });
+    });
+
+    describe('push with an encoded path string', () => {
+      it('creates a location object with encoded pathname', done => {
+        TestSequences.PushEncodedLocation(history, done);
+      });
+    });
+
+    describe('replace a new path', () => {
+      it('calls change listeners with the new location', done => {
+        TestSequences.ReplaceNewLocation(history, done);
+      });
+    });
+
+    describe('replace the same path', () => {
+      it('calls change listeners with the new location', done => {
+        TestSequences.ReplaceSamePath(history, done);
+      });
+    });
+
+    describe('replace state', () => {
+      it('calls change listeners with the new location', done => {
+        TestSequences.ReplaceState(history, done);
+      });
+    });
+
+    describe('location created by encoded and unencoded pathname', () => {
+      it('produces the same location.pathname', done => {
+        TestSequences.LocationPathnameAlwaysSame(history, done);
+      });
+    });
+
+    describe('location created with encoded/unencoded reserved characters', () => {
+      it('produces different location objects', done => {
+        TestSequences.EncodedReservedCharacters(history, done);
+      });
+    });
+
+    describe('goBack', () => {
+      it('calls change listeners with the previous location', done => {
+        TestSequences.GoBack(history, done);
+      });
+    });
+
+    describe('goForward', () => {
+      it('calls change listeners with the next location', done => {
+        TestSequences.GoForward(history, done);
+      });
+    });
+
+    describe('block', () => {
+      it('blocks all transitions', done => {
+        TestSequences.BlockEverything(history, done);
+      });
+    });
+
+    describe('block a POP without listening', () => {
+      it('receives the next location and action as arguments', done => {
+        TestSequences.BlockPopWithoutListening(history, done);
+      });
+    });
+  });
+
+  describe('that denies all transitions', () => {
+    const getUserConfirmation = (_, callback) => callback(false);
+
+    let history;
+    beforeEach(() => {
+      history = createHistory({
+        getUserConfirmation
+      });
+    });
+
+    describe('push', () => {
+      it('does not update the location', done => {
+        TestSequences.DenyPush(history, done);
+      });
+    });
+
+    describe('goBack', () => {
+      it('does not update the location', done => {
+        TestSequences.DenyGoBack(history, done);
+      });
+    });
+
+    describe('goForward', () => {
+      it('does not update the location', done => {
+        TestSequences.DenyGoForward(history, done);
+      });
+    });
+  });
+
+  describe('a transition hook', () => {
+    const getUserConfirmation = (_, callback) => callback(true);
+
+    let history;
+    beforeEach(() => {
+      history = createHistory({
+        getUserConfirmation
+      });
+    });
+
+    it('receives the next location and action as arguments', done => {
+      TestSequences.TransitionHookArgs(history, done);
+    });
+
+    it('cancels the transition when it returns false', done => {
+      TestSequences.ReturnFalseTransitionHook(history, done);
+    });
+  });
+});

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/BackButtonTransitionHook.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/BackButtonTransitionHook.js
@@ -1,0 +1,41 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  let unblock,
+    hookWasCalled = false;
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.push('/home');
+    },
+    (location, action) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/home'
+      });
+
+      unblock = history.block(() => {
+        hookWasCalled = true;
+      });
+
+      window.history.go(-1);
+    },
+    (location, action) => {
+      expect(action).toBe('POP');
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      expect(hookWasCalled).toBe(true);
+
+      unblock();
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/BlockEverything.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/BlockEverything.js
@@ -1,0 +1,25 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      const unblock = history.block();
+
+      history.push('/home');
+
+      expect(history.location).toMatchObject({
+        pathname: '/'
+      });
+
+      unblock();
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/BlockPopWithoutListening.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/BlockPopWithoutListening.js
@@ -1,0 +1,33 @@
+import expect from 'expect';
+
+export default function(history, done) {
+  expect(history.location).toMatchObject({
+    pathname: '/'
+  });
+
+  history.push('/home');
+
+  let transitionHookWasCalled = false;
+  const unblock = history.block(() => {
+    transitionHookWasCalled = true;
+  });
+
+  // These timeouts are a hack to allow for the time it takes
+  // for histories to reflect the change in the URL. Normally
+  // we could just listen and avoid the waiting time. But this
+  // test is designed to test what happens when we don't listen(),
+  // so that's not an option here.
+
+  // Allow some time for history to detect the PUSH.
+  setTimeout(() => {
+    history.goBack();
+
+    // Allow some time for history to detect the POP.
+    setTimeout(() => {
+      expect(transitionHookWasCalled).toBe(true);
+      unblock();
+
+      done();
+    }, 100);
+  }, 10);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/DenyGoBack.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/DenyGoBack.js
@@ -1,0 +1,42 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  let unblock;
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.push('/home');
+    },
+    (location, action) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/home'
+      });
+
+      unblock = history.block(nextLocation => {
+        expect(nextLocation).toMatchObject({
+          pathname: '/'
+        });
+
+        return 'Are you sure?';
+      });
+
+      history.goBack();
+    },
+    (location, action) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/home'
+      });
+
+      unblock();
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/DenyGoForward.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/DenyGoForward.js
@@ -1,0 +1,50 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  let unblock;
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.push('/home');
+    },
+    (location, action) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/home'
+      });
+
+      history.goBack();
+    },
+    (location, action) => {
+      expect(action).toBe('POP');
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      unblock = history.block(nextLocation => {
+        expect(nextLocation).toMatchObject({
+          pathname: '/home'
+        });
+
+        return 'Are you sure?';
+      });
+
+      history.goForward();
+    },
+    (location, action) => {
+      expect(action).toBe('POP');
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      unblock();
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/DenyPush.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/DenyPush.js
@@ -1,0 +1,31 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      const unblock = history.block(nextLocation => {
+        expect(nextLocation).toMatchObject({
+          pathname: '/home'
+        });
+
+        return 'Are you sure?';
+      });
+
+      history.push('/home');
+
+      expect(history.location).toMatchObject({
+        pathname: '/'
+      });
+
+      unblock();
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/EncodedReservedCharacters.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/EncodedReservedCharacters.js
@@ -1,0 +1,38 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    () => {
+      // encoded string
+      const pathname = '/view/%23abc';
+      history.replace(pathname);
+    },
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/view/%23abc'
+      });
+
+      // encoded object
+      const pathname = '/view/%23abc';
+      history.replace({ pathname });
+    },
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/view/%23abc'
+      });
+      // unencoded string
+      const pathname = '/view/#abc';
+      history.replace(pathname);
+    },
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/view/',
+        hash: '#abc'
+      });
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/GoBack.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/GoBack.js
@@ -1,0 +1,31 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.push('/home');
+    },
+    (location, action) => {
+      expect(action).toEqual('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/home'
+      });
+
+      history.goBack();
+    },
+    (location, action) => {
+      expect(action).toEqual('POP');
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/GoForward.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/GoForward.js
@@ -1,0 +1,39 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.push('/home');
+    },
+    (location, action) => {
+      expect(action).toEqual('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/home'
+      });
+
+      history.goBack();
+    },
+    (location, action) => {
+      expect(action).toEqual('POP');
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.goForward();
+    },
+    (location, action) => {
+      expect(action).toEqual('POP');
+      expect(location).toMatchObject({
+        pathname: '/home'
+      });
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/HashChangeTransitionHook.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/HashChangeTransitionHook.js
@@ -1,0 +1,33 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  let unblock,
+    hookWasCalled = false;
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      unblock = history.block(() => {
+        hookWasCalled = true;
+      });
+
+      window.location.hash = 'something-new';
+    },
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/',
+        hash: '#something-new'
+      });
+
+      expect(hookWasCalled).toBe(true);
+
+      unblock();
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/HashbangHashPathCoding.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/HashbangHashPathCoding.js
@@ -1,0 +1,48 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      expect(window.location.hash).toBe('#!/');
+
+      history.push('/home?the=query#the-hash');
+    },
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/home',
+        search: '?the=query',
+        hash: '#the-hash'
+      });
+
+      expect(window.location.hash).toBe('#!/home?the=query#the-hash');
+
+      history.goBack();
+    },
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      expect(window.location.hash).toBe('#!/');
+
+      history.goForward();
+    },
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/home',
+        search: '?the=query',
+        hash: '#the-hash'
+      });
+
+      expect(window.location.hash).toBe('#!/home?the=query#the-hash');
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/InitialLocationHasKey.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/InitialLocationHasKey.js
@@ -1,0 +1,13 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location.key).toBeTruthy();
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/InitialLocationNoKey.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/InitialLocationNoKey.js
@@ -1,0 +1,13 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location.key).toBeFalsy();
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/Listen.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/Listen.js
@@ -1,0 +1,12 @@
+import mock from 'jest-mock';
+import expect from 'expect';
+
+export default function(history, done) {
+  const spy = mock.fn();
+  const unlisten = history.listen(spy);
+
+  expect(spy).not.toHaveBeenCalled();
+
+  unlisten();
+  done();
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/LocationPathnameAlwaysSame.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/LocationPathnameAlwaysSame.js
@@ -1,0 +1,45 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    () => {
+      // encoded string
+      const pathname = '/%E6%AD%B4%E5%8F%B2';
+      history.replace(pathname);
+    },
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/%E6%AD%B4%E5%8F%B2'
+      });
+
+      // encoded object
+      const pathname = '/%E6%AD%B4%E5%8F%B2';
+      history.replace({ pathname });
+    },
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/%E6%AD%B4%E5%8F%B2'
+      });
+      // unencoded string
+      const pathname = '/歴史';
+      history.replace(pathname);
+    },
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/歴史'
+      });
+      // unencoded object
+      const pathname = '/歴史';
+      history.replace({ pathname });
+    },
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/歴史'
+      });
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/NoslashHashPathCoding.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/NoslashHashPathCoding.js
@@ -1,0 +1,50 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      // IE 10+ gives us "#", everyone else gives us ""
+      expect(window.location.hash).toMatch(/^#?$/);
+
+      history.push('/home?the=query#the-hash');
+    },
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/home',
+        search: '?the=query',
+        hash: '#the-hash'
+      });
+
+      expect(window.location.hash).toBe('#home?the=query#the-hash');
+
+      history.goBack();
+    },
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      // IE 10+ gives us "#", everyone else gives us ""
+      expect(window.location.hash).toMatch(/^#?$/);
+
+      history.goForward();
+    },
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/home',
+        search: '?the=query',
+        hash: '#the-hash'
+      });
+
+      expect(window.location.hash).toBe('#home?the=query#the-hash');
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/PushEncodedLocation.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/PushEncodedLocation.js
@@ -1,0 +1,28 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      const pathname = '/%E6%AD%B4%E5%8F%B2';
+      const search = '?%E3%82%AD%E3%83%BC=%E5%80%A4';
+      const hash = '#%E3%83%8F%E3%83%83%E3%82%B7%E3%83%A5';
+      history.push(pathname + search + hash);
+    },
+    (location, action) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/%E6%AD%B4%E5%8F%B2',
+        search: '?%E3%82%AD%E3%83%BC=%E5%80%A4',
+        hash: '#%E3%83%8F%E3%83%83%E3%82%B7%E3%83%A5'
+      });
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/PushMissingPathname.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/PushMissingPathname.js
@@ -1,0 +1,35 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.push('/home?the=query#the-hash');
+    },
+    (location, action) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/home',
+        search: '?the=query',
+        hash: '#the-hash'
+      });
+
+      history.push('?another=query#another-hash');
+    },
+    (location, action) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/home',
+        search: '?another=query',
+        hash: '#another-hash'
+      });
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/PushNewLocation.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/PushNewLocation.js
@@ -1,0 +1,25 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.push('/home?the=query#the-hash');
+    },
+    (location, action) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/home',
+        search: '?the=query',
+        hash: '#the-hash'
+      });
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/PushRelativePathname.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/PushRelativePathname.js
@@ -1,0 +1,35 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.push('/the/path?the=query#the-hash');
+    },
+    (location, action) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/the/path',
+        search: '?the=query',
+        hash: '#the-hash'
+      });
+
+      history.push('../other/path?another=query#another-hash');
+    },
+    (location, action) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/other/path',
+        search: '?another=query',
+        hash: '#another-hash'
+      });
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/PushSamePath.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/PushSamePath.js
@@ -1,0 +1,39 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.push('/home');
+    },
+    (location, action) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/home'
+      });
+
+      history.push('/home');
+    },
+    (location, action) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/home'
+      });
+
+      history.goBack();
+    },
+    (location, action) => {
+      expect(action).toBe('POP');
+      expect(location).toMatchObject({
+        pathname: '/home'
+      });
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/PushSamePathWarning.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/PushSamePathWarning.js
@@ -1,0 +1,55 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  let prevLocation;
+
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.push('/home');
+    },
+    (location, action) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/home'
+      });
+
+      prevLocation = location;
+
+      history.push('/home');
+    },
+    (location, action) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/home'
+      });
+
+      // We should get the SAME location object. Nothing
+      // new was added to the history stack.
+      expect(location).toBe(prevLocation);
+
+      // We should see a warning message.
+      expect(warningMessage).toMatch(
+        'Hash history cannot PUSH the same path; a new entry will not be added to the history stack'
+      );
+    }
+  ];
+
+  let consoleWarn = console.error; // eslint-disable-line no-console
+  let warningMessage;
+
+  // eslint-disable-next-line no-console
+  console.warn = message => {
+    warningMessage = message;
+  };
+
+  execSteps(steps, history, (...args) => {
+    console.warn = consoleWarn; // eslint-disable-line no-console
+    done(...args);
+  });
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/PushState.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/PushState.js
@@ -1,0 +1,26 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.push('/home?the=query#the-hash', { the: 'state' });
+    },
+    (location, action) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/home',
+        search: '?the=query',
+        hash: '#the-hash',
+        state: { the: 'state' }
+      });
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/PushStateWarning.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/PushStateWarning.js
@@ -1,0 +1,40 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.push('/home', { the: 'state' });
+    },
+    (location, action) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/home',
+        state: undefined
+      });
+
+      // We should see a warning message.
+      expect(warningMessage).toMatch(
+        'Hash history cannot push state; it is ignored'
+      );
+    }
+  ];
+
+  let consoleWarn = console.warn; // eslint-disable-line no-console
+  let warningMessage;
+
+  // eslint-disable-next-line no-console
+  console.warn = message => {
+    warningMessage = message;
+  };
+
+  execSteps(steps, history, (...args) => {
+    console.warn = consoleWarn; // eslint-disable-line no-console
+    done(...args);
+  });
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/PushUnicodeLocation.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/PushUnicodeLocation.js
@@ -1,0 +1,28 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      const pathname = '/歴史';
+      const search = '?キー=値';
+      const hash = '#ハッシュ';
+      history.push(pathname + search + hash);
+    },
+    (location, action) => {
+      expect(action).toBe('PUSH');
+      expect(location).toMatchObject({
+        pathname: '/歴史',
+        search: '?キー=値',
+        hash: '#ハッシュ'
+      });
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/ReplaceNewLocation.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/ReplaceNewLocation.js
@@ -1,0 +1,25 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.replace('/home?the=query#the-hash');
+    },
+    (location, action) => {
+      expect(action).toBe('REPLACE');
+      expect(location).toMatchObject({
+        pathname: '/home',
+        search: '?the=query',
+        hash: '#the-hash'
+      });
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/ReplaceSamePath.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/ReplaceSamePath.js
@@ -1,0 +1,37 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  let prevLocation;
+
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.replace('/home');
+    },
+    (location, action) => {
+      expect(action).toBe('REPLACE');
+      expect(location).toMatchObject({
+        pathname: '/home'
+      });
+
+      prevLocation = location;
+
+      history.replace('/home');
+    },
+    (location, action) => {
+      expect(action).toBe('REPLACE');
+      expect(location).toMatchObject({
+        pathname: '/home'
+      });
+
+      expect(location).not.toBe(prevLocation);
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/ReplaceState.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/ReplaceState.js
@@ -1,0 +1,26 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.replace('/home?the=query#the-hash', { the: 'state' });
+    },
+    (location, action) => {
+      expect(action).toBe('REPLACE');
+      expect(location).toMatchObject({
+        pathname: '/home',
+        search: '?the=query',
+        hash: '#the-hash',
+        state: { the: 'state' }
+      });
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/ReplaceStateWarning.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/ReplaceStateWarning.js
@@ -1,0 +1,40 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.replace('/home', { the: 'state' });
+    },
+    (location, action) => {
+      expect(action).toBe('REPLACE');
+      expect(location).toMatchObject({
+        pathname: '/home',
+        state: undefined
+      });
+
+      // We should see a warning message.
+      expect(warningMessage).toMatch(
+        'Hash history cannot replace state; it is ignored'
+      );
+    }
+  ];
+
+  let consoleWarn = console.warn; // eslint-disable-line no-console
+  let warningMessage;
+
+  // eslint-disable-next-line no-console
+  console.warn = message => {
+    warningMessage = message;
+  };
+
+  execSteps(steps, history, (...args) => {
+    console.warn = consoleWarn; // eslint-disable-line no-console
+    done(...args);
+  });
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/ReturnFalseTransitionHook.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/ReturnFalseTransitionHook.js
@@ -1,0 +1,32 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      const unblock = history.block(nextLocation => {
+        expect(nextLocation).toMatchObject({
+          pathname: '/home'
+        });
+
+        // Cancel the transition.
+        return false;
+      });
+
+      history.push('/home');
+
+      expect(history.location).toMatchObject({
+        pathname: '/'
+      });
+
+      unblock();
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/SlashHashPathCoding.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/SlashHashPathCoding.js
@@ -1,0 +1,48 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      expect(window.location.hash).toBe('#/');
+
+      history.push('/home?the=query#the-hash');
+    },
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/home',
+        search: '?the=query',
+        hash: '#the-hash'
+      });
+
+      expect(window.location.hash).toBe('#/home?the=query#the-hash');
+
+      history.goBack();
+    },
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      expect(window.location.hash).toBe('#/');
+
+      history.goForward();
+    },
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/home',
+        search: '?the=query',
+        hash: '#the-hash'
+      });
+
+      expect(window.location.hash).toBe('#/home?the=query#the-hash');
+    }
+  ];
+
+  execSteps(steps, history, done);
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/TransitionHookArgs.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/TransitionHookArgs.js
@@ -1,0 +1,32 @@
+import expect from 'expect';
+
+import execSteps from './execSteps';
+
+export default function(history, done) {
+  let hookLocation, hookAction;
+  const steps = [
+    location => {
+      expect(location).toMatchObject({
+        pathname: '/'
+      });
+
+      history.push('/home');
+    },
+    (location, action) => {
+      expect(hookAction).toBe(action);
+      expect(hookLocation).toBe(location);
+    }
+  ];
+
+  const unblock = history.block((location, action) => {
+    hookLocation = location;
+    hookAction = action;
+
+    return 'Are you sure?';
+  });
+
+  execSteps(steps, history, (...args) => {
+    unblock();
+    done(...args);
+  });
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/execSteps.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/execSteps.js
@@ -1,0 +1,34 @@
+export default function execSteps(steps, history, done) {
+  let index = 0,
+    unlisten,
+    cleanedUp = false;
+
+  const cleanup = (...args) => {
+    if (!cleanedUp) {
+      cleanedUp = true;
+      unlisten();
+      done(...args);
+    }
+  };
+
+  const execNextStep = (...args) => {
+    try {
+      const nextStep = steps[index++];
+
+      if (!nextStep) throw new Error('Test is missing step ' + index);
+
+      nextStep(...args);
+
+      if (index === steps.length) cleanup();
+    } catch (error) {
+      cleanup(error);
+    }
+  };
+
+  if (steps.length) {
+    unlisten = history.listen(execNextStep);
+    execNextStep(history.location);
+  } else {
+    done();
+  }
+}

--- a/app/ui-react/packages/history/modules/__tests__/TestSequences/index.js
+++ b/app/ui-react/packages/history/modules/__tests__/TestSequences/index.js
@@ -1,0 +1,44 @@
+export {
+  default as BackButtonTransitionHook
+} from './BackButtonTransitionHook';
+export { default as BlockEverything } from './BlockEverything';
+export {
+  default as BlockPopWithoutListening
+} from './BlockPopWithoutListening';
+export { default as DenyPush } from './DenyPush';
+export { default as DenyGoBack } from './DenyGoBack';
+export { default as DenyGoForward } from './DenyGoForward';
+export {
+  default as EncodedReservedCharacters
+} from './EncodedReservedCharacters';
+export { default as GoBack } from './GoBack';
+export { default as GoForward } from './GoForward';
+export { default as HashbangHashPathCoding } from './HashbangHashPathCoding';
+export {
+  default as HashChangeTransitionHook
+} from './HashChangeTransitionHook';
+export { default as InitialLocationNoKey } from './InitialLocationNoKey';
+export { default as InitialLocationHasKey } from './InitialLocationHasKey';
+export { default as Listen } from './Listen';
+export {
+  default as LocationPathnameAlwaysSame
+} from './LocationPathnameAlwaysSame';
+export { default as NoslashHashPathCoding } from './NoslashHashPathCoding';
+export { default as PushEncodedLocation } from './PushEncodedLocation';
+export { default as PushNewLocation } from './PushNewLocation';
+export { default as PushMissingPathname } from './PushMissingPathname';
+export { default as PushSamePath } from './PushSamePath';
+export { default as PushSamePathWarning } from './PushSamePathWarning';
+export { default as PushState } from './PushState';
+export { default as PushStateWarning } from './PushStateWarning';
+export { default as PushRelativePathname } from './PushRelativePathname';
+export { default as PushUnicodeLocation } from './PushUnicodeLocation';
+export { default as ReplaceNewLocation } from './ReplaceNewLocation';
+export { default as ReplaceSamePath } from './ReplaceSamePath';
+export { default as ReplaceState } from './ReplaceState';
+export { default as ReplaceStateWarning } from './ReplaceStateWarning';
+export {
+  default as ReturnFalseTransitionHook
+} from './ReturnFalseTransitionHook';
+export { default as SlashHashPathCoding } from './SlashHashPathCoding';
+export { default as TransitionHookArgs } from './TransitionHookArgs';

--- a/app/ui-react/packages/history/modules/__tests__/createHref-test.js
+++ b/app/ui-react/packages/history/modules/__tests__/createHref-test.js
@@ -1,0 +1,258 @@
+import expect from 'expect';
+
+import {
+  createBrowserHistory,
+  createHashHistory,
+  createMemoryHistory
+} from 'history';
+
+describe('a browser history', () => {
+  describe('with no basename', () => {
+    let history;
+    beforeEach(() => {
+      history = createBrowserHistory();
+    });
+
+    it('knows how to create hrefs', () => {
+      const href = history.createHref({
+        pathname: '/the/path',
+        search: '?the=query',
+        hash: '#the-hash'
+      });
+
+      expect(href).toEqual('/the/path?the=query#the-hash');
+    });
+  });
+
+  describe('with a basename', () => {
+    let history;
+    beforeEach(() => {
+      history = createBrowserHistory({ basename: '/the/base' });
+    });
+
+    it('knows how to create hrefs', () => {
+      const href = history.createHref({
+        pathname: '/the/path',
+        search: '?the=query',
+        hash: '#the-hash'
+      });
+
+      expect(href).toEqual('/the/base/the/path?the=query#the-hash');
+    });
+  });
+
+  describe('with a bad basename', () => {
+    let history;
+    beforeEach(() => {
+      history = createBrowserHistory({ basename: '/the/bad/base/' });
+    });
+
+    it('knows how to create hrefs', () => {
+      const href = history.createHref({
+        pathname: '/the/path',
+        search: '?the=query',
+        hash: '#the-hash'
+      });
+
+      expect(href).toEqual('/the/bad/base/the/path?the=query#the-hash');
+    });
+  });
+
+  describe('with a slash basename', () => {
+    let history;
+    beforeEach(() => {
+      history = createBrowserHistory({ basename: '/' });
+    });
+
+    it('knows how to create hrefs', () => {
+      const href = history.createHref({
+        pathname: '/the/path',
+        search: '?the=query',
+        hash: '#the-hash'
+      });
+
+      expect(href).toEqual('/the/path?the=query#the-hash');
+    });
+  });
+
+  describe('encoding', () => {
+    let history;
+    beforeEach(() => {
+      history = createBrowserHistory();
+    });
+
+    it('does not encode the generated path', () => {
+      // encoded
+      const encodedHref = history.createHref({
+        pathname: '/%23abc'
+      });
+      // unencoded
+      const unencodedHref = history.createHref({
+        pathname: '/#abc'
+      });
+
+      expect(encodedHref).toEqual('/%23abc');
+      expect(unencodedHref).toEqual('/#abc');
+    });
+  });
+});
+
+describe('a hash history', () => {
+  describe('with default encoding', () => {
+    let history;
+    beforeEach(() => {
+      history = createHashHistory();
+    });
+
+    it('knows how to create hrefs', () => {
+      const href = history.createHref({
+        pathname: '/the/path',
+        search: '?the=query',
+        hash: '#the-hash'
+      });
+
+      expect(href).toEqual('#/the/path?the=query#the-hash');
+    });
+  });
+
+  describe('with hashType="noslash"', () => {
+    let history;
+    beforeEach(() => {
+      history = createHashHistory({ hashType: 'noslash' });
+    });
+
+    it('knows how to create hrefs', () => {
+      const href = history.createHref({
+        pathname: '/the/path',
+        search: '?the=query',
+        hash: '#the-hash'
+      });
+
+      expect(href).toEqual('#the/path?the=query#the-hash');
+    });
+  });
+
+  describe('with hashType="hashbang"', () => {
+    let history;
+    beforeEach(() => {
+      history = createHashHistory({ hashType: 'hashbang' });
+    });
+
+    it('knows how to create hrefs', () => {
+      const href = history.createHref({
+        pathname: '/the/path',
+        search: '?the=query',
+        hash: '#the-hash'
+      });
+
+      expect(href).toEqual('#!/the/path?the=query#the-hash');
+    });
+  });
+
+  describe('with a basename', () => {
+    let history;
+    beforeEach(() => {
+      history = createHashHistory({ basename: '/the/base' });
+    });
+
+    it('knows how to create hrefs', () => {
+      const href = history.createHref({
+        pathname: '/the/path',
+        search: '?the=query'
+      });
+
+      expect(href).toEqual('#/the/base/the/path?the=query');
+    });
+  });
+
+  describe('with a bad basename', () => {
+    let history;
+    beforeEach(() => {
+      history = createHashHistory({ basename: '/the/bad/base/' });
+    });
+
+    it('knows how to create hrefs', () => {
+      const href = history.createHref({
+        pathname: '/the/path',
+        search: '?the=query'
+      });
+
+      expect(href).toEqual('#/the/bad/base/the/path?the=query');
+    });
+  });
+
+  describe('with a slash basename', () => {
+    let history;
+    beforeEach(() => {
+      history = createHashHistory({ basename: '/' });
+    });
+
+    it('knows how to create hrefs', () => {
+      const href = history.createHref({
+        pathname: '/the/path',
+        search: '?the=query'
+      });
+
+      expect(href).toEqual('#/the/path?the=query');
+    });
+  });
+
+  describe('encoding', () => {
+    let history;
+    beforeEach(() => {
+      history = createHashHistory();
+    });
+
+    it('does not encode the generated path', () => {
+      // encoded
+      const encodedHref = history.createHref({
+        pathname: '/%23abc'
+      });
+      // unencoded
+      const unencodedHref = history.createHref({
+        pathname: '/#abc'
+      });
+
+      expect(encodedHref).toEqual('#/%23abc');
+      expect(unencodedHref).toEqual('#/#abc');
+    });
+  });
+});
+
+describe('a memory history', () => {
+  let history;
+  beforeEach(() => {
+    history = createMemoryHistory();
+  });
+
+  it('knows how to create hrefs', () => {
+    const href = history.createHref({
+      pathname: '/the/path',
+      search: '?the=query',
+      hash: '#the-hash'
+    });
+
+    expect(href).toEqual('/the/path?the=query#the-hash');
+  });
+
+  describe('encoding', () => {
+    let history;
+    beforeEach(() => {
+      history = createMemoryHistory();
+    });
+
+    it('does not encode the generated path', () => {
+      // encoded
+      const encodedHref = history.createHref({
+        pathname: '/%23abc'
+      });
+      // unencoded
+      const unencodedHref = history.createHref({
+        pathname: '/#abc'
+      });
+
+      expect(encodedHref).toEqual('/%23abc');
+      expect(unencodedHref).toEqual('/#abc');
+    });
+  });
+});

--- a/app/ui-react/packages/history/modules/createBrowserHistory.js
+++ b/app/ui-react/packages/history/modules/createBrowserHistory.js
@@ -1,0 +1,340 @@
+import warning from 'tiny-warning';
+import invariant from 'tiny-invariant';
+
+import { createLocation } from './LocationUtils';
+import {
+  addLeadingSlash,
+  stripTrailingSlash,
+  hasBasename,
+  stripBasename,
+  createPath
+} from './PathUtils';
+import createTransitionManager from './createTransitionManager';
+import {
+  canUseDOM,
+  getConfirmation,
+  supportsHistory,
+  supportsPopStateOnHashChange,
+  isExtraneousPopstateEvent
+} from './DOMUtils';
+
+const PopStateEvent = 'popstate';
+const HashChangeEvent = 'hashchange';
+
+function getHistoryState() {
+  try {
+    return window.history.state || {};
+  } catch (e) {
+    // IE 11 sometimes throws when accessing window.history.state
+    // See https://github.com/ReactTraining/history/pull/289
+    return {};
+  }
+}
+
+/**
+ * Creates a history object that uses the HTML5 history API including
+ * pushState, replaceState, and the popstate event.
+ */
+function createBrowserHistory(props = {}) {
+  invariant(canUseDOM, 'Browser history needs a DOM');
+
+  const globalHistory = window.history;
+  const canUseHistory = supportsHistory();
+  const needsHashChangeListener = !supportsPopStateOnHashChange();
+
+  const {
+    forceRefresh = false,
+    getUserConfirmation = getConfirmation,
+    keyLength = 6
+  } = props;
+  const basename = props.basename
+    ? stripTrailingSlash(addLeadingSlash(props.basename))
+    : '';
+
+  function getDOMLocation(historyState) {
+    const { key, state } = historyState || {};
+    const { pathname, search, hash } = window.location;
+
+    let path = pathname + search + hash;
+
+    warning(
+      !basename || hasBasename(path, basename),
+      'You are attempting to use a basename on a page whose URL path does not begin ' +
+        'with the basename. Expected path "' +
+        path +
+        '" to begin with "' +
+        basename +
+        '".'
+    );
+
+    if (basename) path = stripBasename(path, basename);
+
+    return createLocation(path, state, key);
+  }
+
+  function createKey() {
+    return Math.random()
+      .toString(36)
+      .substr(2, keyLength);
+  }
+
+  const transitionManager = createTransitionManager();
+
+  function setState(nextState) {
+    Object.assign(history, nextState);
+    history.length = globalHistory.length;
+    transitionManager.notifyListeners(history.location, history.action);
+  }
+
+  function handlePopState(event) {
+    // Ignore extraneous popstate events in WebKit.
+    if (isExtraneousPopstateEvent(event)) return;
+    handlePop(getDOMLocation(event.state));
+  }
+
+  function handleHashChange() {
+    handlePop(getDOMLocation(getHistoryState()));
+  }
+
+  let forceNextPop = false;
+
+  function handlePop(location) {
+    if (forceNextPop) {
+      forceNextPop = false;
+      setState();
+    } else {
+      const action = 'POP';
+
+      transitionManager.confirmTransitionTo(
+        location,
+        action,
+        getUserConfirmation,
+        ok => {
+          if (ok) {
+            setState({ action, location });
+          } else {
+            revertPop(location);
+          }
+        }
+      );
+    }
+  }
+
+  function revertPop(fromLocation) {
+    const toLocation = history.location;
+
+    // TODO: We could probably make this more reliable by
+    // keeping a list of keys we've seen in localStorage.
+    // Instead, we just default to 0 for keys we don't know.
+
+    let toIndex = allKeys.indexOf(toLocation.key);
+
+    if (toIndex === -1) toIndex = 0;
+
+    let fromIndex = allKeys.indexOf(fromLocation.key);
+
+    if (fromIndex === -1) fromIndex = 0;
+
+    const delta = toIndex - fromIndex;
+
+    if (delta) {
+      forceNextPop = true;
+      go(delta);
+    }
+  }
+
+  const initialLocation = getDOMLocation(getHistoryState());
+  let allKeys = [initialLocation.key];
+
+  // Public interface
+
+  function createHref(location) {
+    return basename + createPath(location);
+  }
+
+  function push(path, state) {
+    warning(
+      !(
+        typeof path === 'object' &&
+        path.state !== undefined &&
+        state !== undefined
+      ),
+      'You should avoid providing a 2nd state argument to push when the 1st ' +
+        'argument is a location-like object that already has state; it is ignored'
+    );
+
+    const action = 'PUSH';
+    const location = createLocation(path, state, createKey(), history.location);
+
+    transitionManager.confirmTransitionTo(
+      location,
+      action,
+      getUserConfirmation,
+      ok => {
+        if (!ok) return;
+
+        const href = createHref(location);
+        const { key, state } = location;
+
+        if (canUseHistory) {
+          globalHistory.pushState({ key }, null, href);
+          try {
+            sessionStorage.setItem(key, JSON.stringify(state));
+          } catch (e) {
+            // storage full, retry after a clean. Old history entries will be nuked, so if the user will go back pages will raise exceptions. Nothing we can do about that I guess?
+            sessionStorage.clear();
+            sessionStorage.setItem(key, JSON.stringify(state));
+          }
+
+          if (forceRefresh) {
+            window.location.href = href;
+          } else {
+            const prevIndex = allKeys.indexOf(history.location.key);
+            const nextKeys = allKeys.slice(
+              0,
+              prevIndex === -1 ? 0 : prevIndex + 1
+            );
+
+            nextKeys.push(location.key);
+            allKeys = nextKeys;
+
+            setState({ action, location });
+          }
+        } else {
+          warning(
+            state === undefined,
+            'Browser history cannot push state in browsers that do not support HTML5 history'
+          );
+
+          window.location.href = href;
+        }
+      }
+    );
+  }
+
+  function replace(path, state) {
+    warning(
+      !(
+        typeof path === 'object' &&
+        path.state !== undefined &&
+        state !== undefined
+      ),
+      'You should avoid providing a 2nd state argument to replace when the 1st ' +
+        'argument is a location-like object that already has state; it is ignored'
+    );
+
+    const action = 'REPLACE';
+    const location = createLocation(path, state, createKey(), history.location);
+
+    transitionManager.confirmTransitionTo(
+      location,
+      action,
+      getUserConfirmation,
+      ok => {
+        if (!ok) return;
+
+        const href = createHref(location);
+        const { key, state } = location;
+
+        if (canUseHistory) {
+          globalHistory.replaceState({ key, state }, null, href);
+
+          if (forceRefresh) {
+            window.location.replace(href);
+          } else {
+            const prevIndex = allKeys.indexOf(history.location.key);
+
+            if (prevIndex !== -1) allKeys[prevIndex] = location.key;
+
+            setState({ action, location });
+          }
+        } else {
+          warning(
+            state === undefined,
+            'Browser history cannot replace state in browsers that do not support HTML5 history'
+          );
+
+          window.location.replace(href);
+        }
+      }
+    );
+  }
+
+  function go(n) {
+    globalHistory.go(n);
+  }
+
+  function goBack() {
+    go(-1);
+  }
+
+  function goForward() {
+    go(1);
+  }
+
+  let listenerCount = 0;
+
+  function checkDOMListeners(delta) {
+    listenerCount += delta;
+
+    if (listenerCount === 1 && delta === 1) {
+      window.addEventListener(PopStateEvent, handlePopState);
+
+      if (needsHashChangeListener)
+        window.addEventListener(HashChangeEvent, handleHashChange);
+    } else if (listenerCount === 0) {
+      window.removeEventListener(PopStateEvent, handlePopState);
+
+      if (needsHashChangeListener)
+        window.removeEventListener(HashChangeEvent, handleHashChange);
+    }
+  }
+
+  let isBlocked = false;
+
+  function block(prompt = false) {
+    const unblock = transitionManager.setPrompt(prompt);
+
+    if (!isBlocked) {
+      checkDOMListeners(1);
+      isBlocked = true;
+    }
+
+    return () => {
+      if (isBlocked) {
+        isBlocked = false;
+        checkDOMListeners(-1);
+      }
+
+      return unblock();
+    };
+  }
+
+  function listen(listener) {
+    const unlisten = transitionManager.appendListener(listener);
+    checkDOMListeners(1);
+
+    return () => {
+      checkDOMListeners(-1);
+      unlisten();
+    };
+  }
+
+  const history = {
+    length: globalHistory.length,
+    action: 'POP',
+    location: initialLocation,
+    createHref,
+    push,
+    replace,
+    go,
+    goBack,
+    goForward,
+    block,
+    listen
+  };
+
+  return history;
+}
+
+export default createBrowserHistory;

--- a/app/ui-react/packages/history/modules/createHashHistory.js
+++ b/app/ui-react/packages/history/modules/createHashHistory.js
@@ -1,0 +1,352 @@
+import warning from 'tiny-warning';
+import invariant from 'tiny-invariant';
+
+import { createLocation, locationsAreEqual } from './LocationUtils';
+import {
+  addLeadingSlash,
+  stripLeadingSlash,
+  stripTrailingSlash,
+  hasBasename,
+  stripBasename,
+  createPath
+} from './PathUtils';
+import createTransitionManager from './createTransitionManager';
+import {
+  canUseDOM,
+  getConfirmation,
+  supportsGoWithoutReloadUsingHash
+} from './DOMUtils';
+
+const HashChangeEvent = 'hashchange';
+
+const HashPathCoders = {
+  hashbang: {
+    encodePath: path =>
+      path.charAt(0) === '!' ? path : '!/' + stripLeadingSlash(path),
+    decodePath: path => (path.charAt(0) === '!' ? path.substr(1) : path)
+  },
+  noslash: {
+    encodePath: stripLeadingSlash,
+    decodePath: addLeadingSlash
+  },
+  slash: {
+    encodePath: addLeadingSlash,
+    decodePath: addLeadingSlash
+  }
+};
+
+function getHashPath() {
+  // We can't use window.location.hash here because it's not
+  // consistent across browsers - Firefox will pre-decode it!
+  const href = window.location.href;
+  const hashIndex = href.indexOf('#');
+  return hashIndex === -1 ? '' : href.substring(hashIndex + 1);
+}
+
+function pushHashPath(path) {
+  window.location.hash = path;
+}
+
+function replaceHashPath(path) {
+  const hashIndex = window.location.href.indexOf('#');
+  window.location.replace(
+    window.location.href.slice(0, hashIndex >= 0 ? hashIndex : 0) + '#' + path
+  );
+}
+
+function createHashHistory(props = {}) {
+  invariant(canUseDOM, 'Hash history needs a DOM');
+
+  const globalHistory = window.history;
+  const canGoWithoutReload = supportsGoWithoutReloadUsingHash();
+
+  const { getUserConfirmation = getConfirmation, hashType = 'slash' } = props;
+  const basename = props.basename
+    ? stripTrailingSlash(addLeadingSlash(props.basename))
+    : '';
+
+  const { encodePath, decodePath } = HashPathCoders[hashType];
+
+  function getDOMLocation() {
+    let path = decodePath(getHashPath());
+
+    warning(
+      !basename || hasBasename(path, basename),
+      'You are attempting to use a basename on a page whose URL path does not begin ' +
+        'with the basename. Expected path "' +
+        path +
+        '" to begin with "' +
+        basename +
+        '".'
+    );
+
+    if (basename) path = stripBasename(path, basename);
+
+    return createLocation(path);
+  }
+
+  const transitionManager = createTransitionManager();
+
+  function setState(nextState) {
+    Object.assign(history, nextState);
+    history.length = globalHistory.length;
+    transitionManager.notifyListeners(history.location, history.action);
+  }
+
+  let forceNextPop = false;
+  let ignorePath = null;
+
+  function handleHashChange() {
+    const path = getHashPath();
+    const encodedPath = encodePath(path);
+
+    if (path !== encodedPath) {
+      // Ensure we always have a properly-encoded hash.
+      replaceHashPath(encodedPath);
+    } else {
+      const location = getDOMLocation();
+      const prevLocation = history.location;
+
+      if (!forceNextPop && locationsAreEqual(prevLocation, location)) return; // A hashchange doesn't always == location change.
+
+      if (ignorePath === createPath(location)) return; // Ignore this change; we already setState in push/replace.
+
+      ignorePath = null;
+
+      handlePop(location);
+    }
+  }
+
+  function handlePop(location) {
+    if (forceNextPop) {
+      forceNextPop = false;
+      setState();
+    } else {
+      const action = 'POP';
+
+      transitionManager.confirmTransitionTo(
+        location,
+        action,
+        getUserConfirmation,
+        ok => {
+          if (ok) {
+            setState({ action, location });
+          } else {
+            revertPop(location);
+          }
+        }
+      );
+    }
+  }
+
+  function revertPop(fromLocation) {
+    const toLocation = history.location;
+
+    // TODO: We could probably make this more reliable by
+    // keeping a list of paths we've seen in sessionStorage.
+    // Instead, we just default to 0 for paths we don't know.
+
+    let toIndex = allPaths.lastIndexOf(createPath(toLocation));
+
+    if (toIndex === -1) toIndex = 0;
+
+    let fromIndex = allPaths.lastIndexOf(createPath(fromLocation));
+
+    if (fromIndex === -1) fromIndex = 0;
+
+    const delta = toIndex - fromIndex;
+
+    if (delta) {
+      forceNextPop = true;
+      go(delta);
+    }
+  }
+
+  // Ensure the hash is encoded properly before doing anything else.
+  const path = getHashPath();
+  const encodedPath = encodePath(path);
+
+  if (path !== encodedPath) replaceHashPath(encodedPath);
+
+  const initialLocation = getDOMLocation();
+  let allPaths = [createPath(initialLocation)];
+
+  // Public interface
+
+  function createHref(location) {
+    return '#' + encodePath(basename + createPath(location));
+  }
+
+  function push(path, state) {
+    warning(
+      state === undefined,
+      'Hash history cannot push state; it is ignored'
+    );
+
+    const action = 'PUSH';
+    const location = createLocation(
+      path,
+      undefined,
+      undefined,
+      history.location
+    );
+
+    transitionManager.confirmTransitionTo(
+      location,
+      action,
+      getUserConfirmation,
+      ok => {
+        if (!ok) return;
+
+        const path = createPath(location);
+        const encodedPath = encodePath(basename + path);
+        const hashChanged = getHashPath() !== encodedPath;
+
+        if (hashChanged) {
+          // We cannot tell if a hashchange was caused by a PUSH, so we'd
+          // rather setState here and ignore the hashchange. The caveat here
+          // is that other hash histories in the page will consider it a POP.
+          ignorePath = path;
+          pushHashPath(encodedPath);
+
+          const prevIndex = allPaths.lastIndexOf(createPath(history.location));
+          const nextPaths = allPaths.slice(
+            0,
+            prevIndex === -1 ? 0 : prevIndex + 1
+          );
+
+          nextPaths.push(path);
+          allPaths = nextPaths;
+
+          setState({ action, location });
+        } else {
+          warning(
+            false,
+            'Hash history cannot PUSH the same path; a new entry will not be added to the history stack'
+          );
+
+          setState();
+        }
+      }
+    );
+  }
+
+  function replace(path, state) {
+    warning(
+      state === undefined,
+      'Hash history cannot replace state; it is ignored'
+    );
+
+    const action = 'REPLACE';
+    const location = createLocation(
+      path,
+      undefined,
+      undefined,
+      history.location
+    );
+
+    transitionManager.confirmTransitionTo(
+      location,
+      action,
+      getUserConfirmation,
+      ok => {
+        if (!ok) return;
+
+        const path = createPath(location);
+        const encodedPath = encodePath(basename + path);
+        const hashChanged = getHashPath() !== encodedPath;
+
+        if (hashChanged) {
+          // We cannot tell if a hashchange was caused by a REPLACE, so we'd
+          // rather setState here and ignore the hashchange. The caveat here
+          // is that other hash histories in the page will consider it a POP.
+          ignorePath = path;
+          replaceHashPath(encodedPath);
+        }
+
+        const prevIndex = allPaths.indexOf(createPath(history.location));
+
+        if (prevIndex !== -1) allPaths[prevIndex] = path;
+
+        setState({ action, location });
+      }
+    );
+  }
+
+  function go(n) {
+    warning(
+      canGoWithoutReload,
+      'Hash history go(n) causes a full page reload in this browser'
+    );
+
+    globalHistory.go(n);
+  }
+
+  function goBack() {
+    go(-1);
+  }
+
+  function goForward() {
+    go(1);
+  }
+
+  let listenerCount = 0;
+
+  function checkDOMListeners(delta) {
+    listenerCount += delta;
+
+    if (listenerCount === 1 && delta === 1) {
+      window.addEventListener(HashChangeEvent, handleHashChange);
+    } else if (listenerCount === 0) {
+      window.removeEventListener(HashChangeEvent, handleHashChange);
+    }
+  }
+
+  let isBlocked = false;
+
+  function block(prompt = false) {
+    const unblock = transitionManager.setPrompt(prompt);
+
+    if (!isBlocked) {
+      checkDOMListeners(1);
+      isBlocked = true;
+    }
+
+    return () => {
+      if (isBlocked) {
+        isBlocked = false;
+        checkDOMListeners(-1);
+      }
+
+      return unblock();
+    };
+  }
+
+  function listen(listener) {
+    const unlisten = transitionManager.appendListener(listener);
+    checkDOMListeners(1);
+
+    return () => {
+      checkDOMListeners(-1);
+      unlisten();
+    };
+  }
+
+  const history = {
+    length: globalHistory.length,
+    action: 'POP',
+    location: initialLocation,
+    createHref,
+    push,
+    replace,
+    go,
+    goBack,
+    goForward,
+    block,
+    listen
+  };
+
+  return history;
+}
+
+export default createHashHistory;

--- a/app/ui-react/packages/history/modules/createMemoryHistory.js
+++ b/app/ui-react/packages/history/modules/createMemoryHistory.js
@@ -1,0 +1,187 @@
+import warning from 'tiny-warning';
+
+import { createPath } from './PathUtils';
+import { createLocation } from './LocationUtils';
+import createTransitionManager from './createTransitionManager';
+
+function clamp(n, lowerBound, upperBound) {
+  return Math.min(Math.max(n, lowerBound), upperBound);
+}
+
+/**
+ * Creates a history object that stores locations in memory.
+ */
+function createMemoryHistory(props = {}) {
+  const {
+    getUserConfirmation,
+    initialEntries = ['/'],
+    initialIndex = 0,
+    keyLength = 6
+  } = props;
+
+  const transitionManager = createTransitionManager();
+
+  function setState(nextState) {
+    Object.assign(history, nextState);
+    history.length = history.entries.length;
+    transitionManager.notifyListeners(history.location, history.action);
+  }
+
+  function createKey() {
+    return Math.random()
+      .toString(36)
+      .substr(2, keyLength);
+  }
+
+  const index = clamp(initialIndex, 0, initialEntries.length - 1);
+  const entries = initialEntries.map(entry =>
+    typeof entry === 'string'
+      ? createLocation(entry, undefined, createKey())
+      : createLocation(entry, undefined, entry.key || createKey())
+  );
+
+  // Public interface
+
+  const createHref = createPath;
+
+  function push(path, state) {
+    warning(
+      !(
+        typeof path === 'object' &&
+        path.state !== undefined &&
+        state !== undefined
+      ),
+      'You should avoid providing a 2nd state argument to push when the 1st ' +
+        'argument is a location-like object that already has state; it is ignored'
+    );
+
+    const action = 'PUSH';
+    const location = createLocation(path, state, createKey(), history.location);
+
+    transitionManager.confirmTransitionTo(
+      location,
+      action,
+      getUserConfirmation,
+      ok => {
+        if (!ok) return;
+
+        const prevIndex = history.index;
+        const nextIndex = prevIndex + 1;
+
+        const nextEntries = history.entries.slice(0);
+        if (nextEntries.length > nextIndex) {
+          nextEntries.splice(
+            nextIndex,
+            nextEntries.length - nextIndex,
+            location
+          );
+        } else {
+          nextEntries.push(location);
+        }
+
+        setState({
+          action,
+          location,
+          index: nextIndex,
+          entries: nextEntries
+        });
+      }
+    );
+  }
+
+  function replace(path, state) {
+    warning(
+      !(
+        typeof path === 'object' &&
+        path.state !== undefined &&
+        state !== undefined
+      ),
+      'You should avoid providing a 2nd state argument to replace when the 1st ' +
+        'argument is a location-like object that already has state; it is ignored'
+    );
+
+    const action = 'REPLACE';
+    const location = createLocation(path, state, createKey(), history.location);
+
+    transitionManager.confirmTransitionTo(
+      location,
+      action,
+      getUserConfirmation,
+      ok => {
+        if (!ok) return;
+
+        history.entries[history.index] = location;
+
+        setState({ action, location });
+      }
+    );
+  }
+
+  function go(n) {
+    const nextIndex = clamp(history.index + n, 0, history.entries.length - 1);
+
+    const action = 'POP';
+    const location = history.entries[nextIndex];
+
+    transitionManager.confirmTransitionTo(
+      location,
+      action,
+      getUserConfirmation,
+      ok => {
+        if (ok) {
+          setState({
+            action,
+            location,
+            index: nextIndex
+          });
+        } else {
+          // Mimic the behavior of DOM histories by
+          // causing a render after a cancelled POP.
+          setState();
+        }
+      }
+    );
+  }
+
+  function goBack() {
+    go(-1);
+  }
+
+  function goForward() {
+    go(1);
+  }
+
+  function canGo(n) {
+    const nextIndex = history.index + n;
+    return nextIndex >= 0 && nextIndex < history.entries.length;
+  }
+
+  function block(prompt = false) {
+    return transitionManager.setPrompt(prompt);
+  }
+
+  function listen(listener) {
+    return transitionManager.appendListener(listener);
+  }
+
+  const history = {
+    length: entries.length,
+    action: 'POP',
+    location: entries[index],
+    index,
+    entries,
+    createHref,
+    push,
+    replace,
+    go,
+    goBack,
+    goForward,
+    canGo,
+    block,
+    listen
+  };
+
+  return history;
+}
+
+export default createMemoryHistory;

--- a/app/ui-react/packages/history/modules/createTransitionManager.js
+++ b/app/ui-react/packages/history/modules/createTransitionManager.js
@@ -1,0 +1,78 @@
+import warning from 'tiny-warning';
+
+function createTransitionManager() {
+  let prompt = null;
+
+  function setPrompt(nextPrompt) {
+    warning(prompt == null, 'A history supports only one prompt at a time');
+
+    prompt = nextPrompt;
+
+    return () => {
+      if (prompt === nextPrompt) prompt = null;
+    };
+  }
+
+  function confirmTransitionTo(
+    location,
+    action,
+    getUserConfirmation,
+    callback
+  ) {
+    // TODO: If another transition starts while we're still confirming
+    // the previous one, we may end up in a weird state. Figure out the
+    // best way to handle this.
+    if (prompt != null) {
+      const result =
+        typeof prompt === 'function' ? prompt(location, action) : prompt;
+
+      if (typeof result === 'string') {
+        if (typeof getUserConfirmation === 'function') {
+          getUserConfirmation(result, callback);
+        } else {
+          warning(
+            false,
+            'A history needs a getUserConfirmation function in order to use a prompt message'
+          );
+
+          callback(true);
+        }
+      } else {
+        // Return false from a transition hook to cancel the transition.
+        callback(result !== false);
+      }
+    } else {
+      callback(true);
+    }
+  }
+
+  let listeners = [];
+
+  function appendListener(fn) {
+    let isActive = true;
+
+    function listener(...args) {
+      if (isActive) fn(...args);
+    }
+
+    listeners.push(listener);
+
+    return () => {
+      isActive = false;
+      listeners = listeners.filter(item => item !== listener);
+    };
+  }
+
+  function notifyListeners(...args) {
+    listeners.forEach(listener => listener(...args));
+  }
+
+  return {
+    setPrompt,
+    confirmTransitionTo,
+    appendListener,
+    notifyListeners
+  };
+}
+
+export default createTransitionManager;

--- a/app/ui-react/packages/history/modules/index.js
+++ b/app/ui-react/packages/history/modules/index.js
@@ -1,0 +1,5 @@
+export { default as createBrowserHistory } from './createBrowserHistory';
+export { default as createHashHistory } from './createHashHistory';
+export { default as createMemoryHistory } from './createMemoryHistory';
+export { createLocation, locationsAreEqual } from './LocationUtils';
+export { parsePath, createPath } from './PathUtils';

--- a/app/ui-react/packages/history/package.json
+++ b/app/ui-react/packages/history/package.json
@@ -1,0 +1,82 @@
+{
+  "name": "@syndesis/history",
+  "version": "4.9.0",
+  "description": "Manage session history with JavaScript",
+  "repository": "ReactTraining/history",
+  "license": "MIT",
+  "author": "Michael Jackson",
+  "main": "index.js",
+  "module": "esm/history.js",
+  "unpkg": "umd/history.js",
+  "files": [
+    "DOMUtils.js",
+    "ExecutionEnvironment.js",
+    "LocationUtils.js",
+    "PathUtils.js",
+    "cjs",
+    "createBrowserHistory.js",
+    "createHashHistory.js",
+    "createMemoryHistory.js",
+    "createTransitionManager.js",
+    "es",
+    "esm",
+    "umd",
+    "warnAboutDeprecatedCJSRequire.js"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "rollup -c",
+    "clean-disabled": "git clean -fdX .",
+    "lint-disabled": "eslint modules",
+    "prepublishOnly": "npm run build",
+    "test-disabled": "karma start --single-run"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.1.2",
+    "loose-envify": "^1.2.0",
+    "resolve-pathname": "^2.2.0",
+    "tiny-invariant": "^1.0.2",
+    "tiny-warning": "^1.0.0",
+    "value-equal": "^0.4.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.1.2",
+    "@babel/plugin-transform-object-assign": "^7.0.0",
+    "@babel/plugin-transform-runtime": "^7.1.0",
+    "@babel/preset-env": "^7.1.0",
+    "babel-core": "^7.0.0-bridge.0",
+    "babel-eslint": "^7.0.0",
+    "babel-loader": "^8.0.4",
+    "babel-plugin-dev-expression": "^0.2.1",
+    "eslint": "^3.3.0",
+    "eslint-plugin-import": "^2.0.0",
+    "expect": "^21.0.0",
+    "jest-mock": "^21.0.0",
+    "karma": "^3.1.3",
+    "karma-browserstack-launcher": "^1.3.0",
+    "karma-chrome-launcher": "^2.2.0",
+    "karma-firefox-launcher": "^1.1.0",
+    "karma-mocha": "^1.3.0",
+    "karma-mocha-reporter": "^2.2.5",
+    "karma-sourcemap-loader": "^0.3.7",
+    "karma-webpack": "^3.0.5",
+    "mocha": "^5.2.0",
+    "rollup": "^0.66.6",
+    "rollup-plugin-babel": "^4.0.3",
+    "rollup-plugin-commonjs": "^9.2.0",
+    "rollup-plugin-node-resolve": "^3.4.0",
+    "rollup-plugin-replace": "^2.1.0",
+    "rollup-plugin-size-snapshot": "^0.7.0",
+    "rollup-plugin-uglify": "^6.0.0",
+    "webpack": "^3.12.0"
+  },
+  "browserify": {
+    "transform": [
+      "loose-envify"
+    ]
+  },
+  "keywords": [
+    "history",
+    "location"
+  ]
+}

--- a/app/ui-react/packages/history/rollup.config.js
+++ b/app/ui-react/packages/history/rollup.config.js
@@ -1,0 +1,104 @@
+import babel from 'rollup-plugin-babel';
+import nodeResolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+import replace from 'rollup-plugin-replace';
+import { sizeSnapshot } from 'rollup-plugin-size-snapshot';
+import { uglify } from 'rollup-plugin-uglify';
+
+import pkg from './package.json';
+
+const input = './modules/index.js';
+const globalName = 'History';
+
+function external(id) {
+  return !id.startsWith('.') && !id.startsWith('/');
+}
+
+const cjs = [
+  {
+    input,
+    output: { file: `cjs/history.js`, format: 'cjs' },
+    external,
+    plugins: [
+      babel({ exclude: /node_modules/ }),
+      replace({ 'process.env.NODE_ENV': JSON.stringify('development') })
+    ]
+  },
+  {
+    input,
+    output: { file: `cjs/history.min.js`, format: 'cjs' },
+    external,
+    plugins: [
+      babel({ exclude: /node_modules/ }),
+      replace({ 'process.env.NODE_ENV': JSON.stringify('production') }),
+      uglify()
+    ]
+  }
+];
+
+const esm = [
+  {
+    input,
+    output: { file: `esm/history.js`, format: 'esm' },
+    external,
+    plugins: [
+      babel({
+        exclude: /node_modules/,
+        runtimeHelpers: true,
+        plugins: [['@babel/transform-runtime', { useESModules: true }]]
+      }),
+      sizeSnapshot()
+    ]
+  }
+];
+
+const umd = [
+  {
+    input,
+    output: { file: `umd/history.js`, format: 'umd', name: globalName },
+    plugins: [
+      babel({
+        exclude: /node_modules/,
+        runtimeHelpers: true,
+        plugins: [['@babel/transform-runtime', { useESModules: true }]]
+      }),
+      nodeResolve(),
+      commonjs({ include: /node_modules/ }),
+      replace({ 'process.env.NODE_ENV': JSON.stringify('development') }),
+      sizeSnapshot()
+    ]
+  },
+  {
+    input,
+    output: { file: `umd/history.min.js`, format: 'umd', name: globalName },
+    plugins: [
+      babel({
+        exclude: /node_modules/,
+        runtimeHelpers: true,
+        plugins: [['@babel/transform-runtime', { useESModules: true }]]
+      }),
+      nodeResolve(),
+      commonjs({ include: /node_modules/ }),
+      replace({ 'process.env.NODE_ENV': JSON.stringify('production') }),
+      sizeSnapshot(),
+      uglify()
+    ]
+  }
+];
+
+let config;
+switch (process.env.BUILD_ENV) {
+  case 'cjs':
+    config = cjs;
+    break;
+  case 'esm':
+    config = esm;
+    break;
+  case 'umd':
+    config = umd;
+    break;
+  default:
+    config = cjs.concat(esm).concat(umd);
+}
+
+export default config;

--- a/app/ui-react/packages/history/tests.webpack.js
+++ b/app/ui-react/packages/history/tests.webpack.js
@@ -1,0 +1,2 @@
+var context = require.context('./modules', true, /-test\.js$/);
+context.keys().forEach(context);

--- a/app/ui-react/packages/history/warnAboutDeprecatedCJSRequire.js
+++ b/app/ui-react/packages/history/warnAboutDeprecatedCJSRequire.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var printWarning = function() {};
+
+if (process.env.NODE_ENV !== 'production') {
+  printWarning = function(format, subs) {
+    var index = 0;
+    var message =
+      'Warning: ' +
+      (subs.length > 0
+        ? format.replace(/%s/g, function() {
+            return subs[index++];
+          })
+        : format);
+
+    if (typeof console !== 'undefined') {
+      console.error(message);
+    }
+
+    try {
+      // --- Welcome to debugging history ---
+      // This error was thrown as a convenience so that you can use the
+      // stack trace to find the callsite that triggered this warning.
+      throw new Error(message);
+    } catch (e) {}
+  };
+}
+
+module.exports = function(member) {
+  printWarning(
+    'Please use `require("history").%s` instead of `require("history/%s")`. ' +
+      'Support for the latter will be removed in the next major release.',
+    [member, member]
+  );
+};

--- a/app/ui-react/packages/ui/package.json
+++ b/app/ui-react/packages/ui/package.json
@@ -74,8 +74,8 @@
   "dependencies": {
     "@patternfly/patternfly": "^2.3.2",
     "@patternfly/react-core": "^3.2.3",
+    "@syndesis/history": "*",
     "classnames": "^2.2.6",
-    "history": "^4.7.2",
     "react-dropzone": "^10.0.0",
     "react-virtualized": "^9.20.1"
   },

--- a/app/ui-react/packages/ui/src/Connection/ConnectionCard.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionCard.tsx
@@ -1,5 +1,5 @@
 import { Text, Title } from '@patternfly/react-core';
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import { Card, DropdownKebab } from 'patternfly-react';
 import * as React from 'react';
 import { Link } from 'react-router-dom';

--- a/app/ui-react/packages/ui/src/Connection/ConnectionCreatorLayout.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionCreatorLayout.tsx
@@ -1,7 +1,7 @@
 // tslint:disable react-unused-props-and-state
 // remove the above line after this goes GA https://github.com/Microsoft/tslint-microsoft-contrib/pull/824
+import * as H from '@syndesis/history';
 import classnames from 'classnames';
-import * as H from 'history';
 import * as React from 'react';
 import { ButtonLink, Loader } from '../Layout';
 

--- a/app/ui-react/packages/ui/src/Connection/ConnectionsListView.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionsListView.tsx
@@ -1,4 +1,4 @@
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import * as React from 'react';
 import { ButtonLink, Container } from '../Layout';
 import { IListViewToolbarProps, ListViewToolbar } from '../Shared';

--- a/app/ui-react/packages/ui/src/Customization/ExtensionDetail.tsx
+++ b/app/ui-react/packages/ui/src/Customization/ExtensionDetail.tsx
@@ -1,5 +1,5 @@
 import { Title, TitleLevel } from '@patternfly/react-core';
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import {
   Button,
   Card,

--- a/app/ui-react/packages/ui/src/Customization/ExtensionImportReview.tsx
+++ b/app/ui-react/packages/ui/src/Customization/ExtensionImportReview.tsx
@@ -1,4 +1,4 @@
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import { Button, Grid } from 'patternfly-react';
 import * as React from 'react';
 import { ButtonLink, Container } from '../Layout';

--- a/app/ui-react/packages/ui/src/Customization/ExtensionListItem.tsx
+++ b/app/ui-react/packages/ui/src/Customization/ExtensionListItem.tsx
@@ -1,4 +1,4 @@
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import {
   Button,
   ListViewInfoItem,

--- a/app/ui-react/packages/ui/src/Customization/ExtensionListView.tsx
+++ b/app/ui-react/packages/ui/src/Customization/ExtensionListView.tsx
@@ -1,5 +1,5 @@
 import { Text, Title } from '@patternfly/react-core';
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import {
   EmptyState,
   ListView,

--- a/app/ui-react/packages/ui/src/Dashboard/Dashboard.tsx
+++ b/app/ui-react/packages/ui/src/Dashboard/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { Title } from '@patternfly/react-core';
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import { CardGrid, Grid } from 'patternfly-react';
 import * as React from 'react';
 import { Link } from 'react-router-dom';

--- a/app/ui-react/packages/ui/src/Data/DvConnection/DvConnectionsListView.tsx
+++ b/app/ui-react/packages/ui/src/Data/DvConnection/DvConnectionsListView.tsx
@@ -1,4 +1,4 @@
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import * as React from 'react';
 import { ButtonLink, Container } from '../../Layout';
 import { IListViewToolbarProps, ListViewToolbar } from '../../Shared';

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ViewList.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ViewList.tsx
@@ -1,4 +1,4 @@
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import {
   EmptyState,
   ListView,

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ViewsCreateLayout.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ViewsCreateLayout.tsx
@@ -1,7 +1,7 @@
 // tslint:disable react-unused-props-and-state
 // remove the above line after this goes GA https://github.com/Microsoft/tslint-microsoft-contrib/pull/824
+import * as H from '@syndesis/history';
 import classnames from 'classnames';
-import * as H from 'history';
 import * as React from 'react';
 import { ButtonLink, Loader } from '../../../Layout';
 import './ViewsCreateLayout.css';

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationList.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationList.tsx
@@ -1,4 +1,4 @@
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import {
   Button,
   EmptyState,

--- a/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationListItem.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/VirtualizationListItem.tsx
@@ -1,4 +1,4 @@
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import {
   //  Button,
   DropdownKebab,

--- a/app/ui-react/packages/ui/src/Integration/CiCd/TagIntegrationDialogBody.tsx
+++ b/app/ui-react/packages/ui/src/Integration/CiCd/TagIntegrationDialogBody.tsx
@@ -1,4 +1,4 @@
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import * as React from 'react';
 import { CiCdList } from './CiCdList';
 import { ITagIntegrationEntry } from './CiCdUIModels';

--- a/app/ui-react/packages/ui/src/Integration/CiCd/TagIntegrationDialogEmptyState.tsx
+++ b/app/ui-react/packages/ui/src/Integration/CiCd/TagIntegrationDialogEmptyState.tsx
@@ -1,4 +1,4 @@
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import { EmptyState } from 'patternfly-react';
 import * as React from 'react';
 import { ButtonLink } from '../../Layout';

--- a/app/ui-react/packages/ui/src/Integration/IntegrationActions.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationActions.tsx
@@ -1,4 +1,4 @@
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import { DropdownKebab } from 'patternfly-react';
 import * as React from 'react';
 import { Link } from 'react-router-dom';

--- a/app/ui-react/packages/ui/src/Integration/IntegrationDetailBreadcrumb.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationDetailBreadcrumb.tsx
@@ -1,5 +1,5 @@
 import { Level, LevelItem } from '@patternfly/react-core';
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import { DropdownKebab } from 'patternfly-react';
 import * as React from 'react';
 import { Link } from 'react-router-dom';

--- a/app/ui-react/packages/ui/src/Integration/IntegrationDetailHistoryListView.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationDetailHistoryListView.tsx
@@ -1,4 +1,4 @@
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import { Grid, ListView, ListViewItem } from 'patternfly-react';
 import * as React from 'react';
 import { ButtonLink } from '../Layout';

--- a/app/ui-react/packages/ui/src/Integration/IntegrationEditorLayout.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationEditorLayout.tsx
@@ -1,7 +1,7 @@
 // tslint:disable react-unused-props-and-state
 // remove the above line after this goes GA https://github.com/Microsoft/tslint-microsoft-contrib/pull/824
+import * as H from '@syndesis/history';
 import classnames from 'classnames';
-import * as H from 'history';
 import * as React from 'react';
 import { ButtonLink, Loader } from '../Layout';
 import './IntegrationEditorLayout.css';

--- a/app/ui-react/packages/ui/src/Integration/IntegrationFlowAddStep.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationFlowAddStep.tsx
@@ -1,4 +1,4 @@
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import './IntegrationFlowAddStep.css';

--- a/app/ui-react/packages/ui/src/Integration/IntegrationsListView.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationsListView.tsx
@@ -1,4 +1,4 @@
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import * as React from 'react';
 import { ButtonLink, Container } from '../Layout';
 import { IListViewToolbarProps, ListViewToolbar } from '../Shared';

--- a/app/ui-react/packages/ui/src/Layout/ButtonLink.tsx
+++ b/app/ui-react/packages/ui/src/Layout/ButtonLink.tsx
@@ -1,7 +1,7 @@
 // tslint:disable react-unused-props-and-state
 // remove the above line after this goes GA https://github.com/Microsoft/tslint-microsoft-contrib/pull/824
+import * as H from '@syndesis/history';
 import classnames from 'classnames';
-import * as H from 'history';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 

--- a/app/ui-react/packages/ui/src/Layout/PfNavLink.tsx
+++ b/app/ui-react/packages/ui/src/Layout/PfNavLink.tsx
@@ -1,4 +1,4 @@
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import * as React from 'react';
 import { Route } from 'react-router';
 import { Link } from 'react-router-dom';

--- a/app/ui-react/packages/ui/src/Layout/TabBarItem.tsx
+++ b/app/ui-react/packages/ui/src/Layout/TabBarItem.tsx
@@ -1,6 +1,6 @@
 // tslint:disable react-unused-props-and-state
 // remove the above line after this goes GA https://github.com/Microsoft/tslint-microsoft-contrib/pull/824
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import * as React from 'react';
 import { PfNavLink } from './PfNavLink';
 

--- a/app/ui-react/packages/ui/src/Shared/models.ts
+++ b/app/ui-react/packages/ui/src/Shared/models.ts
@@ -1,4 +1,4 @@
-import * as H from 'history';
+import * as H from '@syndesis/history';
 import * as React from 'react';
 
 /**

--- a/app/ui-react/syndesis/package.json
+++ b/app/ui-react/syndesis/package.json
@@ -10,7 +10,7 @@
     "@syndesis/models": "*",
     "@syndesis/ui": "*",
     "@syndesis/utils": "*",
-    "history": "^4.7.2",
+    "@syndesis/history": "*",
     "http-proxy-middleware": "^0.19.1",
     "i18next": "^15.0.4",
     "i18next-browser-languagedetector": "^3.0.1",

--- a/app/ui-react/syndesis/src/index.tsx
+++ b/app/ui-react/syndesis/src/index.tsx
@@ -3,12 +3,13 @@ import {
   ServerEventsContext,
   WithServerEvents,
 } from '@syndesis/api';
+import { createBrowserHistory } from '@syndesis/history';
 import { Loader, UnrecoverableError } from '@syndesis/ui';
 import { WithLoader } from '@syndesis/utils';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { I18nextProvider, Translation } from 'react-i18next';
-import { BrowserRouter as Router } from 'react-router-dom';
+import { Router } from 'react-router-dom';
 import { App } from './app';
 import { WithConfig } from './app/WithConfig';
 import i18n from './i18n';
@@ -22,7 +23,7 @@ import { SettingsModule } from './modules/settings';
 import registerServiceWorker from './registerServiceWorker';
 
 ReactDOM.render(
-  <Router>
+  <Router history={createBrowserHistory()}>
     <I18nextProvider i18n={i18n}>
       <WithConfig>
         {({ config, loading, error }) => (

--- a/app/ui-react/syndesis/src/modules/connections/components/Connections.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/components/Connections.tsx
@@ -1,4 +1,5 @@
 import { getConnectionIcon, WithConnectionHelpers } from '@syndesis/api';
+import * as H from '@syndesis/history';
 import { Connection } from '@syndesis/models';
 import {
   ConnectionCard,
@@ -7,7 +8,6 @@ import {
   ConnectionSkeleton,
 } from '@syndesis/ui';
 import { WithLoader } from '@syndesis/utils';
-import * as H from 'history';
 import * as React from 'react';
 import { Translation } from 'react-i18next';
 import { UIContext } from '../../../app';

--- a/app/ui-react/syndesis/src/modules/integrations/components/IntegrationEditorStepAdder.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/IntegrationEditorStepAdder.tsx
@@ -1,4 +1,5 @@
 import { getStepIcon } from '@syndesis/api';
+import * as H from '@syndesis/history';
 import { Step } from '@syndesis/models';
 import {
   ButtonLink,
@@ -6,7 +7,6 @@ import {
   IntegrationEditorStepsListItem,
   IntegrationFlowAddStep,
 } from '@syndesis/ui';
-import * as H from 'history';
 import * as React from 'react';
 
 export interface IIntegrationEditorStepAdderProps {

--- a/app/ui-react/syndesis/src/modules/integrations/components/TagIntegrationDialogWrapper.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/TagIntegrationDialogWrapper.tsx
@@ -1,4 +1,5 @@
 import { WithEnvironments, WithIntegrationTags } from '@syndesis/api';
+import * as H from '@syndesis/history';
 import {
   CiCdList,
   CiCdListSkeleton,
@@ -7,7 +8,6 @@ import {
   TagIntegrationDialogBody,
 } from '@syndesis/ui';
 import { WithLoader } from '@syndesis/utils';
-import * as H from 'history';
 import * as React from 'react';
 import { Translation } from 'react-i18next';
 import { ApiError } from '../../../shared';

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
@@ -1,8 +1,8 @@
 import { getSteps } from '@syndesis/api';
+import * as H from '@syndesis/history';
 import { Step } from '@syndesis/models';
 import { Container, IntegrationEditorLayout } from '@syndesis/ui';
 import { WithRouteData } from '@syndesis/utils';
-import * as H from 'history';
 import * as React from 'react';
 import { PageTitle } from '../../../../shared';
 import { IntegrationEditorStepAdder } from '../IntegrationEditorStepAdder';

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/SaveIntegrationPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/SaveIntegrationPage.tsx
@@ -1,9 +1,9 @@
 import { setIntegrationName, WithIntegrationHelpers } from '@syndesis/api';
 import { AutoForm, IFormDefinition } from '@syndesis/auto-form';
+import * as H from '@syndesis/history';
 import { Integration } from '@syndesis/models';
 import { IntegrationEditorForm, IntegrationEditorLayout } from '@syndesis/ui';
 import { WithRouteData } from '@syndesis/utils';
-import * as H from 'history';
 import * as React from 'react';
 import { PageTitle } from '../../../../shared';
 import {

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/SelectConnectionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/SelectConnectionPage.tsx
@@ -6,6 +6,7 @@ import {
   WithExtensions,
   WithSteps,
 } from '@syndesis/api';
+import * as H from '@syndesis/history';
 import { Step, StepKind } from '@syndesis/models';
 import {
   ButtonLink,
@@ -15,7 +16,6 @@ import {
   IntegrationsListSkeleton,
 } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
-import * as H from 'history';
 import * as React from 'react';
 import { ApiError, PageTitle } from '../../../../shared';
 import {

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigureActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigureActionPage.tsx
@@ -1,8 +1,8 @@
 import { getSteps, WithIntegrationHelpers } from '@syndesis/api';
+import * as H from '@syndesis/history';
 import { Connection, Integration, Step } from '@syndesis/models';
 import { IntegrationEditorLayout } from '@syndesis/ui';
 import { WithRouteData } from '@syndesis/utils';
-import * as H from 'history';
 import * as React from 'react';
 import { PageTitle } from '../../../../../shared';
 import {

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/SelectActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/SelectActionPage.tsx
@@ -1,4 +1,5 @@
 import { getSteps, WithConnection } from '@syndesis/api';
+import * as H from '@syndesis/history';
 import { IConnectionWithIconFile, Step } from '@syndesis/models';
 import {
   ButtonLink,
@@ -8,7 +9,6 @@ import {
   Loader,
 } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
-import * as H from 'history';
 import * as React from 'react';
 import { ApiError, PageTitle } from '../../../../../shared';
 import {

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
@@ -3,13 +3,13 @@ import {
   getExtensionIcon,
   getStepKindIcon,
 } from '@syndesis/api';
+import * as H from '@syndesis/history';
 import {
   ConnectionOverview,
   Extension,
   Step,
   StepKind,
 } from '@syndesis/models';
-import * as H from 'history';
 import { IAddStepPageProps } from './AddStepPage';
 import {
   ISelectConnectionRouteParams,

--- a/app/ui-react/typings/syndesis__history/DOMUtils.d.ts
+++ b/app/ui-react/typings/syndesis__history/DOMUtils.d.ts
@@ -1,0 +1,13 @@
+declare global {
+    // Some users of this package are don't use "dom" libs
+    interface EventTarget {}
+    interface EventListener {}
+    interface EventListenerObject {}
+}
+
+export const isExtraneousPopstateEvent: boolean;
+export function addEventListener(node: EventTarget, event: string, listener: EventListener | EventListenerObject): void;
+export function removeEventListener(node: EventTarget, event: string, listener: EventListener | EventListenerObject): void;
+export function getConfirmation(message: string, callback: (result: boolean) => void): void;
+export function supportsHistory(): boolean;
+export function supportsGoWithoutReloadUsingHash(): boolean;

--- a/app/ui-react/typings/syndesis__history/ExecutionEnvironment.d.ts
+++ b/app/ui-react/typings/syndesis__history/ExecutionEnvironment.d.ts
@@ -1,0 +1,1 @@
+export const canUseDOM: boolean;

--- a/app/ui-react/typings/syndesis__history/LICENSE
+++ b/app/ui-react/typings/syndesis__history/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation. All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/app/ui-react/typings/syndesis__history/LocationUtils.d.ts
+++ b/app/ui-react/typings/syndesis__history/LocationUtils.d.ts
@@ -1,0 +1,4 @@
+import { Path, LocationState, LocationKey, Location, LocationDescriptor } from './index';
+
+export function locationsAreEqual(lv: LocationDescriptor, rv: LocationDescriptor): boolean;
+export function createLocation(path: LocationDescriptor, state?: LocationState, key?: LocationKey, currentLocation?: Location): Location;

--- a/app/ui-react/typings/syndesis__history/PathUtils.d.ts
+++ b/app/ui-react/typings/syndesis__history/PathUtils.d.ts
@@ -1,0 +1,9 @@
+import { Path, Location, LocationDescriptorObject } from './index';
+
+export function addLeadingSlash(path: Path): Path;
+export function stripLeadingSlash(path: Path): Path;
+export function hasBasename(path: Path): boolean;
+export function stripBasename(path: Path, prefix: string): Path;
+export function stripTrailingSlash(path: Path): Path;
+export function parsePath(path: Path): Location;
+export function createPath(location: LocationDescriptorObject): Path;

--- a/app/ui-react/typings/syndesis__history/README.md
+++ b/app/ui-react/typings/syndesis__history/README.md
@@ -1,0 +1,16 @@
+# Installation
+> `npm install --save @types/history`
+
+# Summary
+This package contains type definitions for history (https://github.com/mjackson/history).
+
+# Details
+Files were exported from https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/history
+
+Additional Details
+ * Last updated: Wed, 17 Oct 2018 20:11:23 GMT
+ * Dependencies: none
+ * Global values: History
+
+# Credits
+These definitions were written by Sergey Buturlakin <https://github.com/sergey-buturlakin>, Nathan Brown <https://github.com/ngbrown>, Young Rok Kim <https://github.com/rokoroku>.

--- a/app/ui-react/typings/syndesis__history/createBrowserHistory.d.ts
+++ b/app/ui-react/typings/syndesis__history/createBrowserHistory.d.ts
@@ -1,0 +1,11 @@
+import { History } from './index';
+import { getConfirmation } from './DOMUtils';
+
+export interface BrowserHistoryBuildOptions {
+  basename?: string;
+  forceRefresh?: boolean;
+  getUserConfirmation?: typeof getConfirmation;
+  keyLength?: number;
+}
+
+export default function createBrowserHistory(options?: BrowserHistoryBuildOptions): History;

--- a/app/ui-react/typings/syndesis__history/createHashHistory.d.ts
+++ b/app/ui-react/typings/syndesis__history/createHashHistory.d.ts
@@ -1,0 +1,12 @@
+import { History } from './index';
+import { getConfirmation } from './DOMUtils';
+
+export type HashType = 'hashbang' | 'noslash' | 'slash';
+
+export interface HashHistoryBuildOptions {
+  basename?: string;
+  hashType?: HashType;
+  getUserConfirmation?: typeof getConfirmation;
+}
+
+export default function createHashHistory(options?: HashHistoryBuildOptions): History;

--- a/app/ui-react/typings/syndesis__history/createMemoryHistory.d.ts
+++ b/app/ui-react/typings/syndesis__history/createMemoryHistory.d.ts
@@ -1,0 +1,17 @@
+import { History, Location, LocationState } from './index';
+import { getConfirmation } from './DOMUtils';
+
+export interface MemoryHistoryBuildOptions {
+  getUserConfirmation?: typeof getConfirmation;
+  initialEntries?: string[];
+  initialIndex?: number;
+  keyLength?: number;
+}
+
+export interface MemoryHistory<HistoryLocationState = LocationState> extends History<HistoryLocationState> {
+  index: number;
+  entries: Location<HistoryLocationState>[];
+  canGo(n: number): boolean;
+}
+
+export default function createMemoryHistory(options?: MemoryHistoryBuildOptions): MemoryHistory;

--- a/app/ui-react/typings/syndesis__history/createTransitionManager.d.ts
+++ b/app/ui-react/typings/syndesis__history/createTransitionManager.d.ts
@@ -1,0 +1,15 @@
+import { Location, Action, LocationListener, UnregisterCallback } from './index';
+import { getConfirmation } from './DOMUtils';
+
+export type PromptFunction = (location: Location, action: Action) => any;
+
+export type Prompt = PromptFunction | boolean;
+
+export interface TransitionManager {
+  setPrompt(nextPrompt?: Prompt): UnregisterCallback;
+  appendListener(listener: LocationListener): UnregisterCallback;
+  notifyListeners(location: Location, action: Action): void;
+  confirmTransitionTo(location: Location, action: Action, getUserConfirmation: typeof getConfirmation, callback: (result: boolean) => void): void;
+}
+
+export default function createTransitionManager(): TransitionManager;

--- a/app/ui-react/typings/syndesis__history/index.d.ts
+++ b/app/ui-react/typings/syndesis__history/index.d.ts
@@ -1,0 +1,93 @@
+// Type definitions for history 4.7.2
+// Project: https://github.com/mjackson/history
+// Definitions by: Sergey Buturlakin <https://github.com/sergey-buturlakin>, Nathan Brown <https://github.com/ngbrown>, Young Rok Kim <https://github.com/rokoroku>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.3
+export as namespace History;
+
+export type Action = 'PUSH' | 'POP' | 'REPLACE';
+export type UnregisterCallback = () => void;
+
+export interface History<HistoryLocationState = LocationState> {
+    length: number;
+    action: Action;
+    location: Location<HistoryLocationState>;
+    push(path: Path, state?: HistoryLocationState): void;
+    push(location: LocationDescriptorObject<HistoryLocationState>): void;
+    replace(path: Path, state?: HistoryLocationState): void;
+    replace(location: LocationDescriptorObject<HistoryLocationState>): void;
+    go(n: number): void;
+    goBack(): void;
+    goForward(): void;
+    block(prompt?: boolean | string | TransitionPromptHook): UnregisterCallback;
+    listen(listener: LocationListener): UnregisterCallback;
+    createHref(location: LocationDescriptorObject<HistoryLocationState>): Href;
+}
+
+export interface Location<S = LocationState> {
+    pathname: Pathname;
+    search: Search;
+    state: S;
+    hash: Hash;
+    key?: LocationKey;
+}
+
+export interface LocationDescriptorObject<S = LocationState> {
+    pathname?: Pathname;
+    search?: Search;
+    state?: S;
+    hash?: Hash;
+    key?: LocationKey;
+}
+
+export namespace History {
+    export type LocationDescriptor<S = LocationState> = Path | LocationDescriptorObject<S>;
+    export type LocationKey = string;
+    export type LocationListener = (location: Location, action: Action) => void;
+    export type LocationState = any;
+    export type Path = string;
+    export type Pathname = string;
+    export type Search = string;
+    export type TransitionHook = (location: Location, callback: (result: any) => void) => any;
+    export type TransitionPromptHook = (location: Location, action: Action) => string | false | void;
+    export type Hash = string;
+    export type Href = string;
+}
+
+export type LocationDescriptor<S = LocationState> = History.LocationDescriptor<S>;
+export type LocationKey = History.LocationKey;
+export type LocationListener = History.LocationListener;
+export type LocationState = History.LocationState;
+export type Path = History.Path;
+export type Pathname = History.Pathname;
+export type Search = History.Search;
+export type TransitionHook = History.TransitionHook;
+export type TransitionPromptHook = History.TransitionPromptHook;
+export type Hash = History.Hash;
+export type Href = History.Href;
+
+import { default as createBrowserHistory } from "./createBrowserHistory";
+import { default as createHashHistory } from "./createHashHistory";
+import { default as createMemoryHistory } from "./createMemoryHistory";
+import { createLocation, locationsAreEqual } from "./LocationUtils";
+import { parsePath, createPath } from "./PathUtils";
+
+// Global usage, without modules, needs the small trick, because lib.d.ts
+// already has `history` and `History` global definitions:
+// var createHistory = ((window as any).History as HistoryModule.Module).createHistory;
+export interface Module {
+    createBrowserHistory: typeof createBrowserHistory;
+    createHashHistory: typeof createHashHistory;
+    createMemoryHistory: typeof createMemoryHistory;
+    createLocation: typeof createLocation;
+    locationsAreEqual: typeof locationsAreEqual;
+    parsePath: typeof parsePath;
+    createPath: typeof createPath;
+}
+
+export * from "./createBrowserHistory";
+export * from "./createHashHistory";
+export * from "./createMemoryHistory";
+export { createLocation, locationsAreEqual } from "./LocationUtils";
+export { parsePath, createPath } from "./PathUtils";
+export { createBrowserHistory, createHashHistory, createMemoryHistory };

--- a/app/ui-react/typings/syndesis__history/package.json
+++ b/app/ui-react/typings/syndesis__history/package.json
@@ -1,0 +1,33 @@
+{
+    "name": "@types/syndesis__history",
+    "version": "4.7.2",
+    "description": "TypeScript definitions for history",
+    "license": "MIT",
+    "contributors": [
+        {
+            "name": "Sergey Buturlakin",
+            "url": "https://github.com/sergey-buturlakin",
+            "githubUsername": "sergey-buturlakin"
+        },
+        {
+            "name": "Nathan Brown",
+            "url": "https://github.com/ngbrown",
+            "githubUsername": "ngbrown"
+        },
+        {
+            "name": "Young Rok Kim",
+            "url": "https://github.com/rokoroku",
+            "githubUsername": "rokoroku"
+        }
+    ],
+    "main": "",
+    "types": "",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git"
+    },
+    "scripts": {},
+    "dependencies": {},
+    "typesPublisherContentHash": "9bac9cf00de12a18142d3f0f2e139428d84788981932c17479eb52abc54baff1",
+    "typeScriptVersion": "2.3"
+}

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -239,11 +239,42 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/core@^7.1.2":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.4.tgz#84055750b05fcd50f9915a826b44fa347a825250"
+  integrity sha512-lQgGX3FPRgbz2SKmhMtYgJvVzGZrmjaF4apZ2bLwofAKiSjxU0drPh4S/VasyYXwaTs+A1gvQ45BN8SQJzHsQQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.4.4"
+    "@babel/helpers" "^7.4.4"
+    "@babel/parser" "^7.4.4"
+    "@babel/template" "^7.4.4"
+    "@babel/traverse" "^7.4.4"
+    "@babel/types" "^7.4.4"
+    convert-source-map "^1.1.0"
+    debug "^4.1.0"
+    json5 "^2.1.0"
+    lodash "^4.17.11"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.0.0", "@babel/generator@^7.2.2", "@babel/generator@^7.3.4":
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.3.4.tgz#9aa48c1989257877a9d971296e5b73bfe72e446e"
   dependencies:
     "@babel/types" "^7.3.4"
+    jsesc "^2.5.1"
+    lodash "^4.17.11"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+"@babel/generator@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.4.4.tgz#174a215eb843fc392c7edcaabeaa873de6e8f041"
+  integrity sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==
+  dependencies:
+    "@babel/types" "^7.4.4"
     jsesc "^2.5.1"
     lodash "^4.17.11"
     source-map "^0.5.0"
@@ -277,6 +308,15 @@
     "@babel/traverse" "^7.1.0"
     "@babel/types" "^7.0.0"
 
+"@babel/helper-call-delegate@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz#87c1f8ca19ad552a736a7a27b1c1fcf8b1ff1f43"
+  integrity sha512-l79boDFJ8S1c5hvQvG+rc+wHw6IuH7YldmRKsYtpbawsxURu/paVy57FZMomGK22/JckepaikOkY0MoAmdyOlQ==
+  dependencies:
+    "@babel/helper-hoist-variables" "^7.4.4"
+    "@babel/traverse" "^7.4.4"
+    "@babel/types" "^7.4.4"
+
 "@babel/helper-create-class-features-plugin@^7.2.1", "@babel/helper-create-class-features-plugin@^7.3.0", "@babel/helper-create-class-features-plugin@^7.3.4":
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.3.4.tgz#092711a7a3ad8ea34de3e541644c2ce6af1f6f0c"
@@ -295,6 +335,15 @@
     "@babel/helper-function-name" "^7.1.0"
     "@babel/types" "^7.0.0"
     lodash "^4.17.10"
+
+"@babel/helper-define-map@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-map/-/helper-define-map-7.4.4.tgz#6969d1f570b46bdc900d1eba8e5d59c48ba2c12a"
+  integrity sha512-IX3Ln8gLhZpSuqHJSnTNBWGDE9kdkTEWl21A/K7PQ00tseBwbqCHTvNLHSBd9M0R5rER4h5Rsvj9vw0R5SieBg==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/types" "^7.4.4"
+    lodash "^4.17.11"
 
 "@babel/helper-explode-assignable-expression@^7.1.0":
   version "7.1.0"
@@ -323,6 +372,13 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
+"@babel/helper-hoist-variables@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.4.tgz#0298b5f25c8c09c53102d52ac4a98f773eb2850a"
+  integrity sha512-VYk2/H/BnYbZDDg39hr3t2kKyifAm1W6zHRfhx8jGjIHpQEBv9dry7oQ2f3+J703TLu69nYdxsovl0XYfcnK4w==
+  dependencies:
+    "@babel/types" "^7.4.4"
+
 "@babel/helper-member-expression-to-functions@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0.tgz#8cd14b0a0df7ff00f009e7d7a436945f47c7a16f"
@@ -346,6 +402,18 @@
     "@babel/types" "^7.2.2"
     lodash "^4.17.10"
 
+"@babel/helper-module-transforms@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.4.4.tgz#96115ea42a2f139e619e98ed46df6019b94414b8"
+  integrity sha512-3Z1yp8TVQf+B4ynN7WoHPKS8EkdTbgAEy0nU0rs/1Kw4pDgmvYH3rz3aI11KgxKCba2cn7N+tqzV1mY2HMN96w==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-simple-access" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/template" "^7.4.4"
+    "@babel/types" "^7.4.4"
+    lodash "^4.17.11"
+
 "@babel/helper-optimise-call-expression@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz#a2920c5702b073c15de51106200aa8cad20497d5"
@@ -361,6 +429,13 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.0.0.tgz#2c1718923b57f9bbe64705ffe5640ac64d9bdb27"
   dependencies:
     lodash "^4.17.10"
+
+"@babel/helper-regex@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.4.4.tgz#a47e02bc91fb259d2e6727c2a30013e3ac13c4a2"
+  integrity sha512-Y5nuB/kESmR3tKjU8Nkn1wMGEx1tjJX076HBMeL3XLQCu6vA/YRzuTW0bbb+qRnXvQGn+d6Rx953yffl8vEy7Q==
+  dependencies:
+    lodash "^4.17.11"
 
 "@babel/helper-remap-async-to-generator@^7.1.0":
   version "7.1.0"
@@ -381,6 +456,16 @@
     "@babel/traverse" "^7.3.4"
     "@babel/types" "^7.3.4"
 
+"@babel/helper-replace-supers@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.4.4.tgz#aee41783ebe4f2d3ab3ae775e1cc6f1a90cefa27"
+  integrity sha512-04xGEnd+s01nY1l15EuMS1rfKktNF+1CkKmHoErDppjAAZL+IUBZpzT748x262HF7fibaQPhbvWUl5HeSt1EXg==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.0.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/traverse" "^7.4.4"
+    "@babel/types" "^7.4.4"
+
 "@babel/helper-simple-access@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz#65eeb954c8c245beaa4e859da6188f39d71e585c"
@@ -393,6 +478,13 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz#3aae285c0311c2ab095d997b8c9a94cad547d813"
   dependencies:
     "@babel/types" "^7.0.0"
+
+"@babel/helper-split-export-declaration@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz#ff94894a340be78f53f06af038b205c49d993677"
+  integrity sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==
+  dependencies:
+    "@babel/types" "^7.4.4"
 
 "@babel/helper-wrap-function@^7.1.0":
   version "7.2.0"
@@ -411,6 +503,15 @@
     "@babel/traverse" "^7.1.5"
     "@babel/types" "^7.3.0"
 
+"@babel/helpers@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.4.4.tgz#868b0ef59c1dd4e78744562d5ce1b59c89f2f2a5"
+  integrity sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==
+  dependencies:
+    "@babel/template" "^7.4.4"
+    "@babel/traverse" "^7.4.4"
+    "@babel/types" "^7.4.4"
+
 "@babel/highlight@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
@@ -426,6 +527,11 @@
 "@babel/parser@^7.1.0":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.3.tgz#eb3ac80f64aa101c907d4ce5406360fe75b7895b"
+
+"@babel/parser@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.4.tgz#5977129431b8fe33471730d255ce8654ae1250b6"
+  integrity sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==
 
 "@babel/plugin-proposal-async-generator-functions@^7.2.0":
   version "7.2.0"
@@ -485,6 +591,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
 
+"@babel/plugin-proposal-object-rest-spread@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz#1ef173fcf24b3e2df92a678f027673b55e7e3005"
+  integrity sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+
 "@babel/plugin-proposal-optional-catch-binding@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.2.0.tgz#135d81edb68a081e55e56ec48541ece8065c38f5"
@@ -499,6 +613,15 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-regex" "^7.0.0"
     regexpu-core "^4.2.0"
+
+"@babel/plugin-proposal-unicode-property-regex@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz#501ffd9826c0b91da22690720722ac7cb1ca9c78"
+  integrity sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.4.4"
+    regexpu-core "^4.5.4"
 
 "@babel/plugin-syntax-async-generators@^7.2.0":
   version "7.2.0"
@@ -568,6 +691,15 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-remap-async-to-generator" "^7.1.0"
 
+"@babel/plugin-transform-async-to-generator@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.4.tgz#a3f1d01f2f21cadab20b33a82133116f14fb5894"
+  integrity sha512-YiqW2Li8TXmzgbXw+STsSqPBPFnGviiaSp6CYOq55X8GQ2SGVLrXB6pNid8HkqkZAzOH6knbai3snhP7v0fNwA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-remap-async-to-generator" "^7.1.0"
+
 "@babel/plugin-transform-block-scoped-functions@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz#5d3cc11e8d5ddd752aa64c9148d0db6cb79fd190"
@@ -577,6 +709,14 @@
 "@babel/plugin-transform-block-scoping@^7.2.0", "@babel/plugin-transform-block-scoping@^7.3.4":
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.3.4.tgz#5c22c339de234076eee96c8783b2fed61202c5c4"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    lodash "^4.17.11"
+
+"@babel/plugin-transform-block-scoping@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.4.tgz#c13279fabf6b916661531841a23c4b7dae29646d"
+  integrity sha512-jkTUyWZcTrwxu5DD4rWz6rDB5Cjdmgz6z7M7RLXOJyCUkFBawssDGcGh8M/0FTSB87avyJI1HsTwUXp9nKA1PA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     lodash "^4.17.11"
@@ -607,6 +747,20 @@
     "@babel/helper-split-export-declaration" "^7.0.0"
     globals "^11.1.0"
 
+"@babel/plugin-transform-classes@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.4.tgz#0ce4094cdafd709721076d3b9c38ad31ca715eb6"
+  integrity sha512-/e44eFLImEGIpL9qPxSRat13I5QNRgBLu2hOQJCF7VLy/otSM/sypV1+XaIw5+502RX/+6YaSAPmldk+nhHDPw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-define-map" "^7.4.4"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.4.4"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    globals "^11.1.0"
+
 "@babel/plugin-transform-computed-properties@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.2.0.tgz#83a7df6a658865b1c8f641d510c6f3af220216da"
@@ -619,6 +773,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-transform-destructuring@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.4.tgz#9d964717829cc9e4b601fc82a26a71a4d8faf20f"
+  integrity sha512-/aOx+nW0w8eHiEHm+BTERB2oJn5D127iye/SUQl7NjHy0lf+j7h4MKMMSOwdazGq9OxgiNADncE+SRJkCxjZpQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-transform-dotall-regex@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.2.0.tgz#f0aabb93d120a8ac61e925ea0ba440812dbe0e49"
@@ -626,6 +787,15 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-regex" "^7.0.0"
     regexpu-core "^4.1.3"
+
+"@babel/plugin-transform-dotall-regex@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz#361a148bc951444312c69446d76ed1ea8e4450c3"
+  integrity sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.4.4"
+    regexpu-core "^4.5.4"
 
 "@babel/plugin-transform-duplicate-keys@^7.2.0":
   version "7.2.0"
@@ -660,6 +830,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-transform-for-of@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz#0267fc735e24c808ba173866c6c4d1440fc3c556"
+  integrity sha512-9T/5Dlr14Z9TIEXLXkt8T1DU7F24cbhwhMNUziN3hB1AXoZcdzPcTiKGRn/6iOymDqtTKWnr/BtRKN9JwbKtdQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-transform-function-name@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.2.0.tgz#f7930362829ff99a3174c39f0afcc024ef59731a"
@@ -667,9 +844,24 @@
     "@babel/helper-function-name" "^7.1.0"
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-transform-function-name@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.4.tgz#e1436116abb0610c2259094848754ac5230922ad"
+  integrity sha512-iU9pv7U+2jC9ANQkKeNF6DrPy4GBa4NWQtl6dHB4Pb3izX2JOEvDTFarlNsBj/63ZEzNNIAMs3Qw4fNCcSOXJA==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-transform-literals@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.2.0.tgz#690353e81f9267dad4fd8cfd77eafa86aba53ea1"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-member-expression-literals@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz#fa10aa5c58a2cb6afcf2c9ffa8cb4d8b3d489a2d"
+  integrity sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
@@ -688,11 +880,28 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-simple-access" "^7.1.0"
 
+"@babel/plugin-transform-modules-commonjs@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.4.tgz#0bef4713d30f1d78c2e59b3d6db40e60192cac1e"
+  integrity sha512-4sfBOJt58sEo9a2BQXnZq+Q3ZTSAUXyK3E30o36BOGnJ+tvJ6YSxF0PG6kERvbeISgProodWuI9UVG3/FMY6iw==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.4.4"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-simple-access" "^7.1.0"
+
 "@babel/plugin-transform-modules-systemjs@^7.2.0", "@babel/plugin-transform-modules-systemjs@^7.3.4":
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.3.4.tgz#813b34cd9acb6ba70a84939f3680be0eb2e58861"
   dependencies:
     "@babel/helper-hoist-variables" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-modules-systemjs@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.4.tgz#dc83c5665b07d6c2a7b224c00ac63659ea36a405"
+  integrity sha512-MSiModfILQc3/oqnG7NrP1jHaSPryO6tA2kOMmAQApz5dayPxWiHqmq4sWH2xF5LcQK56LlbKByCd8Aah/OIkQ==
+  dependencies:
+    "@babel/helper-hoist-variables" "^7.4.4"
     "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-transform-modules-umd@^7.2.0":
@@ -708,9 +917,30 @@
   dependencies:
     regexp-tree "^0.1.0"
 
+"@babel/plugin-transform-named-capturing-groups-regex@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.4.4.tgz#5611d96d987dfc4a3a81c4383bb173361037d68d"
+  integrity sha512-Ki+Y9nXBlKfhD+LXaRS7v95TtTGYRAf9Y1rTDiE75zf8YQz4GDaWRXosMfJBXxnk88mGFjWdCRIeqDbon7spYA==
+  dependencies:
+    regexp-tree "^0.1.0"
+
 "@babel/plugin-transform-new-target@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz#ae8fbd89517fa7892d20e6564e641e8770c3aa4a"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-new-target@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.4.tgz#18d120438b0cc9ee95a47f2c72bc9768fbed60a5"
+  integrity sha512-r1z3T2DNGQwwe2vPGZMBNjioT2scgWzK9BCnDEh+46z8EEwXBq24uRzd65I7pjtugzPSj921aM15RpESgzsSuA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-object-assign@^7.0.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.2.0.tgz#6fdeea42be17040f119e38e23ea0f49f31968bde"
+  integrity sha512-nmE55cZBPFgUktbF2OuoZgPRadfxosLOpSgzEPYotKSls9J4pEPcembi8r78RU37Rph6UApCpNmsQA4QMWK9Ng==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
@@ -727,6 +957,22 @@
   dependencies:
     "@babel/helper-call-delegate" "^7.1.0"
     "@babel/helper-get-function-arity" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-parameters@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.4.tgz#7556cf03f318bd2719fe4c922d2d808be5571e16"
+  integrity sha512-oMh5DUO1V63nZcu/ZVLQFqiihBGo4OpxJxR1otF50GMeCLiRx5nUdtokd+u9SuVJrvvuIh9OosRFPP4pIPnwmw==
+  dependencies:
+    "@babel/helper-call-delegate" "^7.4.4"
+    "@babel/helper-get-function-arity" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-transform-property-literals@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz#03e33f653f5b25c4eb572c98b9485055b389e905"
+  integrity sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==
+  dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/plugin-transform-react-constant-elements@7.2.0", "@babel/plugin-transform-react-constant-elements@^7.0.0", "@babel/plugin-transform-react-constant-elements@^7.2.0":
@@ -770,9 +1016,33 @@
   dependencies:
     regenerator-transform "^0.13.4"
 
+"@babel/plugin-transform-regenerator@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.4.tgz#5b4da4df79391895fca9e28f99e87e22cfc02072"
+  integrity sha512-Zz3w+pX1SI0KMIiqshFZkwnVGUhDZzpX2vtPzfJBKQQq8WsP/Xy9DNdELWivxcKOCX/Pywge4SiEaPaLtoDT4g==
+  dependencies:
+    regenerator-transform "^0.13.4"
+
+"@babel/plugin-transform-reserved-words@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.2.0.tgz#4792af87c998a49367597d07fedf02636d2e1634"
+  integrity sha512-fz43fqW8E1tAB3DKF19/vxbpib1fuyCwSPE418ge5ZxILnBhWyhtPgz8eh1RCGGJlwvksHkyxMxh0eenFi+kFw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-transform-runtime@7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz#566bc43f7d0aedc880eaddbd29168d0f248966ea"
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
+"@babel/plugin-transform-runtime@^7.1.0":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.4.tgz#a50f5d16e9c3a4ac18a1a9f9803c107c380bce08"
+  integrity sha512-aMVojEjPszvau3NRg+TIH14ynZLvPewH4xhlCW1w6A3rkxTS1m4uwzRclYR9oS+rl/dr+kT+pzbfHuAWP/lc7Q==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
@@ -805,6 +1075,14 @@
     "@babel/helper-annotate-as-pure" "^7.0.0"
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-transform-template-literals@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.4.4.tgz#9d28fea7bbce637fb7612a0750989d8321d4bcb0"
+  integrity sha512-mQrEC4TWkhLN0z8ygIvEL9ZEToPhG5K7KDW3pzGqOfIGZ28Jb0POUkeWcoz8HnHvhFy6dwAT1j8OzqN8s804+g==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-transform-typeof-symbol@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.2.0.tgz#117d2bcec2fbf64b4b59d1f9819894682d29f2b2"
@@ -825,6 +1103,15 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/helper-regex" "^7.0.0"
     regexpu-core "^4.1.3"
+
+"@babel/plugin-transform-unicode-regex@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz#ab4634bb4f14d36728bf5978322b35587787970f"
+  integrity sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-regex" "^7.4.4"
+    regexpu-core "^4.5.4"
 
 "@babel/polyfill@^7.0.0":
   version "7.2.5"
@@ -880,6 +1167,60 @@
     invariant "^2.2.2"
     js-levenshtein "^1.1.3"
     semver "^5.3.0"
+
+"@babel/preset-env@^7.1.0":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.4.4.tgz#b6f6825bfb27b3e1394ca3de4f926482722c1d6f"
+  integrity sha512-FU1H+ACWqZZqfw1x2G1tgtSSYSfxJLkpaUQL37CenULFARDo+h4xJoVHzRoHbK+85ViLciuI7ME4WTIhFRBBlw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-proposal-async-generator-functions" "^7.2.0"
+    "@babel/plugin-proposal-json-strings" "^7.2.0"
+    "@babel/plugin-proposal-object-rest-spread" "^7.4.4"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.4.4"
+    "@babel/plugin-syntax-async-generators" "^7.2.0"
+    "@babel/plugin-syntax-json-strings" "^7.2.0"
+    "@babel/plugin-syntax-object-rest-spread" "^7.2.0"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.2.0"
+    "@babel/plugin-transform-arrow-functions" "^7.2.0"
+    "@babel/plugin-transform-async-to-generator" "^7.4.4"
+    "@babel/plugin-transform-block-scoped-functions" "^7.2.0"
+    "@babel/plugin-transform-block-scoping" "^7.4.4"
+    "@babel/plugin-transform-classes" "^7.4.4"
+    "@babel/plugin-transform-computed-properties" "^7.2.0"
+    "@babel/plugin-transform-destructuring" "^7.4.4"
+    "@babel/plugin-transform-dotall-regex" "^7.4.4"
+    "@babel/plugin-transform-duplicate-keys" "^7.2.0"
+    "@babel/plugin-transform-exponentiation-operator" "^7.2.0"
+    "@babel/plugin-transform-for-of" "^7.4.4"
+    "@babel/plugin-transform-function-name" "^7.4.4"
+    "@babel/plugin-transform-literals" "^7.2.0"
+    "@babel/plugin-transform-member-expression-literals" "^7.2.0"
+    "@babel/plugin-transform-modules-amd" "^7.2.0"
+    "@babel/plugin-transform-modules-commonjs" "^7.4.4"
+    "@babel/plugin-transform-modules-systemjs" "^7.4.4"
+    "@babel/plugin-transform-modules-umd" "^7.2.0"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.4.4"
+    "@babel/plugin-transform-new-target" "^7.4.4"
+    "@babel/plugin-transform-object-super" "^7.2.0"
+    "@babel/plugin-transform-parameters" "^7.4.4"
+    "@babel/plugin-transform-property-literals" "^7.2.0"
+    "@babel/plugin-transform-regenerator" "^7.4.4"
+    "@babel/plugin-transform-reserved-words" "^7.2.0"
+    "@babel/plugin-transform-shorthand-properties" "^7.2.0"
+    "@babel/plugin-transform-spread" "^7.2.0"
+    "@babel/plugin-transform-sticky-regex" "^7.2.0"
+    "@babel/plugin-transform-template-literals" "^7.4.4"
+    "@babel/plugin-transform-typeof-symbol" "^7.2.0"
+    "@babel/plugin-transform-unicode-regex" "^7.4.4"
+    "@babel/types" "^7.4.4"
+    browserslist "^4.5.2"
+    core-js-compat "^3.0.0"
+    invariant "^2.2.2"
+    js-levenshtein "^1.1.3"
+    semver "^5.5.0"
 
 "@babel/preset-env@^7.1.6", "@babel/preset-env@^7.3.1":
   version "7.3.4"
@@ -986,6 +1327,15 @@
     "@babel/parser" "^7.2.2"
     "@babel/types" "^7.2.2"
 
+"@babel/template@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
+  integrity sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.4.4"
+    "@babel/types" "^7.4.4"
+
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.1.5", "@babel/traverse@^7.2.2", "@babel/traverse@^7.3.4":
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.3.4.tgz#1330aab72234f8dea091b08c4f8b9d05c7119e06"
@@ -1000,9 +1350,33 @@
     globals "^11.1.0"
     lodash "^4.17.11"
 
+"@babel/traverse@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.4.tgz#0776f038f6d78361860b6823887d4f3937133fe8"
+  integrity sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/generator" "^7.4.4"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.4.4"
+    "@babel/types" "^7.4.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.11"
+
 "@babel/types@^7.0.0", "@babel/types@^7.1.6", "@babel/types@^7.2.0", "@babel/types@^7.2.2", "@babel/types@^7.3.0", "@babel/types@^7.3.4":
   version "7.3.4"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.3.4.tgz#bf482eaeaffb367a28abbf9357a94963235d90ed"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.11"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.4.4.tgz#8db9e9a629bb7c29370009b4b779ed93fe57d5f0"
+  integrity sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.11"
@@ -2746,6 +3120,7 @@
 "@types/history@*":
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.2.tgz#0e670ea254d559241b6eeb3894f8754991e73220"
+  integrity sha512-ui3WwXmjTaY73fOQ3/m3nnajU/Orhi6cEu5rzX+BrAAJxa3eITXZ5ch9suPqtM03OWhAHhPSyBGCN4UKoxO20Q==
 
 "@types/i18next@^12.1.0":
   version "12.1.0"
@@ -3227,6 +3602,13 @@ accepts@~1.3.4, accepts@~1.3.5:
     mime-types "~2.1.18"
     negotiator "0.6.1"
 
+acorn-dynamic-import@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz#c752bd210bef679501b6c6cb7fc84f8f47158cc4"
+  integrity sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=
+  dependencies:
+    acorn "^4.0.3"
+
 acorn-dynamic-import@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"
@@ -3244,6 +3626,13 @@ acorn-globals@^4.1.0:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
 
+acorn-jsx@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+  integrity sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=
+  dependencies:
+    acorn "^3.0.4"
+
 acorn-jsx@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
@@ -3252,7 +3641,17 @@ acorn-walk@^6.0.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.1.tgz#d363b66f5fac5f018ff9c3a1e7b6f8e310cc3913"
 
-acorn@^5.0.0, acorn@^5.5.3, acorn@^5.6.2:
+acorn@^3.0.4:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+  integrity sha1-ReN/s56No/JbruP/U2niu18iAXo=
+
+acorn@^4.0.3:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
+  integrity sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=
+
+acorn@^5.0.0, acorn@^5.5.0, acorn@^5.5.3, acorn@^5.6.2:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
 
@@ -3308,6 +3707,11 @@ ajv-errors@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
 
+ajv-keywords@^1.0.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
+  integrity sha1-MU3QpLM2j609/NxU7eYXG4htrzw=
+
 ajv-keywords@^3.1.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.0.tgz#4b831e7b531415a7cc518cd404e73f6193c6349d"
@@ -3320,6 +3724,14 @@ ajv@6.9.1:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+ajv@^4.7.0:
+  version "4.11.8"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
+  integrity sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=
+  dependencies:
+    co "^4.6.0"
+    json-stable-stringify "^1.0.1"
 
 ajv@^5.0.0:
   version "5.5.2"
@@ -3338,6 +3750,15 @@ ajv@^6.1.0, ajv@^6.5.3, ajv@^6.5.5, ajv@^6.9.1:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+align-text@^0.1.1, align-text@^0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
+  integrity sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=
+  dependencies:
+    kind-of "^3.0.2"
+    longest "^1.0.1"
+    repeat-string "^1.5.2"
 
 alphanum-sort@^1.0.0, alphanum-sort@^1.0.1, alphanum-sort@^1.0.2:
   version "1.0.2"
@@ -3377,7 +3798,7 @@ ansi-cyan@^0.1.1:
   dependencies:
     ansi-wrap "0.1.0"
 
-ansi-escapes@^1.0.0:
+ansi-escapes@^1.0.0, ansi-escapes@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
@@ -3716,7 +4137,7 @@ async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.1.4, async@^2.5.0, async@^2.6.1:
+async@^2.0.0, async@^2.1.2, async@^2.1.4, async@^2.5.0, async@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.2.tgz#18330ea7e6e313887f5d2f2a904bac6fe4dd5381"
   dependencies:
@@ -3816,7 +4237,7 @@ axobject-query@^2.0.1:
   dependencies:
     ast-types-flow "0.0.7"
 
-babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
+babel-code-frame@^6.16.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
@@ -3824,7 +4245,7 @@ babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@7.0.0-bridge.0:
+babel-core@7.0.0-bridge.0, babel-core@^7.0.0-bridge.0:
   version "7.0.0-bridge.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
 
@@ -3862,6 +4283,16 @@ babel-eslint@9.0.0:
     "@babel/types" "^7.0.0"
     eslint-scope "3.7.1"
     eslint-visitor-keys "^1.0.0"
+
+babel-eslint@^7.0.0:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.3.tgz#b2fe2d80126470f5c19442dc757253a897710827"
+  integrity sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-traverse "^6.23.1"
+    babel-types "^6.23.0"
+    babylon "^6.17.0"
 
 babel-extract-comments@^1.0.0:
   version "1.0.0"
@@ -4046,6 +4477,11 @@ babel-plugin-check-es2015-constants@^6.8.0:
   integrity sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=
   dependencies:
     babel-runtime "^6.22.0"
+
+babel-plugin-dev-expression@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-dev-expression/-/babel-plugin-dev-expression-0.2.1.tgz#d4a7beefefbb50e3f2734990a82a2486cf9eb9ee"
+  integrity sha1-1Ke+7++7UOPyc0mQqCokhs+eue4=
 
 babel-plugin-dynamic-import-node@2.2.0:
   version "2.2.0"
@@ -4589,7 +5025,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -4610,7 +5046,7 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   dependencies:
@@ -4624,7 +5060,7 @@ babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-tra
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -4633,7 +5069,7 @@ babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.24.1, babel-types@^6.26.
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babylon@^6.15.0, babylon@^6.18.0:
+babylon@^6.15.0, babylon@^6.17.0, babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
@@ -4978,6 +5414,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+braces@^0.1.2:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-0.1.5.tgz#c085711085291d8b75fdd74eab0f8597280711e6"
+  integrity sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=
+  dependencies:
+    expand-range "^0.1.0"
+
 braces@^1.8.2:
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/braces/-/braces-1.8.5.tgz#ba77962e12dff969d6b76711e914b737857bf6a7"
@@ -5106,7 +5549,27 @@ browserslist@^4.0.0, browserslist@^4.3.4, browserslist@^4.3.5, browserslist@^4.4
     electron-to-chromium "^1.3.113"
     node-releases "^1.1.8"
 
-browserstack@^1.5.1:
+browserslist@^4.5.2, browserslist@^4.5.4:
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.5.6.tgz#ea42e8581ca2513fa7f371d4dd66da763938163d"
+  integrity sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==
+  dependencies:
+    caniuse-lite "^1.0.30000963"
+    electron-to-chromium "^1.3.127"
+    node-releases "^1.1.17"
+
+browserstack-local@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/browserstack-local/-/browserstack-local-1.3.7.tgz#cac9fc958eaa0a352e8f1ca1dc91bb141ba5da6f"
+  integrity sha512-ilZlmiy7XYJxsztYan7XueHVr3Ix9EVh/mCiYN1G53wRPEW/hg1KMsseM6UExzVbexEqFEfwjkBLeFlSqxh+bQ==
+  dependencies:
+    https-proxy-agent "^2.2.1"
+    is-running "^2.0.0"
+    ps-tree "=1.1.1"
+    sinon "^1.17.6"
+    temp-fs "^0.9.9"
+
+browserstack@^1.5.1, browserstack@~1.5.1:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/browserstack/-/browserstack-1.5.2.tgz#17d8bb76127a1cc0ea416424df80d218f803673f"
   dependencies:
@@ -5195,6 +5658,11 @@ builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
+builtin-modules@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-2.0.0.tgz#60b7ef5ae6546bd7deefa74b08b62a43a232648e"
+  integrity sha512-3U5kUA5VPsRUA3nofm/BXX7GVHKfxz0hOBAPxXrIvHzlDRkQVqEn6yi8QJegxl4LzOHLdvb7XF5dVawa/VVYBg==
+
 builtin-modules@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.0.0.tgz#1e587d44b006620d90286cc7a9238bbc6129cab1"
@@ -5218,6 +5686,11 @@ byte-size@^4.0.3:
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
+
+bytes@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
+  integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
 c3@^0.4.11, c3@^0.4.15, c3@~0.4.11:
   version "0.4.23"
@@ -5292,6 +5765,13 @@ caller-callsite@^2.0.0:
   dependencies:
     callsites "^2.0.0"
 
+caller-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
+  integrity sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=
+  dependencies:
+    callsites "^0.2.0"
+
 caller-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4"
@@ -5301,6 +5781,11 @@ caller-path@^2.0.0:
 callsite@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
+
+callsites@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
+  integrity sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=
 
 callsites@^2.0.0:
   version "2.0.0"
@@ -5331,6 +5816,11 @@ camelcase-keys@^4.0.0:
     camelcase "^4.1.0"
     map-obj "^2.0.0"
     quick-lru "^1.0.0"
+
+camelcase@^1.0.2:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
+  integrity sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=
 
 camelcase@^2.0.0:
   version "2.1.1"
@@ -5373,6 +5863,11 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000918, caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30000939, caniuse-lite@^1.0.30000940:
   version "1.0.30000941"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000941.tgz#f0810802b2ab8d27f4b625d4769a610e24d5a42c"
+
+caniuse-lite@^1.0.30000963:
+  version "1.0.30000963"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz#5be481d5292f22aff5ee0db4a6c049b65b5798b1"
+  integrity sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ==
 
 canonical-path@1.0.0:
   version "1.0.0"
@@ -5419,6 +5914,14 @@ caseless@~0.8.0:
 ccount@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.3.tgz#f1cec43f332e2ea5a569fd46f9f5bde4e6102aff"
+
+center-align@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
+  integrity sha1-qg0yYptu6XIgBBHL1EYckHvCt60=
+  dependencies:
+    align-text "^0.1.3"
+    lazy-cache "^1.0.3"
 
 chainsaw@~0.1.0:
   version "0.1.0"
@@ -5594,6 +6097,11 @@ circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
 
+circular-json@^0.5.5:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.5.9.tgz#932763ae88f4f7dead7a0d09c8a51a4743a53b1d"
+  integrity sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ==
+
 clap@^1.0.9:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/clap/-/clap-1.2.3.tgz#4f36745b32008492557f46412d66d50cb99bce51"
@@ -5636,7 +6144,7 @@ cli-color@~0.3.2:
     memoizee "~0.3.8"
     timers-ext "0.1"
 
-cli-cursor@^1.0.2:
+cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
   dependencies:
@@ -5679,6 +6187,15 @@ clipboard@^2.0.0:
     good-listener "^1.2.2"
     select "^1.1.2"
     tiny-emitter "^2.0.0"
+
+cliui@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
+  integrity sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=
+  dependencies:
+    center-align "^0.1.1"
+    right-align "^0.1.1"
+    wordwrap "0.0.2"
 
 cliui@^3.2.0:
   version "3.2.0"
@@ -5862,6 +6379,13 @@ columnify@^1.5.4:
     strip-ansi "^3.0.0"
     wcwidth "^1.0.0"
 
+combine-lists@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/combine-lists/-/combine-lists-1.0.1.tgz#458c07e09e0d900fc28b70a3fec2dacd1d2cb7f6"
+  integrity sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=
+  dependencies:
+    lodash "^4.5.0"
+
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
@@ -5891,6 +6415,11 @@ commander@2.17.x, commander@~2.17.1:
 commander@^2.11.0, commander@^2.12.0, commander@^2.12.1, commander@^2.14.1, commander@^2.18.0, commander@^2.19.0, commander@^2.9.0, commander@^2.x:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+
+commander@~2.20.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
 commandpost@^1.3.0:
   version "1.4.0"
@@ -5949,7 +6478,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@1.6.2, concat-stream@^1.5.0, concat-stream@^1.6.0:
+concat-stream@1.6.2, concat-stream@^1.5.0, concat-stream@^1.5.2, concat-stream@^1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
@@ -6169,9 +6698,29 @@ copy-webpack-plugin@4.6.0:
     p-limit "^1.0.0"
     serialize-javascript "^1.4.0"
 
+core-js-compat@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.0.1.tgz#bff73ba31ca8687431b9c88f78d3362646fb76f0"
+  integrity sha512-2pC3e+Ht/1/gD7Sim/sqzvRplMiRnFQVlPpDVaHtY9l7zZP7knamr3VRD6NyGfHd84MrDC0tAM9ulNxYMW0T3g==
+  dependencies:
+    browserslist "^4.5.4"
+    core-js "3.0.1"
+    core-js-pure "3.0.1"
+    semver "^6.0.0"
+
+core-js-pure@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.0.1.tgz#37358fb0d024e6b86d443d794f4e37e949098cbe"
+  integrity sha512-mSxeQ6IghKW3MoyF4cz19GJ1cMm7761ON+WObSyLfTu/Jn3x7w4NwNFnrZxgl4MTSvYYepVLNuRtlB4loMwJ5g==
+
 core-js@2.6.4:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.4.tgz#b8897c062c4d769dd30a0ac5c73976c47f92ea0d"
+
+core-js@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.0.1.tgz#1343182634298f7f38622f95e73f54e48ddf4738"
+  integrity sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -6810,6 +7359,11 @@ date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
 
+date-format@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/date-format/-/date-format-1.2.0.tgz#615e828e233dd1ab9bb9ae0950e0ceccfa6ecad8"
+  integrity sha1-YV6CjiM90aubua4JUODOzPpuytg=
+
 date-format@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/date-format/-/date-format-2.0.0.tgz#7cf7b172f1ec564f0003b39ea302c5498fb98c8f"
@@ -6828,7 +7382,7 @@ debug@*, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@^2.1.1, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -6857,7 +7411,7 @@ decamelize-keys@^1.0.0:
     decamelize "^1.1.0"
     map-obj "^1.0.0"
 
-decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
+decamelize@^1.0.0, decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
@@ -7290,7 +7844,7 @@ duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
 
-duplexer@^0.1.1:
+duplexer@^0.1.1, duplexer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
@@ -7332,6 +7886,11 @@ ejs@^2.6.1:
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.103, electron-to-chromium@^1.3.113:
   version "1.3.113"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz#b1ccf619df7295aea17bc6951dc689632629e4a9"
+
+electron-to-chromium@^1.3.127:
+  version "1.3.129"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.129.tgz#bff32e1840775554aafa301e9dc5002d565aae80"
+  integrity sha512-puirJsgZnedlFEmRa7WEUIaS8ZgHHn7d7inph+RiapCc0x80hdoDyEEpR9z3aRUSZy4fGxOTOFcxnGmySlrmhA==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -7454,6 +8013,16 @@ enhanced-resolve@4.1.0, enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
     memory-fs "^0.4.0"
     tapable "^1.0.0"
 
+enhanced-resolve@^3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz#0421e339fd71419b3da13d129b3979040230476e"
+  integrity sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=
+  dependencies:
+    graceful-fs "^4.1.2"
+    memory-fs "^0.4.0"
+    object-assign "^4.0.1"
+    tapable "^0.2.7"
+
 ent@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ent/-/ent-2.2.0.tgz#e964219325a21d05f44466a2f686ed6ce5f5dd1d"
@@ -7506,6 +8075,15 @@ es-to-primitive@^1.2.0:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es5-ext@^0.10.14:
+  version "0.10.50"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.50.tgz#6d0e23a0abdb27018e5ac4fd09b412bc5517a778"
+  integrity sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==
+  dependencies:
+    es6-iterator "~2.0.3"
+    es6-symbol "~3.1.1"
+    next-tick "^1.0.0"
+
 es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.11, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46, es5-ext@~0.10.5, es5-ext@~0.10.6:
   version "0.10.48"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.48.tgz#9a0b31eeded39e64453bcedf6f9d50bbbfb43850"
@@ -7518,6 +8096,14 @@ es5-shim@^4.5.10:
   version "4.5.12"
   resolved "https://registry.yarnpkg.com/es5-shim/-/es5-shim-4.5.12.tgz#508c13dda1c87dd3df1b50e69e7b96b82149b649"
 
+es6-iterator@^2.0.1, es6-iterator@~2.0.1, es6-iterator@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
+
 es6-iterator@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-0.1.3.tgz#d6f58b8c4fc413c249b4baa19768f8e4d7c8944e"
@@ -7526,13 +8112,17 @@ es6-iterator@~0.1.3:
     es5-ext "~0.10.5"
     es6-symbol "~2.0.1"
 
-es6-iterator@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+es6-map@^0.1.3:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
+  integrity sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=
   dependencies:
     d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-set "~0.1.5"
+    es6-symbol "~3.1.1"
+    event-emitter "~0.3.5"
 
 es6-promise@^4.0.3:
   version "4.2.6"
@@ -7548,11 +8138,22 @@ es6-promisify@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-6.0.1.tgz#6edaa45f3bd570ffe08febce66f7116be4b1cdb6"
 
+es6-set@~0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
+  integrity sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-symbol "3.1.1"
+    event-emitter "~0.3.5"
+
 es6-shim@^0.35.3:
   version "0.35.4"
   resolved "https://registry.yarnpkg.com/es6-shim/-/es6-shim-0.35.4.tgz#8d5a4109756383d3f0323421089c423acf8378f1"
 
-es6-symbol@^3.1.1, es6-symbol@~3.1.1:
+es6-symbol@3.1.1, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
   dependencies:
@@ -7565,6 +8166,16 @@ es6-symbol@~2.0.1:
   dependencies:
     d "~0.1.1"
     es5-ext "~0.10.5"
+
+es6-weak-map@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
+  integrity sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=
+  dependencies:
+    d "1"
+    es5-ext "^0.10.14"
+    es6-iterator "^2.0.1"
+    es6-symbol "^3.1.1"
 
 es6-weak-map@~0.1.4:
   version "0.1.4"
@@ -7594,13 +8205,23 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+escope@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
+  integrity sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=
+  dependencies:
+    es6-map "^0.1.3"
+    es6-weak-map "^2.0.1"
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 eslint-config-react-app@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-3.0.7.tgz#d58c9216ff285e2b4de0eb8403c28b0600e45b3e"
   dependencies:
     confusing-browser-globals "^1.0.5"
 
-eslint-import-resolver-node@^0.3.1:
+eslint-import-resolver-node@^0.3.1, eslint-import-resolver-node@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
   dependencies:
@@ -7620,6 +8241,14 @@ eslint-loader@2.1.1:
 eslint-module-utils@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz#546178dab5e046c8b562bbb50705e2456d7bda49"
+  dependencies:
+    debug "^2.6.8"
+    pkg-dir "^2.0.0"
+
+eslint-module-utils@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz#8b93499e9b00eab80ccb6614e69f03678e84e09a"
+  integrity sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==
   dependencies:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
@@ -7644,6 +8273,23 @@ eslint-plugin-import@2.14.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
     resolve "^1.6.0"
+
+eslint-plugin-import@^2.0.0:
+  version "2.17.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.17.2.tgz#d227d5c6dc67eca71eb590d2bb62fb38d86e9fcb"
+  integrity sha512-m+cSVxM7oLsIpmwNn2WXTJoReOF9f/CtLMo7qOVmKd1KntBy0hEcuNZ3erTmWjx+DxRO0Zcrm5KwAvI9wHcV5g==
+  dependencies:
+    array-includes "^3.0.3"
+    contains-path "^0.1.0"
+    debug "^2.6.9"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.2"
+    eslint-module-utils "^2.4.0"
+    has "^1.0.3"
+    lodash "^4.17.11"
+    minimatch "^3.0.4"
+    read-pkg-up "^2.0.0"
+    resolve "^1.10.0"
 
 eslint-plugin-jsx-a11y@6.1.2:
   version "6.1.2"
@@ -7734,6 +8380,55 @@ eslint@5.12.0:
     table "^5.0.2"
     text-table "^0.2.0"
 
+eslint@^3.3.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
+  integrity sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=
+  dependencies:
+    babel-code-frame "^6.16.0"
+    chalk "^1.1.3"
+    concat-stream "^1.5.2"
+    debug "^2.1.1"
+    doctrine "^2.0.0"
+    escope "^3.6.0"
+    espree "^3.4.0"
+    esquery "^1.0.0"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    glob "^7.0.3"
+    globals "^9.14.0"
+    ignore "^3.2.0"
+    imurmurhash "^0.1.4"
+    inquirer "^0.12.0"
+    is-my-json-valid "^2.10.0"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.5.1"
+    json-stable-stringify "^1.0.0"
+    levn "^0.3.0"
+    lodash "^4.0.0"
+    mkdirp "^0.5.0"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.1"
+    pluralize "^1.2.1"
+    progress "^1.1.8"
+    require-uncached "^1.0.2"
+    shelljs "^0.7.5"
+    strip-bom "^3.0.0"
+    strip-json-comments "~2.0.1"
+    table "^3.7.8"
+    text-table "~0.2.0"
+    user-home "^2.0.0"
+
+espree@^3.4.0:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
+  integrity sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==
+  dependencies:
+    acorn "^5.5.0"
+    acorn-jsx "^3.0.0"
+
 espree@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
@@ -7758,7 +8453,7 @@ esprima@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.0.4.tgz#9f557e08fc3b4d26ece9dd34f8fbf476b62585ad"
 
-esquery@^1.0.1:
+esquery@^1.0.0, esquery@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
   dependencies:
@@ -7794,12 +8489,25 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
-event-emitter@~0.3.4:
+event-emitter@~0.3.4, event-emitter@~0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
   dependencies:
     d "1"
     es5-ext "~0.10.14"
+
+event-stream@=3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
+  integrity sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=
+  dependencies:
+    duplexer "~0.1.1"
+    from "~0"
+    map-stream "~0.1.0"
+    pause-stream "0.0.11"
+    split "0.3"
+    stream-combiner "~0.0.4"
+    through "~2.3.1"
 
 eventemitter3@^3.0.0, eventemitter3@^3.1.0:
   version "3.1.0"
@@ -7886,6 +8594,15 @@ exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
 
+expand-braces@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/expand-braces/-/expand-braces-0.1.2.tgz#488b1d1d2451cb3d3a6b192cfc030f44c5855fea"
+  integrity sha1-SIsdHSRRyz06axks/AMPRMWFX+o=
+  dependencies:
+    array-slice "^0.2.3"
+    array-unique "^0.2.1"
+    braces "^0.1.2"
+
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
@@ -7904,6 +8621,14 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+expand-range@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-0.1.1.tgz#4cb8eda0993ca56fa4f41fc42f3cbb4ccadff044"
+  integrity sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=
+  dependencies:
+    is-number "^0.1.1"
+    repeat-string "^0.2.2"
+
 expand-range@^1.8.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
@@ -7913,6 +8638,18 @@ expand-range@^1.8.1:
 expand-template@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
+
+expect@^21.0.0:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-21.2.1.tgz#003ac2ac7005c3c29e73b38a272d4afadd6d1d7b"
+  integrity sha512-orfQQqFRTX0jH7znRIGi8ZMR8kTNpXklTTz8+HGTpmTKZo3Occ6JNB5FXMb8cRuiiC/GyDqsr30zUa66ACYlYw==
+  dependencies:
+    ansi-styles "^3.2.0"
+    jest-diff "^21.2.1"
+    jest-get-type "^21.2.0"
+    jest-matcher-utils "^21.2.1"
+    jest-message-util "^21.2.1"
+    jest-regex-util "^21.2.0"
 
 expect@^23.6.0:
   version "23.6.0"
@@ -8164,7 +8901,7 @@ figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
 
-figures@^1.0.1, figures@^1.3.2, figures@^1.7.0:
+figures@^1.0.1, figures@^1.3.2, figures@^1.3.5, figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
   dependencies:
@@ -8495,6 +9232,13 @@ format@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
 
+formatio@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+  integrity sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=
+  dependencies:
+    samsam "~1.1"
+
 formik@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/formik/-/formik-1.5.1.tgz#ef5687e1ade5b1fe5f1d51435b422238aad107e9"
@@ -8529,6 +9273,11 @@ from2@^2.1.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
+
+from@~0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
+  integrity sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=
 
 fs-access@^1.0.0:
   version "1.0.1"
@@ -8687,6 +9436,20 @@ gaze@^1.0.0:
   resolved "https://registry.yarnpkg.com/gaze/-/gaze-1.1.3.tgz#c441733e13b927ac8c0ff0b4c3b033f28812924a"
   dependencies:
     globule "^1.0.0"
+
+generate-function@^2.0.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.3.1.tgz#f069617690c10c868e73b8465746764f97c3479f"
+  integrity sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==
+  dependencies:
+    is-property "^1.0.2"
+
+generate-object-property@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
+  integrity sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=
+  dependencies:
+    is-property "^1.0.0"
 
 generic-names@^1.0.3:
   version "1.0.3"
@@ -8868,7 +9631,7 @@ glob@7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.1.3, glob@^7.0.0, glob@^7.0.3, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.1:
+glob@7.1.3, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@~7.1.1:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   dependencies:
@@ -8926,7 +9689,7 @@ globals@^11.1.0, globals@^11.7.0:
   version "11.11.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.11.0.tgz#dcf93757fa2de5486fbeed7118538adf789e9c2e"
 
-globals@^9.18.0:
+globals@^9.14.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
@@ -9124,6 +9887,11 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+  integrity sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=
+
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -9232,14 +10000,16 @@ highlight.js@~9.12.0:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
 
 history@^4.7.2:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/history/-/history-4.7.2.tgz#22b5c7f31633c5b8021c7f4a8a954ac139ee8d5b"
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.9.0.tgz#84587c2068039ead8af769e9d6a6860a14fa1bca"
+  integrity sha512-H2DkjCjXf0Op9OAr6nJ56fcRkTSNrUiv41vNJ6IswJjif6wlpZK0BTfFbi7qK9dXLSYZxkq5lBsj3vUjlYBYZA==
   dependencies:
-    invariant "^2.2.1"
+    "@babel/runtime" "^7.1.2"
     loose-envify "^1.2.0"
     resolve-pathname "^2.2.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
     value-equal "^0.4.0"
-    warning "^3.0.0"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -9545,7 +10315,7 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^3.3.5:
+ignore@^3.2.0, ignore@^3.3.5:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
 
@@ -9723,6 +10493,25 @@ inquirer@6.2.1:
     strip-ansi "^5.0.0"
     through "^2.3.6"
 
+inquirer@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
+  integrity sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=
+  dependencies:
+    ansi-escapes "^1.1.0"
+    ansi-regex "^2.0.0"
+    chalk "^1.0.0"
+    cli-cursor "^1.0.1"
+    cli-width "^2.0.0"
+    figures "^1.3.5"
+    lodash "^4.3.0"
+    readline2 "^1.0.1"
+    run-async "^0.1.0"
+    rx-lite "^3.1.2"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.0"
+    through "^2.3.6"
+
 inquirer@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.6.0.tgz#614d7bb3e48f9e6a8028e94a0c38f23ef29823d3"
@@ -9838,6 +10627,11 @@ is-alphanumerical@^1.0.0:
   dependencies:
     is-alphabetical "^1.0.0"
     is-decimal "^1.0.0"
+
+is-arguments@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.0.4.tgz#3faf966c7cba0ff437fb31f6250082fcf0448cf3"
+  integrity sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -9988,6 +10782,11 @@ is-generator-fn@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.0.0.tgz#038c31b774709641bda678b1f06a4e3227c10b3e"
 
+is-generator-function@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.0.7.tgz#d2132e529bb0000a7f80794d4bdf5cd5e5813522"
+  integrity sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==
+
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
@@ -10021,9 +10820,30 @@ is-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
 
+is-my-ip-valid@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz#7b351b8e8edd4d3995d4d066680e664d94696824"
+  integrity sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==
+
+is-my-json-valid@^2.10.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz#8fd6e40363cd06b963fa877d444bfb5eddc62175"
+  integrity sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==
+  dependencies:
+    generate-function "^2.0.0"
+    generate-object-property "^1.1.0"
+    is-my-ip-valid "^1.0.0"
+    jsonpointer "^4.0.0"
+    xtend "^4.0.0"
+
 is-npm@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
+
+is-number@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-0.1.1.tgz#69a7af116963d47206ec9bd9b48a14216f1e3806"
+  integrity sha1-aaevEWlj1HIG7JvZtIoUIW8eOAY=
 
 is-number@^2.1.0:
   version "2.1.0"
@@ -10089,6 +10909,11 @@ is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
+is-property@^1.0.0, is-property@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
+  integrity sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=
+
 is-redirect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
@@ -10118,6 +10943,11 @@ is-root@2.0.0:
 is-root@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-root/-/is-root-1.0.0.tgz#07b6c233bc394cd9d02ba15c966bd6660d6342d5"
+
+is-running@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-running/-/is-running-2.1.0.tgz#30a73ff5cc3854e4fc25490809e9f5abf8de09e0"
+  integrity sha1-MKc/9cw4VOT8JUkICen1q/jeCeA=
 
 is-ssh@^1.3.0:
   version "1.3.1"
@@ -10575,6 +11405,16 @@ jest-config@^24.7.1:
     pretty-format "^24.7.0"
     realpath-native "^1.1.0"
 
+jest-diff@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-21.2.1.tgz#46cccb6cab2d02ce98bc314011764bb95b065b4f"
+  integrity sha512-E5fu6r7PvvPr5qAWE1RaUwIh/k6Zx/3OOkZ4rk5dBJkEWRrUuSgbMt2EO8IUTPTd6DOqU3LW6uTIwX5FRvXoFA==
+  dependencies:
+    chalk "^2.0.1"
+    diff "^3.2.0"
+    jest-get-type "^21.2.0"
+    pretty-format "^21.2.1"
+
 jest-diff@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.6.0.tgz#1500f3f16e850bb3d71233408089be099f610c7d"
@@ -10723,6 +11563,11 @@ jest-environment-node@^24.7.1:
     jest-mock "^24.7.0"
     jest-util "^24.7.1"
 
+jest-get-type@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-21.2.0.tgz#f6376ab9db4b60d81e39f30749c6c466f40d4a23"
+  integrity sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==
+
 jest-get-type@^22.1.0:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
@@ -10852,6 +11697,15 @@ jest-leak-detector@^24.7.0:
   dependencies:
     pretty-format "^24.7.0"
 
+jest-matcher-utils@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz#72c826eaba41a093ac2b4565f865eb8475de0f64"
+  integrity sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^21.2.0"
+    pretty-format "^21.2.1"
+
 jest-matcher-utils@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz#726bcea0c5294261a7417afb6da3186b4b8cac80"
@@ -10877,6 +11731,15 @@ jest-matcher-utils@^24.7.0:
     jest-diff "^24.7.0"
     jest-get-type "^24.3.0"
     pretty-format "^24.7.0"
+
+jest-message-util@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-21.2.1.tgz#bfe5d4692c84c827d1dcf41823795558f0a1acbe"
+  integrity sha512-EbC1X2n0t9IdeMECJn2BOg7buOGivCvVNjqKMXTzQOu7uIfLml+keUfCALDh8o4rbtndIeyGU8/BKfoTr/LVDQ==
+  dependencies:
+    chalk "^2.0.1"
+    micromatch "^2.3.11"
+    slash "^1.0.0"
 
 jest-message-util@^23.4.0:
   version "23.4.0"
@@ -10911,6 +11774,11 @@ jest-message-util@^24.7.1:
     slash "^2.0.0"
     stack-utils "^1.0.1"
 
+jest-mock@^21.0.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-21.2.0.tgz#7eb0770e7317968165f61ea2a7281131534b3c0f"
+  integrity sha512-aZDfyVf0LEoABWiY6N0d+O963dUQSyUa4qgzurHR3TBDPen0YxKCJ6l2i7lQGh1tVdsuvdrCZ4qPj+A7PievCw==
+
 jest-mock@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.2.0.tgz#ad1c60f29e8719d47c26e1138098b6d18b261134"
@@ -10932,6 +11800,11 @@ jest-pnp-resolver@1.0.2:
 jest-pnp-resolver@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz#ecdae604c077a7fbc70defb6d517c3c1c898923a"
+
+jest-regex-util@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-21.2.0.tgz#1b1e33e63143babc3e0f2e6c9b5ba1eb34b2d530"
+  integrity sha512-BKQ1F83EQy0d9Jen/mcVX7D+lUt2tthhK/2gDWRgLDJRNOdRgSp1iVqFxP8EN1ARuypvDflRfPzYT8fQnoBQFQ==
 
 jest-regex-util@^23.3.0:
   version "23.3.0"
@@ -11409,6 +12282,14 @@ js-yaml@^3.1.0, js-yaml@^3.11.0, js-yaml@^3.12.0, js-yaml@^3.4.3, js-yaml@^3.7.0
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.5.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
@@ -11463,6 +12344,11 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
+json-loader@^0.5.4:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
+  integrity sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==
+
 json-parse-better-errors@^1.0.0, json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -11483,7 +12369,7 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
-json-stable-stringify@^1.0.1:
+json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
   dependencies:
@@ -11539,6 +12425,11 @@ jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
 
+jsonpointer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
+  integrity sha1-T9kss04OnbPInIYi7PUfm5eMbLk=
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -11567,7 +12458,16 @@ junk@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/junk/-/junk-1.0.3.tgz#87be63488649cbdca6f53ab39bec9ccd2347f592"
 
-karma-chrome-launcher@~2.2.0:
+karma-browserstack-launcher@^1.3.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/karma-browserstack-launcher/-/karma-browserstack-launcher-1.5.1.tgz#4caf4cd476a76d3c88205818d8994fc170a68fb4"
+  integrity sha512-zt9Ukow5A9WZHZXCFVO/h5kRsAdaZYeMNJK9Uan8v42amQXt3B/DZVxl24NCcAIxufKjW13UWd9iJ9knG9OCYw==
+  dependencies:
+    browserstack "~1.5.1"
+    browserstack-local "^1.3.7"
+    q "~1.5.0"
+
+karma-chrome-launcher@^2.2.0, karma-chrome-launcher@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz#cf1b9d07136cc18fe239327d24654c3dbc368acf"
   dependencies:
@@ -11586,6 +12486,11 @@ karma-coverage-istanbul-reporter@^2.0.5:
   dependencies:
     istanbul-api "^2.1.1"
     minimatch "^3.0.4"
+
+karma-firefox-launcher@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/karma-firefox-launcher/-/karma-firefox-launcher-1.1.0.tgz#2c47030452f04531eb7d13d4fc7669630bb93339"
+  integrity sha512-LbZ5/XlIXLeQ3cqnCbYLn+rOVhuMIK9aZwlP6eOLGzWdo1UVp7t6CN3DP4SafiRLjexKwHeKHDm0c38Mtd3VxA==
 
 karma-jasmine-html-reporter@^1.4.0:
   version "1.4.0"
@@ -11611,11 +12516,80 @@ karma-junit-reporter@^1.2.0:
     path-is-absolute "^1.0.0"
     xmlbuilder "8.2.2"
 
+karma-mocha-reporter@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/karma-mocha-reporter/-/karma-mocha-reporter-2.2.5.tgz#15120095e8ed819186e47a0b012f3cd741895560"
+  integrity sha1-FRIAlejtgZGG5HoLAS8810GJVWA=
+  dependencies:
+    chalk "^2.1.0"
+    log-symbols "^2.1.0"
+    strip-ansi "^4.0.0"
+
+karma-mocha@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/karma-mocha/-/karma-mocha-1.3.0.tgz#eeaac7ffc0e201eb63c467440d2b69c7cf3778bf"
+  integrity sha1-7qrH/8DiAetjxGdEDStpx883eL8=
+  dependencies:
+    minimist "1.2.0"
+
 karma-source-map-support@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/karma-source-map-support/-/karma-source-map-support-1.3.0.tgz#36dd4d8ca154b62ace95696236fae37caf0a7dde"
   dependencies:
     source-map-support "^0.5.5"
+
+karma-sourcemap-loader@^0.3.7:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.7.tgz#91322c77f8f13d46fed062b042e1009d4c4505d8"
+  integrity sha1-kTIsd/jxPUb+0GKwQuEAnUxFBdg=
+  dependencies:
+    graceful-fs "^4.1.2"
+
+karma-webpack@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/karma-webpack/-/karma-webpack-3.0.5.tgz#1ff1e3a690fb73ae95ee95f9ab58f341cfc7b40f"
+  integrity sha512-nRudGJWstvVuA6Tbju9tyGUfXTtI1UXMXoRHVmM2/78D0q6s/Ye2IC157PKNDC15PWFGR0mVIRtWLAdcfsRJoA==
+  dependencies:
+    async "^2.0.0"
+    babel-runtime "^6.0.0"
+    loader-utils "^1.0.0"
+    lodash "^4.0.0"
+    source-map "^0.5.6"
+    webpack-dev-middleware "^2.0.6"
+
+karma@^3.1.3:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/karma/-/karma-3.1.4.tgz#3890ca9722b10d1d14b726e1335931455788499e"
+  integrity sha512-31Vo8Qr5glN+dZEVIpnPCxEGleqE0EY6CtC2X9TagRV3rRQ3SNrvfhddICkJgUK3AgqpeKSZau03QumTGhGoSw==
+  dependencies:
+    bluebird "^3.3.0"
+    body-parser "^1.16.1"
+    chokidar "^2.0.3"
+    colors "^1.1.0"
+    combine-lists "^1.0.0"
+    connect "^3.6.0"
+    core-js "^2.2.0"
+    di "^0.0.1"
+    dom-serialize "^2.2.0"
+    expand-braces "^0.1.1"
+    flatted "^2.0.0"
+    glob "^7.1.1"
+    graceful-fs "^4.1.2"
+    http-proxy "^1.13.0"
+    isbinaryfile "^3.0.0"
+    lodash "^4.17.5"
+    log4js "^3.0.0"
+    mime "^2.3.1"
+    minimatch "^3.0.2"
+    optimist "^0.6.1"
+    qjobs "^1.1.4"
+    range-parser "^1.2.0"
+    rimraf "^2.6.0"
+    safe-buffer "^5.0.1"
+    socket.io "2.1.1"
+    source-map "^0.6.1"
+    tmp "0.0.33"
+    useragent "2.3.0"
 
 karma@~4.0.0:
   version "4.0.1"
@@ -12022,7 +12996,7 @@ loader-utils@1.1.0:
     emojis-list "^2.0.0"
     json5 "^0.5.0"
 
-loader-utils@1.2.3, loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.1:
+loader-utils@1.2.3, loader-utils@^1.0.0, loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.1:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
   dependencies:
@@ -12196,7 +13170,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4.17.11, lodash@>4.17.4, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.0.1, lodash@^4.14.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@~4.17.10:
+lodash@4.17.11, lodash@>4.17.4, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.0.1, lodash@^4.14.0, lodash@^4.16.4, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.0, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
@@ -12239,6 +13213,17 @@ log-update@^2.3.0:
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
 
+log4js@^3.0.0:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/log4js/-/log4js-3.0.6.tgz#e6caced94967eeeb9ce399f9f8682a4b2b28c8ff"
+  integrity sha512-ezXZk6oPJCWL483zj64pNkMuY/NcRX5MPiB0zE6tjZM137aeusrOnW1ecxgF9cmwMWkBMhjteQxBPoZBh9FDxQ==
+  dependencies:
+    circular-json "^0.5.5"
+    date-format "^1.2.0"
+    debug "^3.1.0"
+    rfdc "^1.1.2"
+    streamroller "0.7.0"
+
 log4js@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/log4js/-/log4js-4.0.2.tgz#0c73e623ca4448669653eb0e9f629beacc7fbbe3"
@@ -12260,13 +13245,23 @@ loglevelnext@^1.0.1:
     es6-symbol "^3.1.1"
     object.assign "^4.1.0"
 
+lolex@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
+  integrity sha1-fD2mL/yzDw9agKJWbKJORdigHzE=
+
+longest@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
+  integrity sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
+
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-loud-rejection@^1.0.0:
+loud-rejection@^1.0.0, loud-rejection@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
   dependencies:
@@ -12329,7 +13324,7 @@ magic-string@^0.22.4:
   dependencies:
     vlq "^0.2.2"
 
-magic-string@^0.25.0, magic-string@^0.25.1:
+magic-string@^0.25.0, magic-string@^0.25.1, magic-string@^0.25.2:
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.2.tgz#139c3a729515ec55e96e69e82a11fe890a293ad9"
   dependencies:
@@ -12392,6 +13387,11 @@ map-obj@^2.0.0:
 map-or-similar@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/map-or-similar/-/map-or-similar-1.5.0.tgz#6de2653174adfb5d9edc33c69d3e92a1b76faf08"
+
+map-stream@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
+  integrity sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=
 
 map-visit@^1.0.0:
   version "1.0.0"
@@ -12684,6 +13684,11 @@ mime@^2.0.3, mime@^2.3.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.0.tgz#e051fd881358585f3279df333fe694da0bcffdd6"
 
+mime@^2.1.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.2.tgz#ce5229a5e99ffc313abac806b482c10e7ba6ac78"
+  integrity sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==
+
 mime@~1.2.11:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.2.11.tgz#58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10"
@@ -12927,6 +13932,11 @@ mute-stream@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.4.tgz#a9219960a6d5d5d046597aee51252c6655f7177e"
 
+mute-stream@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
+  integrity sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=
+
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
@@ -12995,7 +14005,7 @@ nested-object-assign@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/nested-object-assign/-/nested-object-assign-1.0.3.tgz#5aca69390d9affe5a612152b5f0843ae399ac597"
 
-next-tick@1:
+next-tick@1, next-tick@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
 
@@ -13180,6 +14190,13 @@ node-pre-gyp@^0.10.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
+
+node-releases@^1.1.17:
+  version "1.1.17"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.17.tgz#71ea4631f0a97d5cd4f65f7d04ecf9072eac711a"
+  integrity sha512-/SCjetyta1m7YXLgtACZGDYJdCSIBAWorDWkGCGZlydP2Ll7J48l7j/JxNYZ+xsgSPbWfdulVS/aY+GdjUsQ7Q==
+  dependencies:
+    semver "^5.3.0"
 
 node-releases@^1.1.3, node-releases@^1.1.8:
   version "1.1.9"
@@ -13503,7 +14520,7 @@ object.assign@^4.1.0:
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
 
-object.entries@^1.0.4:
+object.entries@^1.0.4, object.entries@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.0.tgz#2024fc6d6ba246aee38bdb0ffd5cfbcf371b7519"
   dependencies:
@@ -14170,6 +15187,13 @@ patternfly@3.59.1, patternfly@^3.28.0, patternfly@^3.58.0:
     patternfly-bootstrap-combobox "~1.1.7"
     patternfly-bootstrap-treeview "~2.1.0"
 
+pause-stream@0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
+  integrity sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=
+  dependencies:
+    through "~2.3"
+
 pbkdf2@^3.0.3:
   version "3.0.17"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
@@ -14260,6 +15284,11 @@ plugin-error@^0.1.2:
     arr-diff "^1.0.1"
     arr-union "^2.0.1"
     extend-shallow "^1.1.2"
+
+pluralize@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
+  integrity sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=
 
 pluralize@^7.0.0:
   version "7.0.0"
@@ -15225,6 +16254,14 @@ pretty-error@^2.0.2, pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
+pretty-format@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"
+  integrity sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
+
 pretty-format@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.6.0.tgz#5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760"
@@ -15273,6 +16310,11 @@ process@^0.11.10:
 process@~0.5.1:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
+
+progress@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
+  integrity sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=
 
 progress@^2.0.0, progress@^2.0.1:
   version "2.0.3"
@@ -15423,6 +16465,13 @@ prr@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
 
+ps-tree@=1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.1.1.tgz#5f1ba35455b8c25eeb718d04c37de1555d96d3db"
+  integrity sha512-kef7fYYSKVqQffmzTMsVcUD1ObNJMp8sNSmHGlGKsZQyL/ht9MZKk86u0Rd1NhpTOAuhqwKCLLpktwkqz+MF8A==
+  dependencies:
+    event-stream "=3.3.4"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -15524,7 +16573,7 @@ q@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.4.1.tgz#55705bcd93c5f3673530c2c2cbc0c2b3addc286e"
 
-q@^1.1.2, q@^1.4.1, q@^1.5.1:
+q@^1.1.2, q@^1.4.1, q@^1.5.1, q@~1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
 
@@ -16311,6 +17360,15 @@ readdirp@^2.0.0, readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
+readline2@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
+  integrity sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    mute-stream "0.0.5"
+
 readline2@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/readline2/-/readline2-0.1.1.tgz#99443ba6e83b830ef3051bfd7dc241a82728d568"
@@ -16426,6 +17484,13 @@ regenerate-unicode-properties@^8.0.1:
   dependencies:
     regenerate "^1.4.0"
 
+regenerate-unicode-properties@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.0.2.tgz#7b38faa296252376d363558cfbda90c9ce709662"
+  integrity sha512-SbA/iNrBUf6Pv2zU8Ekv1Qbhv92yxL4hiDa2siuxs4KKn4oOoMDHXjAf7+Nz9qinUQ46B1LcWEi/PhJfPWpZWQ==
+  dependencies:
+    regenerate "^1.4.0"
+
 regenerate@^1.2.1, regenerate@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.0.tgz#4a856ec4b56e4077c557589cae85e7a4c8869a11"
@@ -16485,6 +17550,18 @@ regexpu-core@^4.1.3, regexpu-core@^4.2.0:
   dependencies:
     regenerate "^1.4.0"
     regenerate-unicode-properties "^8.0.1"
+    regjsgen "^0.5.0"
+    regjsparser "^0.6.0"
+    unicode-match-property-ecmascript "^1.0.4"
+    unicode-match-property-value-ecmascript "^1.1.0"
+
+regexpu-core@^4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.5.4.tgz#080d9d02289aa87fe1667a4f5136bc98a6aebaae"
+  integrity sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==
+  dependencies:
+    regenerate "^1.4.0"
+    regenerate-unicode-properties "^8.0.2"
     regjsgen "^0.5.0"
     regjsparser "^0.6.0"
     unicode-match-property-ecmascript "^1.0.4"
@@ -16569,6 +17646,11 @@ renderkid@^2.0.1:
 repeat-element@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
+
+repeat-string@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-0.2.2.tgz#c7a8d3236068362059a7e4651fc6884e8b1fb4ae"
+  integrity sha1-x6jTI2BoNiBZp+RlH8aITosftK4=
 
 repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
@@ -16713,6 +17795,14 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
 
+require-uncached@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
+  integrity sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=
+  dependencies:
+    caller-path "^0.1.0"
+    resolve-from "^1.0.0"
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -16730,6 +17820,11 @@ resolve-cwd@^2.0.0:
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
   dependencies:
     resolve-from "^3.0.0"
+
+resolve-from@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+  integrity sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=
 
 resolve-from@^3.0.0:
   version "3.0.0"
@@ -16805,6 +17900,13 @@ rgba-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
 
+right-align@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
+  integrity sha1-YTObci/mo1FWiSENJOFMlhSGE+8=
+  dependencies:
+    align-text "^0.1.1"
+
 rimraf@2, rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.0, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@~2.6.2:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
@@ -16814,6 +17916,13 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.0, rimraf@^2.
 rimraf@~2.2.0:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
+
+rimraf@~2.5.2:
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
+  integrity sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=
+  dependencies:
+    glob "^7.0.5"
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
@@ -16828,7 +17937,7 @@ rollup-plugin-alias@^1.5.1:
   dependencies:
     slash "^2.0.0"
 
-rollup-plugin-babel@^4.1.0-0:
+rollup-plugin-babel@^4.0.3, rollup-plugin-babel@^4.1.0-0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-4.3.2.tgz#8c0e1bd7aa9826e90769cf76895007098ffd1413"
   dependencies:
@@ -16858,6 +17967,16 @@ rollup-plugin-commonjs@^9.0.0, rollup-plugin-commonjs@^9.1.3:
     resolve "^1.10.0"
     rollup-pluginutils "^2.3.3"
 
+rollup-plugin-commonjs@^9.2.0:
+  version "9.3.4"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.3.4.tgz#2b3dddbbbded83d45c36ff101cdd29e924fd23bc"
+  integrity sha512-DTZOvRoiVIHHLFBCL4pFxOaJt8pagxsVldEXBOn6wl3/V21wVaj17HFfyzTsQUuou3sZL3lEJZVWKPFblJfI6w==
+  dependencies:
+    estree-walker "^0.6.0"
+    magic-string "^0.25.2"
+    resolve "^1.10.0"
+    rollup-pluginutils "^2.6.0"
+
 rollup-plugin-es3@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-es3/-/rollup-plugin-es3-1.1.0.tgz#f866f91b4db839e5b475d8e4a7b9d4c77ecade14"
@@ -16876,6 +17995,15 @@ rollup-plugin-json@^3.1.0:
   resolved "https://registry.yarnpkg.com/rollup-plugin-json/-/rollup-plugin-json-3.1.0.tgz#7c1daf60c46bc21021ea016bd00863561a03321b"
   dependencies:
     rollup-pluginutils "^2.3.1"
+
+rollup-plugin-node-resolve@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.4.0.tgz#908585eda12e393caac7498715a01e08606abc89"
+  integrity sha512-PJcd85dxfSBWih84ozRtBkB731OjXk0KnzN0oGp7WOWcarAFkVa71cV5hTJg2qpVsV2U8EUwrzHP3tvy9vS3qg==
+  dependencies:
+    builtin-modules "^2.0.0"
+    is-module "^1.0.0"
+    resolve "^1.1.6"
 
 rollup-plugin-node-resolve@^4.0.0:
   version "4.0.1"
@@ -16911,6 +18039,29 @@ rollup-plugin-preserve-shebang@^0.1.6:
   dependencies:
     magic-string "^0.22.4"
 
+rollup-plugin-replace@^2.0.0, rollup-plugin-replace@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-2.2.0.tgz#f41ae5372e11e7a217cde349c8b5d5fd115e70e3"
+  integrity sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==
+  dependencies:
+    magic-string "^0.25.2"
+    rollup-pluginutils "^2.6.0"
+
+rollup-plugin-size-snapshot@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-size-snapshot/-/rollup-plugin-size-snapshot-0.7.0.tgz#f0070e4aeee736f45f8eb6b96e12e6238705c13b"
+  integrity sha512-wlFRHInOfJZbXHWA4rftymqHuVDCeKUhJF3vuBZuU5y+O0LAj6RQM7vGn2/UoLImENFci31ff3pnKjW36DDP2A==
+  dependencies:
+    acorn "^6.0.1"
+    bytes "^3.0.0"
+    chalk "^2.4.1"
+    gzip-size "^5.0.0"
+    jest-diff "^23.6.0"
+    memory-fs "^0.4.1"
+    rollup-plugin-replace "^2.0.0"
+    terser "^3.8.2"
+    webpack "^4.19.0"
+
 rollup-plugin-sizes@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-sizes/-/rollup-plugin-sizes-0.4.2.tgz#1d97ecda2667a43afbb19d801e2476f80f67d12f"
@@ -16945,6 +18096,16 @@ rollup-plugin-typescript2@^0.19.0:
     rollup-pluginutils "2.3.3"
     tslib "1.9.3"
 
+rollup-plugin-uglify@^6.0.0:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-uglify/-/rollup-plugin-uglify-6.0.2.tgz#681042cfdf7ea4e514971946344e1a95bc2772fe"
+  integrity sha512-qwz2Tryspn5QGtPUowq5oumKSxANKdrnfz7C0jm4lKxvRDsNe/hSGsB9FntUul7UeC4TsZEWKErVgE1qWSO0gw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    jest-worker "^24.0.0"
+    serialize-javascript "^1.6.1"
+    uglify-js "^3.4.9"
+
 rollup-pluginutils@2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.3.3.tgz#3aad9b1eb3e7fe8262820818840bf091e5ae6794"
@@ -16966,6 +18127,22 @@ rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.3.0, rollup-pluginutils@^2.3.1,
     estree-walker "^0.6.0"
     micromatch "^3.1.10"
 
+rollup-pluginutils@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.6.0.tgz#203706edd43dfafeaebc355d7351119402fc83ad"
+  integrity sha512-aGQwspEF8oPKvg37u3p7h0cYNwmJR1sCBMZGZ5b9qy8HGtETknqjzcxrDRrcAnJNXN18lBH4Q9vZYth/p4n8jQ==
+  dependencies:
+    estree-walker "^0.6.0"
+    micromatch "^3.1.10"
+
+rollup@^0.66.6:
+  version "0.66.6"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.66.6.tgz#ce7d6185beb7acea644ce220c25e71ae03275482"
+  integrity sha512-J7/SWanrcb83vfIHqa8+aVVGzy457GcjA6GVZEnD0x2u4OnOd0Q1pCrEoNe8yLwM6z6LZP02zBT2uW0yh5TqOw==
+  dependencies:
+    "@types/estree" "0.0.39"
+    "@types/node" "*"
+
 rollup@^0.67.0, rollup@^0.67.3:
   version "0.67.4"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.67.4.tgz#8ed6b0993337f84ec8a0387f824fa6c197e833ec"
@@ -16980,6 +18157,13 @@ rsvp@^3.3.3:
 rsvp@^4.8.4:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.4.tgz#b50e6b34583f3dd89329a2f23a8a2be072845911"
+
+run-async@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
+  integrity sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=
+  dependencies:
+    once "^1.3.0"
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -16996,6 +18180,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
   dependencies:
     aproba "^1.1.1"
+
+rx-lite@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
+  integrity sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=
 
 rx@^2.2.27:
   version "2.5.3"
@@ -17056,6 +18245,16 @@ safe-regex@^1.1.0:
 "safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+
+samsam@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
+  integrity sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=
+
+samsam@~1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.3.tgz#9f5087419b4d091f232571e7fa52e90b0f552621"
+  integrity sha1-n1CHQZtNCR8jJXHn+lLpCw9VJiE=
 
 sane@^2.0.0:
   version "2.5.2"
@@ -17234,6 +18433,11 @@ semver@^2.2.1, semver@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-2.3.2.tgz#b9848f25d6cf36333073ec9ef8856d42f1233e52"
 
+semver@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.0.0.tgz#05e359ee571e5ad7ed641a6eec1e547ba52dea65"
+  integrity sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==
+
 semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
@@ -17259,6 +18463,11 @@ send@0.16.2:
 serialize-javascript@^1.4.0, serialize-javascript@^1.5.0:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.6.1.tgz#4d1f697ec49429a847ca6f442a2a755126c4d879"
+
+serialize-javascript@^1.6.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.7.0.tgz#d6e0dfb2a3832a8c94468e6eb1db97e55a192a65"
+  integrity sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==
 
 serve-favicon@^2.5.0:
   version "2.5.0"
@@ -17381,6 +18590,15 @@ shell-quote@~1.4.1:
     array-reduce "~0.0.0"
     jsonify "~0.0.0"
 
+shelljs@^0.7.5:
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
+  integrity sha1-3svPh0sNHl+3LhSxZKloMEjprLM=
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
 shelljs@^0.8.1, shelljs@^0.8.2:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
@@ -17424,6 +18642,16 @@ simple-swizzle@^0.2.2:
   resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
   dependencies:
     is-arrayish "^0.3.1"
+
+sinon@^1.17.6:
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+  integrity sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=
+  dependencies:
+    formatio "1.1.1"
+    lolex "1.3.2"
+    samsam "1.1.2"
+    util ">=0.10.3 <1"
 
 sisteransi@^0.1.1:
   version "0.1.1"
@@ -17646,7 +18874,7 @@ source-map@^0.4.2, source-map@~0.4.1:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7:
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -17730,6 +18958,13 @@ split2@^2.0.0:
   resolved "https://registry.yarnpkg.com/split2/-/split2-2.2.0.tgz#186b2575bcf83e85b7d18465756238ee4ee42493"
   dependencies:
     through2 "^2.0.2"
+
+split@0.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
+  integrity sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=
+  dependencies:
+    through "2"
 
 split@^1.0.0:
   version "1.0.1"
@@ -17825,6 +19060,13 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
+stream-combiner@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
+  integrity sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=
+  dependencies:
+    duplexer "~0.1.1"
+
 stream-each@^1.1.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.3.tgz#ebe27a0c389b04fbcc233642952e10731afa9bae"
@@ -17849,6 +19091,16 @@ stream-shift@^1.0.0:
 stream-to-observable@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.1.0.tgz#45bf1d9f2d7dc09bed81f1c307c430e68b84cffe"
+
+streamroller@0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-0.7.0.tgz#a1d1b7cf83d39afb0d63049a5acbf93493bdf64b"
+  integrity sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==
+  dependencies:
+    date-format "^1.2.0"
+    debug "^3.1.0"
+    mkdirp "^0.5.1"
+    readable-stream "^2.3.0"
 
 streamroller@^1.0.1:
   version "1.0.3"
@@ -18135,6 +19387,13 @@ supports-color@^3.1.2, supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
+supports-color@^4.2.1:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+  integrity sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=
+  dependencies:
+    has-flag "^2.0.0"
+
 supports-color@^6.0.0, supports-color@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
@@ -18218,6 +19477,18 @@ table-resolver@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/table-resolver/-/table-resolver-3.3.0.tgz#22e575d3c6aed15404ab71a0f2046c4ff55e556e"
 
+table@^3.7.8:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
+  integrity sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=
+  dependencies:
+    ajv "^4.7.0"
+    ajv-keywords "^1.0.0"
+    chalk "^1.1.1"
+    lodash "^4.0.0"
+    slice-ansi "0.0.4"
+    string-width "^2.0.0"
+
 table@^5.0.2:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/table/-/table-5.2.3.tgz#cde0cc6eb06751c009efab27e8c820ca5b67b7f2"
@@ -18237,6 +19508,11 @@ talkback@^1.10.0:
     json5 "^2.1.0"
     mkdirp "^0.5.1"
     node-fetch "^2.2.1"
+
+tapable@^0.2.7:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.9.tgz#af2d8bbc9b04f74ee17af2b4d9048f807acd18a8"
+  integrity sha512-2wsvQ+4GwBvLPLWsNfLCDYGsW6xb7aeC6utq2Qh0PFwgEy7K7dsma9Jsmb2zSQj7GvYAyUGSntLtsv++GmgL1A==
 
 tapable@^1.0.0, tapable@^1.1.0:
   version "1.1.1"
@@ -18317,6 +19593,13 @@ temp-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
 
+temp-fs@^0.9.9:
+  version "0.9.9"
+  resolved "https://registry.yarnpkg.com/temp-fs/-/temp-fs-0.9.9.tgz#8071730437870720e9431532fe2814364f8803d7"
+  integrity sha1-gHFzBDeHByDpQxUy/igUNk+IA9c=
+  dependencies:
+    rimraf "~2.5.2"
+
 temp-write@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/temp-write/-/temp-write-3.4.0.tgz#8cff630fb7e9da05f047c74ce4ce4d685457d492"
@@ -18395,7 +19678,7 @@ text-extensions@^1.0.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
 
-text-table@0.2.0, text-table@^0.2.0:
+text-table@0.2.0, text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
@@ -18422,7 +19705,7 @@ through2@~0.4.1:
     readable-stream "~1.0.17"
     xtend "~2.1.1"
 
-through@2, "through@>=2.2.7 <3", through@X.X.X, through@^2.3.4, through@^2.3.6, through@^2.3.8, through@~2.3.4:
+through@2, "through@>=2.2.7 <3", through@X.X.X, through@^2.3.4, through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -18471,7 +19754,12 @@ tiny-glob@^0.2.6:
     globalyzer "^0.1.0"
     globrex "^0.1.1"
 
-tiny-warning@^1.0.2:
+tiny-invariant@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.4.tgz#346b5415fd93cb696b0c4e8a96697ff590f92463"
+  integrity sha512-lMhRd/djQJ3MoaHEBrw8e2/uM4rs9YMNk0iOr8rHQ0QdbM7D4l0gFl3szKdeixrlyfm9Zqi4dxHCM2qVG8ND5g==
+
+tiny-warning@^1.0.0, tiny-warning@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.2.tgz#1dfae771ee1a04396bdfde27a3adcebc6b648b28"
 
@@ -18810,6 +20098,24 @@ uglify-js@3.4.x, uglify-js@^3.0.7, uglify-js@^3.1.4:
     commander "~2.17.1"
     source-map "~0.6.1"
 
+uglify-js@^2.8.29:
+  version "2.8.29"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
+  integrity sha1-KcVzMUgFe7Th913zW3qcty5qWd0=
+  dependencies:
+    source-map "~0.5.1"
+    yargs "~3.10.0"
+  optionalDependencies:
+    uglify-to-browserify "~1.0.0"
+
+uglify-js@^3.4.9:
+  version "3.5.10"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.10.tgz#652bef39f86d9dbfd6674407ee05a5e2d372cf2d"
+  integrity sha512-/GTF0nosyPLbdJBd+AwYiZ+Hu5z8KXWnO0WCGt1BQ/u9Iamhejykqmz5o1OHJ53+VAk6xVxychonnApDjuqGsw==
+  dependencies:
+    commander "~2.20.0"
+    source-map "~0.6.1"
+
 uglify-js@~2.3:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.3.6.tgz#fa0984770b428b7a9b2a8058f46355d14fef211a"
@@ -18817,6 +20123,20 @@ uglify-js@~2.3:
     async "~0.2.6"
     optimist "~0.3.5"
     source-map "~0.1.7"
+
+uglify-to-browserify@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
+  integrity sha1-bgkk1r2mta/jSeOabWMoUKD4grc=
+
+uglifyjs-webpack-plugin@^0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz#b951f4abb6bd617e66f63eb891498e391763e309"
+  integrity sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=
+  dependencies:
+    source-map "^0.5.6"
+    uglify-js "^2.8.29"
+    webpack-sources "^1.0.1"
 
 uid-number@0.0.5:
   version "0.0.5"
@@ -18983,6 +20303,11 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
 
+url-join@^2.0.2:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-2.0.5.tgz#5af22f18c052a000a48d7b82c5e9c2e2feeda728"
+  integrity sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=
+
 url-loader@1.1.2, url-loader@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-1.1.2.tgz#b971d191b83af693c5e3fea4064be9e1f2d7f8d8"
@@ -19052,6 +20377,17 @@ util@0.10.3:
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
   dependencies:
     inherits "2.0.1"
+
+"util@>=0.10.3 <1":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.12.0.tgz#bb5e3d29ba2703c7add0ad337003be3ca477798a"
+  integrity sha512-pPSOFl7VLhZ7LO/SFABPraZEEurkJUWSMn3MuA/r3WQZc+Z1fqou2JqLSOZbCLl73EUIxuUVX8X4jkX2vfJeAA==
+  dependencies:
+    inherits "2.0.3"
+    is-arguments "^1.0.4"
+    is-generator-function "^1.0.7"
+    object.entries "^1.1.0"
+    safe-buffer "^5.1.2"
 
 util@^0.11.0:
   version "0.11.1"
@@ -19176,7 +20512,7 @@ watch@~0.18.0:
     exec-sh "^0.2.0"
     minimist "^1.2.0"
 
-watchpack@^1.5.0:
+watchpack@^1.4.0, watchpack@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"
   dependencies:
@@ -19252,6 +20588,19 @@ webpack-dev-middleware@3.5.1:
     range-parser "^1.0.3"
     webpack-log "^2.0.0"
 
+webpack-dev-middleware@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-2.0.6.tgz#a51692801e8310844ef3e3790e1eacfe52326fd4"
+  integrity sha512-tj5LLD9r4tDuRIDa5Mu9lnY2qBBehAITv6A9irqXhw/HQquZgTx3BCd57zYbU2gMDnncA49ufK2qVQSbaKJwOw==
+  dependencies:
+    loud-rejection "^1.6.0"
+    memory-fs "~0.4.1"
+    mime "^2.1.0"
+    path-is-absolute "^1.0.0"
+    range-parser "^1.0.3"
+    url-join "^2.0.2"
+    webpack-log "^1.0.1"
+
 webpack-dev-middleware@^3.5.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.6.0.tgz#71f1b04e52ff8d442757af2be3a658237d53a3e5"
@@ -19305,7 +20654,7 @@ webpack-hot-middleware@^2.24.3:
     querystring "^0.2.0"
     strip-ansi "^3.0.0"
 
-webpack-log@^1.1.2, webpack-log@^1.2.0:
+webpack-log@^1.0.1, webpack-log@^1.1.2, webpack-log@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-1.2.0.tgz#a4b34cda6b22b518dbb0ab32e567962d5c72a43d"
   dependencies:
@@ -19341,7 +20690,7 @@ webpack-merge@4.2.1:
   dependencies:
     lodash "^4.17.5"
 
-webpack-sources@1.3.0, webpack-sources@^1.1.0, webpack-sources@^1.2.0, webpack-sources@^1.3.0:
+webpack-sources@1.3.0, webpack-sources@^1.0.1, webpack-sources@^1.1.0, webpack-sources@^1.2.0, webpack-sources@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.3.0.tgz#2a28dcb9f1f45fe960d8f1493252b5ee6530fa85"
   dependencies:
@@ -19407,6 +20756,64 @@ webpack@4.29.0:
     neo-async "^2.5.0"
     node-libs-browser "^2.0.0"
     schema-utils "^0.4.4"
+    tapable "^1.1.0"
+    terser-webpack-plugin "^1.1.0"
+    watchpack "^1.5.0"
+    webpack-sources "^1.3.0"
+
+webpack@^3.12.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.12.0.tgz#3f9e34360370602fcf639e97939db486f4ec0d74"
+  integrity sha512-Sw7MdIIOv/nkzPzee4o0EdvCuPmxT98+vVpIvwtcwcF1Q4SDSNp92vwcKc4REe7NItH9f1S4ra9FuQ7yuYZ8bQ==
+  dependencies:
+    acorn "^5.0.0"
+    acorn-dynamic-import "^2.0.0"
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+    async "^2.1.2"
+    enhanced-resolve "^3.4.0"
+    escope "^3.6.0"
+    interpret "^1.0.0"
+    json-loader "^0.5.4"
+    json5 "^0.5.1"
+    loader-runner "^2.3.0"
+    loader-utils "^1.1.0"
+    memory-fs "~0.4.1"
+    mkdirp "~0.5.0"
+    node-libs-browser "^2.0.0"
+    source-map "^0.5.3"
+    supports-color "^4.2.1"
+    tapable "^0.2.7"
+    uglifyjs-webpack-plugin "^0.4.6"
+    watchpack "^1.4.0"
+    webpack-sources "^1.0.1"
+    yargs "^8.0.2"
+
+webpack@^4.19.0:
+  version "4.30.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.30.0.tgz#aca76ef75630a22c49fcc235b39b4c57591d33a9"
+  integrity sha512-4hgvO2YbAFUhyTdlR4FNyt2+YaYBYHavyzjCMbZzgglo02rlKi/pcsEzwCuCpsn1ryzIl1cq/u8ArIKu8JBYMg==
+  dependencies:
+    "@webassemblyjs/ast" "1.8.5"
+    "@webassemblyjs/helper-module-context" "1.8.5"
+    "@webassemblyjs/wasm-edit" "1.8.5"
+    "@webassemblyjs/wasm-parser" "1.8.5"
+    acorn "^6.0.5"
+    acorn-dynamic-import "^4.0.0"
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+    chrome-trace-event "^1.0.0"
+    enhanced-resolve "^4.1.0"
+    eslint-scope "^4.0.0"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^2.3.0"
+    loader-utils "^1.1.0"
+    memory-fs "~0.4.1"
+    micromatch "^3.1.8"
+    mkdirp "~0.5.0"
+    neo-async "^2.5.0"
+    node-libs-browser "^2.0.0"
+    schema-utils "^1.0.0"
     tapable "^1.1.0"
     terser-webpack-plugin "^1.1.0"
     watchpack "^1.5.0"
@@ -19534,11 +20941,21 @@ win-release@^1.0.0:
   dependencies:
     semver "^5.0.1"
 
+window-size@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
+  integrity sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=
+
 windows-release@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/windows-release/-/windows-release-3.1.0.tgz#8d4a7e266cbf5a233f6c717dac19ce00af36e12e"
   dependencies:
     execa "^0.10.0"
+
+wordwrap@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
+  integrity sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=
 
 wordwrap@~0.0.2:
   version "0.0.3"
@@ -19970,6 +21387,35 @@ yargs@^7.0.0, yargs@^7.1.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
+
+yargs@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
+  integrity sha1-YpmpBVsc78lp/355wdkY3Osiw2A=
+  dependencies:
+    camelcase "^4.1.0"
+    cliui "^3.2.0"
+    decamelize "^1.1.1"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    read-pkg-up "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^7.0.0"
+
+yargs@~3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.10.0.tgz#f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1"
+  integrity sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=
+  dependencies:
+    camelcase "^1.0.2"
+    cliui "^2.1.0"
+    decamelize "^1.0.0"
+    window-size "0.1.0"
 
 yauzl@2.10.0:
   version "2.10.0"


### PR DESCRIPTION
Fixes #211

To fix this I had to clone the `history` package and modify it to use the `sessionStorage` to store the state attached to a `LocationDescriptor`, instead of using the browser's default which is too small for some of our integrations.