### PR TITLE
fix: CircleCI `publish` operates in `~`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,6 @@ jobs:
 
   publish:
     executor: docker-publish/docker
-    working_directory: ~/repo/app/ui-react
     steps:
       - attach_workspace:
           at: ~/


### PR DESCRIPTION
Since `persist_to_workspace` is configured with `~/repo/app/ui-react` as
`root` we do not need the `working_directory`.