### PR TITLE
feat: show a notification when a new version of the app is available

### DIFF
--- a/app/ui-react/packages/ui/src/Layout/ButtonLink.tsx
+++ b/app/ui-react/packages/ui/src/Layout/ButtonLink.tsx
@@ -46,6 +46,7 @@ export const ButtonLink: React.FunctionComponent<IButtonLinkProps> = ({
       onClick={onClick}
       className={className}
       disabled={disabled || (!onClick && !href)}
+      {...props}
     >
       {children}
     </button>

--- a/app/ui-react/packages/ui/src/Shared/DndFileChooser.tsx
+++ b/app/ui-react/packages/ui/src/Shared/DndFileChooser.tsx
@@ -213,6 +213,7 @@ export class DndFileChooser extends React.Component<
     const notifications = rejectedFiles.map(file => ({
       key: file.name,
       message: this.props.onUploadRejected(file.name),
+      persistent: false,
       type: 'error' as INotificationType,
     }));
 

--- a/app/ui-react/packages/ui/src/Shared/Notifications.tsx
+++ b/app/ui-react/packages/ui/src/Shared/Notifications.tsx
@@ -9,7 +9,8 @@ export type INotificationType = 'success' | 'info' | 'warning' | 'error';
 
 export interface INotification {
   key: string;
-  message: string;
+  message: React.ReactNode;
+  persistent: boolean;
   type: INotificationType;
 }
 
@@ -27,18 +28,22 @@ export class Notifications extends React.Component<INotificationsProps> {
           <TimedToastNotification
             key={notification.key}
             type={notification.type}
-            persistent={false}
+            persistent={notification.persistent}
             onDismiss={this.props.removeNotificationAction.bind(
               this,
               notification
             )}
             timerdelay={this.props.notificationTimerDelay}
           >
-            <Container
-              dangerouslySetInnerHTML={{
-                __html: notification.message,
-              }}
-            />
+            {typeof notification.message === 'string' ? (
+              <Container
+                dangerouslySetInnerHTML={{
+                  __html: notification.message,
+                }}
+              />
+            ) : (
+              <Container>{notification.message}</Container>
+            )}
           </TimedToastNotification>
         ))}
       </ToastNotificationList>

--- a/app/ui-react/syndesis/package.json
+++ b/app/ui-react/syndesis/package.json
@@ -30,7 +30,8 @@
     "react-i18next": "^10.2.0",
     "react-loadable": "^5.5.0",
     "react-router": "^5.0.0",
-    "react-router-dom": "^5.0.0"
+    "react-router-dom": "^5.0.0",
+    "workbox-window": "^4.3.1"
   },
   "scripts": {
     "lint": "tslint -c ../tslint.json --project .",

--- a/app/ui-react/syndesis/public/manifest.json
+++ b/app/ui-react/syndesis/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Syndesis",
+  "name": "Syndesis",
   "icons": [
     {
       "src": "favicon.ico",

--- a/app/ui-react/typings/workbox-window/index.d.ts
+++ b/app/ui-react/typings/workbox-window/index.d.ts
@@ -1,0 +1,46 @@
+declare module 'workbox-window' {
+  class Workbox {
+    constructor(scriptURL: string, registerOptions?: object);
+
+    register(immediate?: boolean): Promise<any>;
+    active(): Promise<ServiceWorker>;
+    controlling(): Promise<ServiceWorker>;
+    getSW(): Promise<ServiceWorker>;
+    messageSW(data: object): Promise<object>;
+
+    addEventListener(event: 'message', callback: (data: IWorkboxEventMessage) => void): void;
+    addEventListener(event: 'installed', callback: (data: IWorkboxEvent) => void): void;
+    addEventListener(event: 'waiting', callback: (data: IWorkboxEventWaiting) => void): void;
+    addEventListener(event: 'controlling', callback: (data: IWorkboxEvent) => void): void;
+    addEventListener(event: 'activated', callback: (data: IWorkboxEvent) => void): void;
+    addEventListener(event: 'redundant', callback: (data: IWorkboxEvent) => void): void;
+    addEventListener(event: 'externalinstalled', callback: (data: IWorkboxEventExternal) => void): void;
+    addEventListener(event: 'externalwaiting', callback: (data: IWorkboxEventExternal) => void): void;
+    addEventListener(event: 'externalactivated', callback: (data: IWorkboxEventExternal) => void): void;
+  }
+
+  type WorkboxEvent = 'message' | 'installed' | 'waiting' | 'controlling' | 'activated' | 'redundant' | 'externalinstalled' | 'externalwaiting' | 'externalactivated';
+
+  interface IWorkboxEventBase {
+    originalEvent: Event;
+    type: WorkboxEvent;
+    target: Workbox;
+  }
+
+  interface IWorkboxEventMessage extends IWorkboxEventBase {
+    data: any;
+  }
+
+  interface IWorkboxEvent extends IWorkboxEventBase {
+    sw: ServiceWorker;
+    isUpdate: boolean|undefined;
+  }
+
+  interface IWorkboxEventWaiting extends IWorkboxEvent {
+    wasWaitingBeforeRegister: boolean|undefined;
+  }
+
+  interface IWorkboxEventExternal extends IWorkboxEventBase {
+    sw: ServiceWorker;
+  }
+}

--- a/app/ui-react/typings/workbox-window/package.json
+++ b/app/ui-react/typings/workbox-window/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@types/workbox-window",
+  "version": "1.0.0",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Demo

![worker-refresh-toast](https://user-images.githubusercontent.com/966316/57527612-687a9800-7330-11e9-8e6e-6fdb2ec660ec.gif)

## How does it work

When building the app for production, a service worker is automatically installed and executed every time the app is loaded by the browser. If a new version of the application is available, the assets (js, css, images) are downloaded in background while the user is working, and a persistent toast is eventually displayed to inform the user of the fact, providing a link to click to update the application.

If the user decides to dismiss the toast or reloads the page without clicking the link in the toast, the old version of the app will be loaded instead, and the toast is displayed again. This will continue until the user clicks the link in the toast.

## Caveat

For this to work on the [new staging environment](https://syndesis-react-staging.b6ff.rh-idev.openshiftapps.com), if you have already visited it in the past you'll have to close the tab and open it again to ensure that the latest service worker is installed. From that moment forward, you'll be getting the toast for new deploys.