### PR TITLE
feat: wire in the template step page and get it saving/loading

### DIFF
--- a/app/ui-react/packages/ui/package.json
+++ b/app/ui-react/packages/ui/package.json
@@ -78,6 +78,8 @@
     "@patternfly/react-icons": "^3.8.1",
     "@syndesis/history": "*",
     "classnames": "^2.2.6",
+    "codemirror": "^5.46.0",
+    "react-codemirror2": "^6.0.0",
     "react-dropzone": "^10.0.0",
     "react-virtualized": "^9.20.1"
   },

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailInfo.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailInfo.tsx
@@ -26,6 +26,7 @@ export class IntegrationDetailInfo extends React.PureComponent<
       <div className="integration-detail-info">
         {this.props.name}
         <>
+          &nbsp;&nbsp;&nbsp;&nbsp;
           {this.props.currentState === 'Pending' && (
             <IntegrationStatusDetail
               targetState={this.props.targetState}
@@ -41,7 +42,6 @@ export class IntegrationDetailInfo extends React.PureComponent<
           )}
           {this.props.currentState === 'Published' && this.props.version && (
             <>
-              &nbsp;&nbsp;&nbsp;&nbsp;
               <span className="pficon pficon-ok" />
               &nbsp;Published version {this.props.version}
             </>

--- a/app/ui-react/packages/ui/src/Integration/editor/index.ts
+++ b/app/ui-react/packages/ui/src/Integration/editor/index.ts
@@ -1,1 +1,2 @@
 export * from './shared';
+export * from './steps';

--- a/app/ui-react/packages/ui/src/Integration/editor/steps/index.ts
+++ b/app/ui-react/packages/ui/src/Integration/editor/steps/index.ts
@@ -1,0 +1,1 @@
+export * from './template';

--- a/app/ui-react/packages/ui/src/Integration/editor/steps/template/TemplateStepCard.tsx
+++ b/app/ui-react/packages/ui/src/Integration/editor/steps/template/TemplateStepCard.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { ButtonLink, Container, PageSection } from '../../../../Layout';
+
+export interface ITemplateStepCardProps {
+  i18nDone: string;
+  isValid: boolean;
+  submitForm: (e?: any) => void;
+}
+
+export class TemplateStepCard extends React.Component<ITemplateStepCardProps> {
+  public render() {
+    return (
+      <PageSection>
+        <Container>
+          <div className="row row-cards-pf">
+            <div className="card-pf">
+              <div className="card-pf-body">
+                <Container>{this.props.children}</Container>
+              </div>
+              <div className="card-pf-footer">
+                <ButtonLink
+                  onClick={this.props.submitForm}
+                  disabled={!this.props.isValid}
+                  as={'primary'}
+                >
+                  {this.props.i18nDone}
+                </ButtonLink>
+              </div>
+            </div>
+          </div>
+        </Container>
+      </PageSection>
+    );
+  }
+}

--- a/app/ui-react/packages/ui/src/Integration/editor/steps/template/TemplateStepTemplateEditor.tsx
+++ b/app/ui-react/packages/ui/src/Integration/editor/steps/template/TemplateStepTemplateEditor.tsx
@@ -1,0 +1,49 @@
+import { Text, TextContent } from '@patternfly/react-core';
+import * as React from 'react';
+import { TextEditor } from '../../../../Shared';
+import { TemplateType } from './TemplateStepTypeSelector';
+
+interface ITemplateStepTemplateEditorProps {
+  mode: TemplateType;
+  textEditorDescription: React.ReactNode;
+  onChange: (editor: any, data: any, value: string) => void;
+  initialValue: string;
+  i18nFileUploadLimit: string;
+}
+
+export class TemplateStepTemplateEditor extends React.Component<
+  ITemplateStepTemplateEditorProps
+> {
+  public render() {
+    const editorOptions = {
+      gutters: ['CodeMirror-lint-markers'],
+      lineNumbers: false,
+      lineWrapping: true,
+      lint: true,
+      mode: this.props.mode,
+      readOnly: false,
+      showCursorWhenSelecting: true,
+      styleActiveLine: true,
+      tabSize: 2,
+    };
+    return (
+      <>
+        <TextContent>
+          <Text>{this.props.textEditorDescription}</Text>
+        </TextContent>
+        <TextContent>
+          <Text>
+            <small>
+              <i>{this.props.i18nFileUploadLimit}</i>
+            </small>
+          </Text>
+        </TextContent>
+        <TextEditor
+          onChange={this.props.onChange}
+          options={editorOptions}
+          value={this.props.initialValue}
+        />
+      </>
+    );
+  }
+}

--- a/app/ui-react/packages/ui/src/Integration/editor/steps/template/TemplateStepTypeSelector.tsx
+++ b/app/ui-react/packages/ui/src/Integration/editor/steps/template/TemplateStepTypeSelector.tsx
@@ -1,0 +1,80 @@
+import { Text, TextContent } from '@patternfly/react-core';
+import * as React from 'react';
+
+export enum TemplateType {
+  Freemarker = 'freemarker',
+  Mustache = 'mustache',
+  Velocity = 'velocity',
+}
+
+export interface ITemplateStepTypeSelectorProps {
+  i18nSpecifyTemplateType: string;
+  i18nFreemarkerLabel: string;
+  i18nMustacheLabel: string;
+  i18nVelocityLabel: string;
+  templateType: TemplateType;
+  onTemplateTypeChange: (type: TemplateType) => void;
+}
+
+export class TemplateStepTypeSelector extends React.Component<
+  ITemplateStepTypeSelectorProps
+> {
+  constructor(props: ITemplateStepTypeSelectorProps) {
+    super(props);
+    this.handleChange = this.handleChange.bind(this);
+  }
+  public handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const { value } = event.currentTarget;
+    this.props.onTemplateTypeChange(value as TemplateType);
+  }
+  public render() {
+    return (
+      <>
+        <TextContent>
+          <Text>{this.props.i18nSpecifyTemplateType}</Text>
+        </TextContent>
+        <div className="template-language-choices">
+          <div className="radio-inline">
+            <input
+              type="radio"
+              id="freemarker-choice"
+              name="template-lang-choice"
+              value={TemplateType.Freemarker}
+              checked={this.props.templateType === TemplateType.Freemarker}
+              onChange={this.handleChange}
+            />
+            <label htmlFor="freemarker-choice">
+              {this.props.i18nFreemarkerLabel}
+            </label>
+          </div>
+          <div className="radio-inline">
+            <input
+              type="radio"
+              id="mustache-choice"
+              name="template-lang-choice"
+              value={TemplateType.Mustache}
+              checked={this.props.templateType === TemplateType.Mustache}
+              onChange={this.handleChange}
+            />
+            <label htmlFor="mustache-choice">
+              {this.props.i18nMustacheLabel}
+            </label>
+          </div>
+          <div className="radio-inline">
+            <input
+              type="radio"
+              id="velocity-choice"
+              name="template-lang-choice"
+              value={TemplateType.Velocity}
+              checked={this.props.templateType === TemplateType.Velocity}
+              onChange={this.handleChange}
+            />
+            <label htmlFor="velocity-choice">
+              {this.props.i18nVelocityLabel}
+            </label>
+          </div>
+        </div>
+      </>
+    );
+  }
+}

--- a/app/ui-react/packages/ui/src/Integration/editor/steps/template/index.ts
+++ b/app/ui-react/packages/ui/src/Integration/editor/steps/template/index.ts
@@ -1,0 +1,3 @@
+export * from './TemplateStepCard';
+export * from './TemplateStepTypeSelector';
+export * from './TemplateStepTemplateEditor';

--- a/app/ui-react/packages/ui/src/Shared/TextEditor.tsx
+++ b/app/ui-react/packages/ui/src/Shared/TextEditor.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { ICodeMirror, UnControlled as CodeMirror } from 'react-codemirror2';
+
+import 'codemirror/lib/codemirror.css';
+
+export type ITextEditor = ICodeMirror;
+
+export interface ITextEditorProps {
+  value: string;
+  options: { [name: string]: any };
+  onChange: (editor: ITextEditor, data: any, value: string) => void;
+}
+
+export class TextEditor extends React.Component<ITextEditorProps> {
+  public render() {
+    // Set default options here
+    const options = { ...this.props.options };
+    return (
+      <>
+        <CodeMirror
+          value={this.props.value}
+          options={options}
+          onChange={this.props.onChange}
+        />
+      </>
+    );
+  }
+}

--- a/app/ui-react/packages/ui/src/Shared/index.ts
+++ b/app/ui-react/packages/ui/src/Shared/index.ts
@@ -14,4 +14,5 @@ export * from './Notifications';
 export * from './SimplePageHeader';
 export * from './ProgressWithLink';
 export * from './PfDropdownItem';
+export * from './TextEditor';
 export * from './UnrecoverableError';

--- a/app/ui-react/packages/ui/stories/Integration/editor/steps/TemplateStep.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Integration/editor/steps/TemplateStep.stories.tsx
@@ -1,0 +1,93 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import {
+  Container,
+  TemplateStepCard,
+  TemplateStepTemplateEditor,
+  TemplateStepTypeSelector,
+  TemplateType,
+} from '../../../../src';
+import { ITextEditor } from '../../../../src/Shared';
+
+const stories = storiesOf('Integration/editor/step/TemplateStep', module);
+
+stories.add('Normal', () => (
+  <>
+    <Container>
+      <TemplateStepStory
+        initialText={'Some words or something {{body}}'}
+        initialTemplateType={TemplateType.Mustache}
+      />
+    </Container>
+  </>
+));
+
+interface ITemplateStepStoryProps {
+  initialText: string;
+  initialTemplateType: string;
+}
+
+interface ITemplateStepStoryState {
+  text: string;
+  type: TemplateType;
+}
+
+class TemplateStepStory extends React.Component<
+  ITemplateStepStoryProps,
+  ITemplateStepStoryState
+> {
+  constructor(props: ITemplateStepStoryProps) {
+    super(props);
+    this.state = {
+      text: this.props.initialText,
+      type: this.props.initialTemplateType as TemplateType,
+    };
+    this.handleChange = this.handleChange.bind(this);
+    this.handleTemplateTypeChange = this.handleTemplateTypeChange.bind(this);
+  }
+  public handleChange(editor: ITextEditor, data: any, value: string) {
+    this.setState({
+      text: value,
+    });
+  }
+  public handleTemplateTypeChange(type: TemplateType) {
+    this.setState({
+      type,
+    });
+  }
+  public render() {
+    return (
+      <>
+        <TemplateStepCard
+          i18nDone={'Done'}
+          isValid={true}
+          submitForm={() => {
+            /* todo */
+          }}
+        >
+          <TemplateStepTypeSelector
+            i18nSpecifyTemplateType={'Specify template type:'}
+            i18nFreemarkerLabel={'Freemarker'}
+            i18nMustacheLabel={'Mustache'}
+            i18nVelocityLabel={'Velocity'}
+            templateType={this.state.type as TemplateType}
+            onTemplateTypeChange={this.handleTemplateTypeChange}
+          />
+          <TemplateStepTemplateEditor
+            mode={this.state.type as TemplateType}
+            i18nFileUploadLimit={'Max: 1 file (up to 1MB)'}
+            textEditorDescription={
+              <p>
+                Drag and drop a file, paste in text, or start typing in the text
+                editor below to add a template. If you already have a template
+                file, browse to upload the file.
+              </p>
+            }
+            initialValue={this.state.text}
+            onChange={this.handleChange}
+          />
+        </TemplateStepCard>
+      </>
+    );
+  }
+}

--- a/app/ui-react/packages/ui/stories/Shared/TextEditor.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Shared/TextEditor.stories.tsx
@@ -1,0 +1,44 @@
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import { ITextEditor, TextEditor } from '../../src/Shared';
+
+const stories = storiesOf('Shared/TextEditor', module);
+
+stories.add('Normal', () => (
+  <TextEditorStory initialValue={'\n\n\nHello world!\n\n\n'} />
+));
+
+interface ITextEditorStoryProps {
+  initialValue: string;
+}
+
+interface ITextEditorStoryState {
+  value: string;
+}
+
+class TextEditorStory extends React.Component<
+  ITextEditorStoryProps,
+  ITextEditorStoryState
+> {
+  constructor(props: ITextEditorStoryProps) {
+    super(props);
+    this.state = {
+      value: this.props.initialValue,
+    };
+    this.handleChange = this.handleChange.bind(this);
+  }
+  public handleChange(editor: ITextEditor, data: any, value: string) {
+    this.setState({
+      value,
+    });
+  }
+  public render() {
+    return (
+      <TextEditor
+        value={this.state.value}
+        options={{}}
+        onChange={this.handleChange}
+      />
+    );
+  }
+}

--- a/app/ui-react/syndesis/src/modules/integrations/IntegrationCreatorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/IntegrationCreatorApp.tsx
@@ -21,6 +21,7 @@ import { SelectActionPage } from './components/editor/endpoint/SelectActionPage'
 import { SaveIntegrationPage } from './components/editor/SaveIntegrationPage';
 import { SelectConnectionPage } from './components/editor/SelectConnectionPage';
 import { ConfigureStepPage } from './components/editor/step/ConfigureStepPage';
+import { TemplateStepPage } from './components/editor/template/TemplateStepPage';
 import { getDataShapeText, toUIStepKind } from './components/editor/utils';
 import resolvers from './resolvers';
 import routes from './routes';
@@ -46,7 +47,13 @@ const addStepPage = (
     }
     filterHref={resolvers.create.configure.editStep.basicFilter}
     mapperHref={resolvers.create.configure.editStep.dataMapper}
-    templateHref={resolvers.create.configure.editStep.template}
+    templateHref={(step, params, state) =>
+      resolvers.create.configure.editStep.template({
+        step,
+        ...params,
+        ...state,
+      })
+    }
     stepHref={(step, params, state) =>
       resolvers.create.configure.editStep.step({
         step,
@@ -486,7 +493,13 @@ const addStepSelectConnectionPage = (
     }
     filterHref={resolvers.create.configure.addStep.basicFilter}
     mapperHref={resolvers.create.configure.addStep.dataMapper}
-    templateHref={resolvers.create.configure.addStep.template}
+    templateHref={(step, params, state) =>
+      resolvers.create.configure.addStep.template({
+        step,
+        ...params,
+        ...state,
+      })
+    }
     stepHref={(step, params, state) =>
       resolvers.create.configure.addStep.step({
         step,
@@ -665,6 +678,38 @@ const editStepConfigureStepPage = (
   />
 );
 
+const addTemplateStepPage = (
+  <TemplateStepPage
+    mode={'adding'}
+    cancelHref={(p, s) => resolvers.create.configure.index({ ...p, ...s })}
+    sidebar={({ steps, activeIndex }) => (
+      <IntegrationEditorSidebar steps={steps} activeIndex={activeIndex} />
+    )}
+    postConfigureHref={(integration, params) =>
+      resolvers.create.configure.index({
+        integration,
+        ...params,
+      })
+    }
+  />
+);
+
+const editTemplateStepPage = (
+  <TemplateStepPage
+    mode={'editing'}
+    cancelHref={(p, s) => resolvers.create.configure.index({ ...p, ...s })}
+    sidebar={({ steps, activeIndex }) => (
+      <IntegrationEditorSidebar steps={steps} activeIndex={activeIndex} />
+    )}
+    postConfigureHref={(integration, params) =>
+      resolvers.create.configure.index({
+        integration,
+        ...params,
+      })
+    }
+  />
+);
+
 const TODO: React.FunctionComponent = () => <>TODO</>;
 
 /**
@@ -719,7 +764,7 @@ export const IntegrationCreatorApp: React.FunctionComponent = () => {
             }}
             template={{
               templatePath: routes.create.start.template,
-              templateChildren: TODO,
+              templateChildren: addTemplateStepPage,
             }}
             dataMapper={{
               mapperPath: routes.create.start.dataMapper,
@@ -764,7 +809,7 @@ export const IntegrationCreatorApp: React.FunctionComponent = () => {
             }}
             template={{
               templatePath: routes.create.finish.template,
-              templateChildren: TODO,
+              templateChildren: addTemplateStepPage,
             }}
             dataMapper={{
               mapperPath: routes.create.finish.dataMapper,
@@ -817,7 +862,7 @@ export const IntegrationCreatorApp: React.FunctionComponent = () => {
             }}
             template={{
               templatePath: routes.create.configure.addStep.template,
-              templateChildren: TODO,
+              templateChildren: addTemplateStepPage,
             }}
             dataMapper={{
               mapperPath: routes.create.configure.addStep.dataMapper,
@@ -862,7 +907,7 @@ export const IntegrationCreatorApp: React.FunctionComponent = () => {
             }}
             template={{
               templatePath: routes.create.configure.editStep.template,
-              templateChildren: TODO,
+              templateChildren: editTemplateStepPage,
             }}
             dataMapper={{
               mapperPath: routes.create.configure.editStep.dataMapper,

--- a/app/ui-react/syndesis/src/modules/integrations/IntegrationEditorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/IntegrationEditorApp.tsx
@@ -18,6 +18,7 @@ import { SelectActionPage } from './components/editor/endpoint/SelectActionPage'
 import { SaveIntegrationPage } from './components/editor/SaveIntegrationPage';
 import { SelectConnectionPage } from './components/editor/SelectConnectionPage';
 import { ConfigureStepPage } from './components/editor/step/ConfigureStepPage';
+import { TemplateStepPage } from './components/editor/template/TemplateStepPage';
 import resolvers from './resolvers';
 import routes from './routes';
 
@@ -42,7 +43,13 @@ const addStepPage = (
     }
     filterHref={resolvers.integration.edit.editStep.basicFilter}
     mapperHref={resolvers.integration.edit.editStep.dataMapper}
-    templateHref={resolvers.integration.edit.editStep.template}
+    templateHref={(step, params, state) =>
+      resolvers.integration.edit.editStep.template({
+        step,
+        ...params,
+        ...state,
+      })
+    }
     stepHref={(step, params, state) =>
       resolvers.integration.edit.editStep.step({
         step,
@@ -72,7 +79,13 @@ const selectConnectionPage = (
     }
     filterHref={resolvers.integration.edit.addStep.basicFilter}
     mapperHref={resolvers.integration.edit.addStep.dataMapper}
-    templateHref={resolvers.integration.edit.addStep.template}
+    templateHref={(step, params, state) =>
+      resolvers.integration.edit.addStep.template({
+        step,
+        ...params,
+        ...state,
+      })
+    }
     stepHref={(step, params, state) =>
       resolvers.integration.edit.addStep.step({
         step,
@@ -244,6 +257,38 @@ const editStepConfigureStepPage = (
   />
 );
 
+const addTemplateStepPage = (
+  <TemplateStepPage
+    cancelHref={(p, s) => resolvers.integration.edit.index({ ...p, ...s })}
+    mode={'adding'}
+    sidebar={({ steps, activeIndex }) => (
+      <IntegrationEditorSidebar steps={steps} activeIndex={activeIndex} />
+    )}
+    postConfigureHref={(integration, params) =>
+      resolvers.integration.edit.index({
+        integration,
+        ...params,
+      })
+    }
+  />
+);
+
+const editTemplateStepPage = (
+  <TemplateStepPage
+    cancelHref={(p, s) => resolvers.integration.edit.index({ ...p, ...s })}
+    mode={'editing'}
+    sidebar={({ steps, activeIndex }) => (
+      <IntegrationEditorSidebar steps={steps} activeIndex={activeIndex} />
+    )}
+    postConfigureHref={(integration, params) =>
+      resolvers.integration.edit.index({
+        integration,
+        ...params,
+      })
+    }
+  />
+);
+
 export interface IIntegrationEditorAppRouteState {
   integration: Integration;
 }
@@ -321,7 +366,7 @@ export const IntegrationEditorApp: React.FunctionComponent = () => {
                 }}
                 template={{
                   templatePath: routes.integration.edit.addStep.template,
-                  templateChildren: TODO,
+                  templateChildren: addTemplateStepPage,
                 }}
                 dataMapper={{
                   mapperPath: routes.integration.edit.addStep.dataMapper,
@@ -368,7 +413,7 @@ export const IntegrationEditorApp: React.FunctionComponent = () => {
                 }}
                 template={{
                   templatePath: routes.integration.edit.editStep.template,
-                  templateChildren: TODO,
+                  templateChildren: editTemplateStepPage,
                 }}
                 dataMapper={{
                   mapperPath: routes.integration.edit.editStep.dataMapper,

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/EditorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/EditorApp.tsx
@@ -5,6 +5,7 @@ import { EditPage } from './api-provider/ReviewPage';
 import { UploadPage } from './api-provider/UploadPage';
 import { ConfigureActionPage } from './endpoint/ConfigureActionPage';
 import { SelectActionPage } from './endpoint/SelectActionPage';
+import { TemplateStepPage } from './template/TemplateStepPage';
 
 export interface IEndpointEditorAppProps {
   selectActionPath: string;
@@ -68,7 +69,7 @@ export const ApiProviderApp: React.FunctionComponent<
 
 export interface ITemplateAppProps {
   templatePath: string;
-  templateChildren: React.ReactNode;
+  templateChildren: React.ReactElement<TemplateStepPage>;
 }
 export const TemplateApp: React.FunctionComponent<
   ITemplateAppProps

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/interfaces.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/interfaces.tsx
@@ -90,6 +90,17 @@ export interface ISelectConnectionRouteParams {
   position: string;
 }
 
+export interface ITemplateStepRouteParams {
+  flowId: string;
+  position: string;
+}
+
+export interface ITemplateStepRouteState {
+  step: StepKind;
+  integration: Integration;
+  updatedIntegration?: Integration;
+}
+
 /**
  * @param integration - the integration object coming from step 3.index, used to
  * render the IVP.

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/template/TemplateStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/template/TemplateStepPage.tsx
@@ -1,0 +1,125 @@
+import { getSteps, WithIntegrationHelpers } from '@syndesis/api';
+import * as H from '@syndesis/history';
+import { Integration, StringMap } from '@syndesis/models';
+import {
+  IntegrationEditorLayout,
+  TemplateStepCard,
+  TemplateType,
+} from '@syndesis/ui';
+import { WithRouteData } from '@syndesis/utils';
+import * as React from 'react';
+import { PageTitle } from '../../../../../shared';
+import {
+  ITemplateStepRouteParams,
+  ITemplateStepRouteState,
+  IUIStep,
+} from '../interfaces';
+import { toUIStepKindCollection } from '../utils';
+import { WithTemplater } from './WithTemplater';
+
+export interface ITemplateStepPageProps {
+  mode: 'adding' | 'editing';
+  cancelHref: (
+    p: ITemplateStepRouteParams,
+    s: ITemplateStepRouteState
+  ) => H.LocationDescriptor;
+  sidebar: (props: {
+    steps: IUIStep[];
+    activeIndex: number;
+  }) => React.ReactNode;
+  postConfigureHref: (
+    integration: Integration,
+    p: ITemplateStepRouteParams,
+    s: ITemplateStepRouteState
+  ) => H.LocationDescriptorObject;
+}
+
+export class TemplateStepPage extends React.Component<ITemplateStepPageProps> {
+  public render() {
+    return (
+      <WithIntegrationHelpers>
+        {({ addStep, updateStep }) => (
+          <WithRouteData<ITemplateStepRouteParams, ITemplateStepRouteState>>
+            {(
+              { flowId, position },
+              { step, integration, updatedIntegration },
+              { history }
+            ) => {
+              const positionAsNumber = parseInt(position, 10);
+              const onUpdatedIntegration = async ({
+                values,
+              }: StringMap<any>) => {
+                updatedIntegration = await (this.props.mode === 'adding'
+                  ? addStep
+                  : updateStep)(
+                  updatedIntegration || integration,
+                  step,
+                  flowId,
+                  positionAsNumber,
+                  values
+                );
+                history.push(
+                  this.props.postConfigureHref(
+                    updatedIntegration,
+                    { flowId, position },
+                    {
+                      integration,
+                      step,
+                      updatedIntegration,
+                    }
+                  )
+                );
+              };
+              const configuredProperties = step.configuredProperties || {};
+              const language =
+                configuredProperties.language || TemplateType.Mustache;
+              const template = configuredProperties.template || '';
+              return (
+                <>
+                  <PageTitle title={'Upload Template'} />
+                  <IntegrationEditorLayout
+                    title={'Upload Template'}
+                    description={
+                      'A template step takes data from a source and inserts it into the format that is defined in a template that you provide.'
+                    }
+                    sidebar={this.props.sidebar({
+                      activeIndex: positionAsNumber,
+                      steps: toUIStepKindCollection(
+                        getSteps(updatedIntegration || integration, flowId)
+                      ),
+                    })}
+                    content={
+                      <WithTemplater
+                        initialLanguage={language as TemplateType}
+                        initialText={template}
+                        onUpdatedIntegration={onUpdatedIntegration}
+                      >
+                        {({ controls, submitForm }) => (
+                          <TemplateStepCard
+                            i18nDone={'Done'}
+                            isValid={true}
+                            submitForm={submitForm}
+                          >
+                            {controls}
+                          </TemplateStepCard>
+                        )}
+                      </WithTemplater>
+                    }
+                    cancelHref={this.props.cancelHref(
+                      { flowId, position },
+                      {
+                        integration,
+                        step,
+                        updatedIntegration,
+                      }
+                    )}
+                  />
+                </>
+              );
+            }}
+          </WithRouteData>
+        )}
+      </WithIntegrationHelpers>
+    );
+  }
+}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/template/WithTemplater.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/template/WithTemplater.tsx
@@ -1,0 +1,85 @@
+import { StringMap } from '@syndesis/models';
+import {
+  TemplateStepTemplateEditor,
+  TemplateStepTypeSelector,
+  TemplateType,
+  TextEditor,
+} from '@syndesis/ui';
+import * as React from 'react';
+
+export interface IWithTemplaterChildrenProps {
+  controls: JSX.Element;
+  submitForm(): any;
+}
+export interface IWithTemplaterProps {
+  initialLanguage: TemplateType;
+  initialText: string;
+  onUpdatedIntegration(props: StringMap<any>): Promise<void>;
+  children(props: IWithTemplaterChildrenProps): any;
+}
+
+export interface IWithTemplaterState {
+  language: TemplateType;
+  text: string;
+}
+
+export class WithTemplater extends React.Component<
+  IWithTemplaterProps,
+  IWithTemplaterState
+> {
+  constructor(props: IWithTemplaterProps) {
+    super(props);
+    this.state = {
+      language: this.props.initialLanguage,
+      text: this.props.initialText,
+    };
+    this.handleTemplateTypeChange = this.handleTemplateTypeChange.bind(this);
+    this.handleEditorChange = this.handleEditorChange.bind(this);
+  }
+  public handleTemplateTypeChange(newType: TemplateType) {
+    this.setState({ language: newType });
+  }
+  public handleEditorChange(editor: TextEditor, data: any, text: string) {
+    this.setState({ text });
+  }
+  public render() {
+    const submitForm = () => {
+      this.props.onUpdatedIntegration({
+        values: {
+          language: this.state.language,
+          template: this.state.text,
+        },
+      });
+    };
+    const controls = (
+      <>
+        <TemplateStepTypeSelector
+          i18nSpecifyTemplateType={'Specify template type:'}
+          i18nFreemarkerLabel={'Freemarker'}
+          i18nMustacheLabel={'Mustache'}
+          i18nVelocityLabel={'Velocity'}
+          templateType={this.state.language as TemplateType}
+          onTemplateTypeChange={this.handleTemplateTypeChange}
+        />
+        <TemplateStepTemplateEditor
+          mode={this.state.language}
+          i18nFileUploadLimit={'Max: 1 file (up to 1MB)'}
+          textEditorDescription={
+            <>
+              Drag and drop a file, paste in text, or start typing in the text
+              editor below to add a template. If you already have a template
+              file, browse to upload the file.
+            </>
+          }
+          initialValue={this.state.text}
+          onChange={this.handleEditorChange}
+        />
+      </>
+    );
+
+    return this.props.children({
+      controls,
+      submitForm,
+    });
+  }
+}

--- a/app/ui-react/syndesis/src/modules/integrations/resolvers.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/resolvers.ts
@@ -24,6 +24,8 @@ import {
   ISelectActionRouteState,
   ISelectConnectionRouteParams,
   ISelectConnectionRouteState,
+  ITemplateStepRouteParams,
+  ITemplateStepRouteState,
 } from './components/editor/interfaces';
 import {
   IDetailsRouteParams,
@@ -151,6 +153,26 @@ export const configureConfigureStepMapper = ({
   };
 };
 
+export const configureTemplateStepMapper = ({
+  position,
+  step,
+  updatedIntegration,
+  ...rest
+}: IEditorConfigureStep) => {
+  const { params, state } = configureIndexMapper(rest);
+  return {
+    params: {
+      ...params,
+      position,
+    } as ITemplateStepRouteParams,
+    state: {
+      ...state,
+      step,
+      updatedIntegration,
+    } as ITemplateStepRouteState,
+  };
+};
+
 // TODO: unit test every single one of these resolvers 😫
 
 export const listResolver = makeResolverNoParams(routes.list);
@@ -259,6 +281,12 @@ export const createConfigureAddStepConfigureStepResolver = makeResolver<
   IConfigureStepRouteState
 >(routes.create.configure.addStep.step, configureConfigureStepMapper);
 
+export const createConfigureAddStepTemplateStepResolver = makeResolver<
+  IEditorConfigureStep,
+  ITemplateStepRouteParams,
+  ITemplateStepRouteState
+>(routes.create.configure.addStep.template, configureTemplateStepMapper);
+
 export const createConfigureEditStepSelectActionResolver = makeResolver<
   IEditorSelectAction,
   ISelectActionRouteParams,
@@ -288,6 +316,12 @@ export const createConfigureEditStepSaveAndPublishResolver = makeResolver<
   ISaveIntegrationRouteParams,
   ISaveIntegrationRouteState
 >(routes.create.configure.saveAndPublish, configureIndexMapper);
+
+export const createConfigureEditStepTemplateStepResolver = makeResolver<
+  IEditorConfigureStep,
+  ITemplateStepRouteParams,
+  ITemplateStepRouteState
+>(routes.create.configure.editStep.template, configureTemplateStepMapper);
 
 export const integrationActivityResolver = makeResolver<
   { integrationId: string; integration?: IIntegrationOverviewWithDraft },
@@ -351,6 +385,12 @@ export const integrationEditAddStepConfigureStepResolver = makeResolver<
   IConfigureStepRouteState
 >(routes.integration.edit.addStep.step, configureConfigureStepMapper);
 
+export const integrationEditAddStepTemplateStepResolver = makeResolver<
+  IEditorConfigureStep,
+  ITemplateStepRouteParams,
+  ITemplateStepRouteState
+>(routes.integration.edit.addStep.template, configureTemplateStepMapper);
+
 export const integrationEditEditStepSelectActionResolver = makeResolver<
   IEditorSelectAction,
   ISelectActionRouteParams,
@@ -374,6 +414,12 @@ export const integrationEditEditStepConfigureStepResolver = makeResolver<
   IConfigureStepRouteParams,
   IConfigureStepRouteState
 >(routes.integration.edit.editStep.step, configureConfigureStepMapper);
+
+export const integrationEditEditStepTemplateStepResolver = makeResolver<
+  IEditorConfigureStep,
+  ITemplateStepRouteParams,
+  ITemplateStepRouteState
+>(routes.integration.edit.editStep.template, configureTemplateStepMapper);
 
 export const integrationEditSaveAndPublish = makeResolver<
   IEditorIndex,
@@ -460,7 +506,7 @@ const resolvers: RouteResolver<typeof routes> = {
         },
         basicFilter: () => 'basicFilter',
         dataMapper: () => 'dataMapper',
-        template: () => 'template',
+        template: createConfigureAddStepTemplateStepResolver,
         step: createConfigureAddStepConfigureStepResolver,
         extension: () => 'extension',
       },
@@ -482,7 +528,7 @@ const resolvers: RouteResolver<typeof routes> = {
         },
         basicFilter: () => 'basicFilter',
         dataMapper: () => 'dataMapper',
-        template: () => 'template',
+        template: createConfigureEditStepTemplateStepResolver,
         step: createConfigureEditStepConfigureStepResolver,
         extension: () => 'extension',
       },
@@ -512,7 +558,7 @@ const resolvers: RouteResolver<typeof routes> = {
         },
         basicFilter: () => 'basicFilter',
         dataMapper: () => 'dataMapper',
-        template: () => 'template',
+        template: integrationEditAddStepTemplateStepResolver,
         step: integrationEditAddStepConfigureStepResolver,
         extension: () => 'extension',
       },
@@ -534,7 +580,7 @@ const resolvers: RouteResolver<typeof routes> = {
         },
         basicFilter: () => 'basicFilter',
         dataMapper: () => 'dataMapper',
-        template: () => 'template',
+        template: integrationEditEditStepTemplateStepResolver,
         step: integrationEditEditStepConfigureStepResolver,
         extension: () => 'extension',
       },

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -6698,6 +6698,11 @@ codelyzer@^4.4.4:
     source-map "^0.5.7"
     sprintf-js "^1.1.1"
 
+codemirror@^5.46.0:
+  version "5.46.0"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.46.0.tgz#be3591572f88911e0105a007c324856a9ece0fb7"
+  integrity sha512-3QpMge0vg4QEhHW3hBAtCipJEWjTJrqLLXdIaWptJOblf1vHFeXLNtFhPai/uX2lnFCehWNk4yOdaMR853Z02w==
+
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
@@ -17152,6 +17157,11 @@ react-clientside-effect@^1.2.0:
   dependencies:
     "@babel/runtime" "^7.0.0"
     shallowequal "^1.1.0"
+
+react-codemirror2@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/react-codemirror2/-/react-codemirror2-6.0.0.tgz#180065df57a64026026cde569a9708fdf7656525"
+  integrity sha512-D7y9qZ05FbUh9blqECaJMdDwKluQiO3A9xB+fssd5jKM7YAXucRuEOlX32mJQumUvHUkHRHqXIPBjm6g0FW0Ag==
 
 react-collapse@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
relates to #254

![image](https://user-images.githubusercontent.com/351660/57548082-120c5a00-732e-11e9-93b6-0ba2df94a4bc.png)

It loads/saves the `configuredProperties` to the step, still need to implement the linting support/validation and file drag/drop functionality.
