### PR TITLE
Connection Card match previous styles, fix kebab

### DIFF
--- a/app/ui-react/packages/ui/src/Connection/ConnectionCard.css
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionCard.css
@@ -1,21 +1,21 @@
 .connection-card,
 .connection-card:hover {
   color: inherit;
+  cursor: pointer;
+  height: 240px;
+  position: relative;
   text-decoration: none;
 }
 
-.connection-card__content {
-  display: flex;
-  align-items: center;
-  flex-flow: column;
-  text-align: center;
+.connection-card:hover {
+  box-shadow: 0 1px 6px rgba(3,3,3,.35);
 }
 
 .connection-card__heading--tech-preview {
   color: #363636;
   cursor: pointer;
   font-size: small;
-  padding: 4px;
+  padding: 5px 10px;
 }
 
 .connection-card__heading--no-border {
@@ -24,7 +24,49 @@
   padding: 4px;
 }
 
-.connection-card__footer--tech-preview {
+.connection-card__heading .heading__dropdown {
+  position: absolute;
+  top: 35px;
+  right: 35px;
+}
+
+a.connection-card__content:hover,
+a.connection-card__content:focus {
+  color: initial;
+  text-decoration: none;
+}
+
+.connection-card__body {
+  display: flex;
+  align-items: center;
+  flex-flow: column;
+  text-align: center;
+}
+
+.connection-card__body .connection-card__icon {
+  max-height: 35px;
+  max-width: 35px;
+  margin-bottom: 25px;
+  padding: 3px;
+}
+
+.connection-card__body .connection-card__title,
+.connection-card__body .connection-card__title:hover {
+  color: initial;
+  font-size: 20px;
+  font-weight: 300;
+  text-decoration: none;
+}
+
+.connection-card__body .connection-card__description {
+  color: initial;
+  font-size: small;
+  font-weight: 300;
+  margin-top: 15px;
+  text-decoration: none;
+}
+
+.connection-card__footer--config-required {
   background-color: #fdf2e5;
   border-color: #ec7a08;
   font-size: smaller;

--- a/app/ui-react/packages/ui/src/Connection/ConnectionCard.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionCard.tsx
@@ -107,12 +107,12 @@ export class ConnectionCard extends React.PureComponent<
             onConfirm={this.doDelete}
           />
         )}
-        <Card matchHeight={true}>
+        <Card matchHeight={true} className={'connection-card'}>
           <Card.Heading
             className={
               this.props.techPreview
-                ? 'connection-card__heading--tech-preview'
-                : 'connection-card__heading--no-border'
+                ? 'connection-card__heading connection-card__heading--tech-preview'
+                : 'connection-card__heading connection-card__heading--no-border'
             }
           >
             {this.props.techPreview ? (
@@ -138,7 +138,7 @@ export class ConnectionCard extends React.PureComponent<
               <Level gutter={'md'}>&nbsp;</Level>
             )}
             {this.props.menuProps && (
-              <div className="pull-right">
+              <div className="heading__dropdown pull-right">
                 <DropdownKebab
                   id={`connection-${this.props.name}-menu`}
                   pullRight={true}
@@ -194,9 +194,9 @@ export class ConnectionCard extends React.PureComponent<
               </div>
             )}
           </Card.Heading>
-          <Link to={this.props.href} className={'connection-card'}>
+          <Link to={this.props.href} className={'connection-card__content'}>
             <Card.Body>
-              <div className={'connection-card__content'}>
+              <div className={'connection-card__body'}>
                 <div className="connection-card__icon">
                   <img src={this.props.icon} alt={this.props.name} width={46} />
                 </div>
@@ -212,17 +212,16 @@ export class ConnectionCard extends React.PureComponent<
                 </Text>
               </div>
             </Card.Body>
-            {this.props.configurationRequired ? (
+            {this.props.configurationRequired && (
               <Card.Footer
                 className={
-                  this.props.techPreview &&
-                  'connection-card__footer--tech-preview alert alert-warning'
+                  'connection-card__footer--config-required alert alert-warning'
                 }
               >
                 <Icon type={'pf'} name={'warning-triangle-o'} size={'2x'} />
                 {this.props.i18nConfigurationRequired}
               </Card.Footer>
-            ) : null}
+            )}
           </Link>
         </Card>
       </>


### PR DESCRIPTION
- Fix kebab misalignment
- Add dropshadow to card on hover, remove underline and hyperlink color
- Improve aesthetics of card, add padding and increase height
- Change check for `techPreview` and rename `tech-preview` class in footer to `config-required`, which makes more sense.

![screencapture-localhost-3000-connections-2019-05-13-14_24_02](https://user-images.githubusercontent.com/3844502/57625215-55173900-758b-11e9-94ac-f2b8638c8fed.png)

Hover:

<img width="479" alt="Screenshot 2019-05-13 14 25 09 copy" src="https://user-images.githubusercontent.com/3844502/57625270-6fe9ad80-758b-11e9-96f4-b8412f54200e.png">

fix #249 