### PR TITLE
fix: ci docker publish, specify Dockerfile path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,7 @@ workflows:
               ignore:
                 - gh-pages
       - docker/publish:
+          dockerfile: ~/project/app/ui-react/Dockerfile
           path: ~/project/app/ui-react
           extra_build_args: '--ulimit nofile=1024'
           image: syndesis/syndesis-ui


### PR DESCRIPTION
Turns out that I should read the source of the Docker Orb a bit better,
it is not sufficient to just specify the `path`, `dockerfile` needs to
be specified also.