### PR TITLE
fix: fix: CircleCI `publish` image/tag for push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,8 @@ jobs:
           extra_build_args: '--ulimit nofile=1024'
           image: syndesis/syndesis-ui
           tag: latest-react
-      - docker-publish/deploy
+      - docker-publish/deploy:
+        image: syndesis/syndesis-ui:latest-react
 
   doc-deploy:
     docker:


### PR DESCRIPTION
Seems that the CircleCI Orb commands are independently configured so we
need to repeat the image/tag parameters.