### PR TITLE
fix: CircleCI `publish` operates in `~/project`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
     executor: docker-publish/docker
     steps:
       - attach_workspace:
-          at: ~/
+          at: ~/project
       - setup_remote_docker
       - docker-publish/check
       - docker-publish/build:


### PR DESCRIPTION
Seems like the default for CircleCI is to look into
`/home/circleci/project` so this restores the persisted files to that
location in order for the Docker Orb to work.

File under you-live-you-learn.