### PR TITLE
Docker image build and push from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,10 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
-version: 2
+version: 2.1
+
+orbs:
+  docker-publish: circleci/docker-publish@0.1.6
 
 jobs:
   build:
@@ -60,6 +63,28 @@ jobs:
           root: doc
           paths:
             - '*'
+
+      - persist_to_workspace:
+          root: ~/repo/app/ui-react
+          paths:
+            - Dockerfile
+            - .dockerignore
+            - 'nginx*'
+            - syndesis/build
+
+  publish:
+    executor: docker-publish/docker
+    working_directory: ~/repo/app/ui-react
+    steps:
+      - attach_workspace:
+          at: ~/
+      - setup_remote_docker
+      - docker-publish/check
+      - docker-publish/build:
+          extra_build_args: '--ulimit nofile=1024'
+          image: syndesis/syndesis-ui
+          tag: latest-react
+      - docker-publish/deploy
 
   doc-deploy:
     docker:
@@ -158,7 +183,6 @@ jobs:
               -X POST https://ghcommentbot.herokuapp.com/comment
 
 workflows:
-  version: 2
   build:
     jobs:
       - build:
@@ -166,6 +190,13 @@ workflows:
             branches:
               ignore:
                 - gh-pages
+      - publish:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
       - doc-deploy:
           requires:
             - build

--- a/app/ui-react/.dockerignore
+++ b/app/ui-react/.dockerignore
@@ -1,0 +1,3 @@
+*/**
+!nginx*
+!syndesis/build/**

--- a/app/ui-react/Dockerfile
+++ b/app/ui-react/Dockerfile
@@ -1,0 +1,60 @@
+FROM docker.io/centos:7
+
+ENV NGINX_VERSION 1.13.4-1.el7
+
+# This refers to the files copied by assembly configuration in pom.xml
+# Change this to e.g. "dist" if running the dockerfile from top-level e.g.
+# docker build --build-arg SRC_DIR=dist --build-arf CONTEXT_DIR=docker -f docker/Dockerfile
+ARG SRC_DIR="syndesis/build"
+ARG CONTEXT_DIR="."
+
+LABEL name="nginxinc/nginx" \
+      maintainer="Syndesis Authors <syndesis@googlegroups.com>" \
+      vendor="NGINX Inc." \
+      version="${NGINX_VERSION}" \
+      release="1" \
+      summary="NGINX" \
+      description="nginx will do ....."
+### Required labels above - recommended below
+LABEL url="https://www.nginx.com/" \
+      io.k8s.display-name="NGINX" \
+      io.openshift.expose-services="http:8080" \
+      io.openshift.tags="nginx,nginxinc"
+
+ADD ${CONTEXT_DIR}/nginx.repo /etc/yum.repos.d/nginx.repo
+
+RUN curl -sO http://nginx.org/keys/nginx_signing.key && \
+    rpm --import ./nginx_signing.key && \
+    yum -y install --setopt=tsflags=nodocs nginx-${NGINX_VERSION}.ngx && \
+    rm -f ./nginx_signing.key && \
+    yum clean all
+
+# forward request and error logs to docker log collector
+# - Change pid file location & remove nginx user & change port to 8080
+# - modify perms for non-root runtime
+RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
+    ln -sf /dev/stderr /var/log/nginx/error.log && \
+    sed -i 's/\/var\/run\/nginx.pid/\/var\/cache\/nginx\/nginx.pid/g' /etc/nginx/nginx.conf && \
+    sed -i -e '/user/!b' -e '/nginx/!b' -e '/nginx/d' /etc/nginx/nginx.conf && \
+    rm -f /etc/nginx/conf.d/default.conf && \
+    chown -R 998 /var/cache/nginx /etc/nginx && \
+    chmod -R g=u /var/cache/nginx /etc/nginx
+
+
+# Copy licenses
+#RUN mkdir -p /opt/ipaas/licenses
+#COPY licenses /opt/ipaas/licenses
+
+#VOLUME ["/var/cache/nginx"]
+
+EXPOSE 8080 8443
+
+# Add symbolic link to config.json to avoid mounting issues
+RUN ln -sf /usr/share/nginx/html/config/config.json /usr/share/nginx/html/config.json
+
+USER 998
+
+CMD ["nginx", "-g", "daemon off;"]
+
+COPY ${CONTEXT_DIR}/nginx-syndesis.conf /etc/nginx/conf.d
+COPY ${SRC_DIR} /usr/share/nginx/html

--- a/app/ui-react/nginx-syndesis.conf
+++ b/app/ui-react/nginx-syndesis.conf
@@ -1,0 +1,40 @@
+server {
+    listen       8080;
+    server_name  localhost;
+
+    gzip         on;
+    gzip_disable "msie6";
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss image/svg+xml;
+
+    root         /usr/share/nginx/html;
+
+    location = / {
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
+        try_files /index.html =200;
+    }
+
+    location ~ /.+ {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location = /logout {
+        set $cookie "";
+        if ($http_syndesis_xsrf_token = "awesome") {
+            set $cookie "_oauth_proxy=deleted; Expires=Thu, 01-Jan-1970 00:00:01 GMT; Domain=.$host; HttpOnly; Secure";
+        }
+        add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+        add_header Pragma "no-cache" always;
+        add_header Expires "0" always;
+        add_header Set-Cookie $cookie always;
+        default_type "text/html; charset=ISO-8859-1";
+        alias /usr/share/nginx/html/logout.html;
+    }
+
+}

--- a/app/ui-react/nginx.repo
+++ b/app/ui-react/nginx.repo
@@ -1,0 +1,5 @@
+[nginx]
+name=nginx repo
+baseurl=http://nginx.org/packages/mainline/rhel/7/$basearch/
+gpgcheck=1
+enabled=1

--- a/install/generator/02-syndesis-image-streams.yml.mustache
+++ b/install/generator/02-syndesis-image-streams.yml.mustache
@@ -30,7 +30,7 @@
     tags:
     - from:
         kind: DockerImage
-        name: ${SYNDESIS_REGISTRY}/{{ Images.SyndesisImagesPrefix }}/{{ Images.Syndesis.Ui }}:{{ Tags.Syndesis }}
+        name: ${SYNDESIS_REGISTRY}/{{ Images.SyndesisImagesPrefix }}/{{ Images.Syndesis.Ui }}:{{ Tags.Syndesis }}-react
       importPolicy:
         scheduled: true
       name: "{{ Tags.Syndesis }}"

--- a/install/syndesis.yml
+++ b/install/syndesis.yml
@@ -199,7 +199,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-ui:latest
+        name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-ui:latest-react
       importPolicy:
         scheduled: true
       name: "latest"


### PR DESCRIPTION
Bit more info in the commit messages.

This adds a `Dockerfile` ported over from the origin fork and sets the `syndesis.yml` template to use the tag `latest-react` (this enables the use of minishift via `syndesis minishift --install --local`). Also adds CircleCI configuration to build and publish to Docker Hub.