### PR TITLE
chore: speedup compilation

### DIFF
--- a/app/ui-react/packages/api/package.json
+++ b/app/ui-react/packages/api/package.json
@@ -41,8 +41,8 @@
     "test": "jest",
     "test:watch": "yarn run test --watch",
     "prebuild": "rimraf dist",
-    "build": "microbundle --no-compress",
-    "dev": "microbundle watch --no-compress"
+    "build": "microbundle --format cjs --no-compress",
+    "dev": "microbundle watch --format cjs --no-compress"
   },
   "peerDependencies": {
     "patternfly-react": "^2.29.2",

--- a/app/ui-react/packages/atlasmap-adapter/package.json
+++ b/app/ui-react/packages/atlasmap-adapter/package.json
@@ -51,8 +51,8 @@
     "test": "jest",
     "test:watch": "yarn run test --watch",
     "prebuild": "rimraf dist",
-    "build": "microbundle --no-compress",
-    "dev": "microbundle watch --no-compress"
+    "build": "microbundle --format cjs --no-compress",
+    "dev": "microbundle watch --format cjs --no-compress"
   },
   "peerDependencies": {
     "react": "^16.6.0",

--- a/app/ui-react/packages/auto-form/package.json
+++ b/app/ui-react/packages/auto-form/package.json
@@ -51,8 +51,8 @@
     "test": "jest",
     "test:watch": "yarn run test --watch",
     "prebuild": "rimraf dist",
-    "build": "microbundle --no-compress",
-    "dev": "microbundle watch --no-compress",
+    "build": "microbundle --format cjs --no-compress",
+    "dev": "microbundle watch --format cjs --no-compress",
     "storybook": "start-storybook -p 9002",
     "build-storybook": "build-storybook -o ../../doc/auto-form"
   },

--- a/app/ui-react/packages/ui/package.json
+++ b/app/ui-react/packages/ui/package.json
@@ -59,8 +59,8 @@
     "test": "jest",
     "test:watch": "yarn run test --watch",
     "prebuild": "rimraf dist",
-    "build": "microbundle --no-compress",
-    "dev": "microbundle watch --no-compress",
+    "build": "microbundle --format cjs --no-compress",
+    "dev": "microbundle watch --format cjs --no-compress",
     "storybook": "start-storybook -p 9001",
     "build-storybook": "build-storybook -o ../../doc/ui"
   },

--- a/app/ui-react/packages/utils/package.json
+++ b/app/ui-react/packages/utils/package.json
@@ -41,8 +41,8 @@
     "test": "jest",
     "test:watch": "yarn run test --watch",
     "prebuild": "rimraf dist",
-    "build": "microbundle --no-compress",
-    "dev": "microbundle watch --no-compress"
+    "build": "microbundle --format cjs --no-compress",
+    "dev": "microbundle watch --format cjs --no-compress"
   },
   "peerDependencies": {
     "react": "^16.6.0",

--- a/app/ui-react/syndesis/craco.config.js
+++ b/app/ui-react/syndesis/craco.config.js
@@ -1,5 +1,7 @@
 module.exports = function({ env, paths }) {
   return {
+    // disable the custom loading of sourcemaps, it's too slow
+    /*
     webpack: {
       configure: (webpackConfig, { env, paths }) => {
         webpackConfig.module.rules[2].oneOf = webpackConfig.module.rules[2].oneOf.map(
@@ -13,5 +15,6 @@ module.exports = function({ env, paths }) {
         return webpackConfig;
       },
     },
+    */
   };
 };


### PR DESCRIPTION
Speedup achieved by removing the building of unneeded module formats; also removed the extraction of sourcemaps from the packages, which is a bummer since we can't debug the ts code of anything that's a dependency when running the app but was _really_ slowing down things.