### PR TITLE
refactor: ci docker build publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 version: 2.1
 
 orbs:
-  docker-publish: circleci/docker-publish@0.1.6
+  docker: circleci/docker@0.1.0
 
 jobs:
   build:
@@ -71,20 +71,6 @@ jobs:
             - .dockerignore
             - 'nginx*'
             - syndesis/build
-
-  publish:
-    executor: docker-publish/docker
-    steps:
-      - attach_workspace:
-          at: ~/project
-      - setup_remote_docker
-      - docker-publish/check
-      - docker-publish/build:
-          extra_build_args: '--ulimit nofile=1024'
-          image: syndesis/syndesis-ui
-          tag: latest-react
-      - docker-publish/deploy:
-          image: syndesis/syndesis-ui:latest-react
 
   doc-deploy:
     docker:
@@ -190,7 +176,14 @@ workflows:
             branches:
               ignore:
                 - gh-pages
-      - publish:
+      - docker/publish:
+          path: ~/project/app/ui-react
+          extra_build_args: '--ulimit nofile=1024'
+          image: syndesis/syndesis-ui
+          tag: latest-react
+          after_checkout:
+            - attach_workspace:
+                at: ~/project/app/ui-react
           requires:
             - build
           filters:


### PR DESCRIPTION
For aesthetics (bit less YAML) and maintenance (use more defaults), this uses the Docker publish orb's job instead of commands in a custom job.

Also found an orb that seems more _official_ and supports a tag on push.