### PR TITLE
fix: `deploy` command `image` parameter ident

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
           image: syndesis/syndesis-ui
           tag: latest-react
       - docker-publish/deploy:
-        image: syndesis/syndesis-ui:latest-react
+          image: syndesis/syndesis-ui:latest-react
 
   doc-deploy:
     docker:


### PR DESCRIPTION
Wrong indent of the `image` parameter in YAML build configuration caused
it not to be used.