### PR TITLE
feat: re-fetch upon receiving connected message; clear error on read

### DIFF
--- a/app/ui-react/packages/api/src/Fetch.tsx
+++ b/app/ui-react/packages/api/src/Fetch.tsx
@@ -66,7 +66,7 @@ export class Fetch<T> extends React.Component<IFetchProps<T>, IFetchState<T>> {
 
   public async read() {
     try {
-      this.setState({ loading: true });
+      this.setState({ error: false, errorMessage: undefined, loading: true });
       const response = await callFetch({
         body: this.props.body,
         contentType: this.props.contentType,

--- a/app/ui-react/packages/api/src/WithApiConnectors.tsx
+++ b/app/ui-react/packages/api/src/WithApiConnectors.tsx
@@ -38,11 +38,18 @@ export class WithApiConnectors extends React.Component<
           }
           return (
             <ServerEventsContext.Consumer>
-              {({ registerChangeListener, unregisterChangeListener }) => (
+              {({
+                registerChangeListener,
+                unregisterChangeListener,
+                registerMessageListener,
+                unregisterMessageListener,
+              }) => (
                 <WithChangeListener
                   read={read}
                   registerChangeListener={registerChangeListener}
                   unregisterChangeListener={unregisterChangeListener}
+                  registerMessageListener={registerMessageListener}
+                  unregisterMessageListener={unregisterMessageListener}
                   filter={this.changeFilter}
                 >
                   {() => this.props.children(response)}

--- a/app/ui-react/packages/api/src/WithChangeListener.tsx
+++ b/app/ui-react/packages/api/src/WithChangeListener.tsx
@@ -1,6 +1,10 @@
 import { debounce } from '@syndesis/utils';
 import * as React from 'react';
-import { IChangeEvent } from './WithServerEvents';
+import {
+  EVENT_SERVICE_CONNECTED,
+  IChangeEvent,
+  IMessageEvent,
+} from './WithServerEvents';
 
 export interface IWithChangeListenerProps {
   filter: (change: IChangeEvent) => boolean;
@@ -9,6 +13,8 @@ export interface IWithChangeListenerProps {
   debounceWait?: number;
   registerChangeListener: (listener: (event: IChangeEvent) => void) => void;
   unregisterChangeListener: (listener: (event: IChangeEvent) => void) => void;
+  registerMessageListener: (listener: (event: IMessageEvent) => void) => void;
+  unregisterMessageListener: (listener: (event: IMessageEvent) => void) => void;
   children(): any;
 }
 
@@ -19,6 +25,7 @@ export class WithChangeListener extends React.Component<
   public constructor(props: IWithChangeListenerProps) {
     super(props);
     this.changeListener = this.changeListener.bind(this);
+    this.messageListener = this.messageListener.bind(this);
     this.read = this.read.bind(this);
     this.debouncedRead = this.props.disableDebounce
       ? this.read
@@ -35,10 +42,18 @@ export class WithChangeListener extends React.Component<
 
   public async componentDidMount() {
     this.props.registerChangeListener(this.changeListener);
+    this.props.registerMessageListener(this.messageListener);
   }
 
   public async componentWillUnmount() {
     this.props.unregisterChangeListener(this.changeListener);
+    this.props.unregisterMessageListener(this.messageListener);
+  }
+
+  public messageListener(event: IMessageEvent) {
+    if (event.data === EVENT_SERVICE_CONNECTED) {
+      this.debouncedRead();
+    }
   }
 
   public changeListener(event: IChangeEvent) {

--- a/app/ui-react/packages/api/src/WithConnections.tsx
+++ b/app/ui-react/packages/api/src/WithConnections.tsx
@@ -98,11 +98,18 @@ export class WithConnections extends React.Component<IWithConnectionsProps> {
           }
           return (
             <ServerEventsContext.Consumer>
-              {({ registerChangeListener, unregisterChangeListener }) => (
+              {({
+                registerChangeListener,
+                unregisterChangeListener,
+                registerMessageListener,
+                unregisterMessageListener,
+              }) => (
                 <WithChangeListener
                   read={read}
                   registerChangeListener={registerChangeListener}
                   unregisterChangeListener={unregisterChangeListener}
+                  registerMessageListener={registerMessageListener}
+                  unregisterMessageListener={unregisterMessageListener}
                   debounceWait={this.props.debounceWait}
                   filter={this.changeFilter}
                 >

--- a/app/ui-react/packages/api/src/WithConnectors.tsx
+++ b/app/ui-react/packages/api/src/WithConnectors.tsx
@@ -60,11 +60,18 @@ export class WithConnectors extends React.Component<IWithConnectorsProps> {
           }
           return (
             <ServerEventsContext.Consumer>
-              {({ registerChangeListener, unregisterChangeListener }) => (
+              {({
+                registerChangeListener,
+                unregisterChangeListener,
+                registerMessageListener,
+                unregisterMessageListener,
+              }) => (
                 <WithChangeListener
                   read={read}
                   registerChangeListener={registerChangeListener}
                   unregisterChangeListener={unregisterChangeListener}
+                  registerMessageListener={registerMessageListener}
+                  unregisterMessageListener={unregisterMessageListener}
                   filter={this.changeFilter}
                 >
                   {() =>

--- a/app/ui-react/packages/api/src/WithExtensionIntegrations.tsx
+++ b/app/ui-react/packages/api/src/WithExtensionIntegrations.tsx
@@ -37,11 +37,18 @@ export class WithExtensionIntegrations extends React.Component<
             this.props.children(response)
           ) : (
             <ServerEventsContext.Consumer>
-              {({ registerChangeListener, unregisterChangeListener }) => (
+              {({
+                registerChangeListener,
+                unregisterChangeListener,
+                registerMessageListener,
+                unregisterMessageListener,
+              }) => (
                 <WithChangeListener
                   read={read}
                   registerChangeListener={registerChangeListener}
                   unregisterChangeListener={unregisterChangeListener}
+                  registerMessageListener={registerMessageListener}
+                  unregisterMessageListener={unregisterMessageListener}
                   filter={this.changeFilter}
                 >
                   {() => this.props.children(response)}

--- a/app/ui-react/packages/api/src/WithExtensions.tsx
+++ b/app/ui-react/packages/api/src/WithExtensions.tsx
@@ -35,11 +35,18 @@ export class WithExtensions extends React.Component<IWithExtensionsProps> {
             this.props.children(response)
           ) : (
             <ServerEventsContext.Consumer>
-              {({ registerChangeListener, unregisterChangeListener }) => (
+              {({
+                registerChangeListener,
+                unregisterChangeListener,
+                registerMessageListener,
+                unregisterMessageListener,
+              }) => (
                 <WithChangeListener
                   read={read}
                   registerChangeListener={registerChangeListener}
                   unregisterChangeListener={unregisterChangeListener}
+                  registerMessageListener={registerMessageListener}
+                  unregisterMessageListener={unregisterMessageListener}
                   filter={this.changeFilter}
                 >
                   {() => this.props.children(response)}

--- a/app/ui-react/packages/api/src/WithIntegration.tsx
+++ b/app/ui-react/packages/api/src/WithIntegration.tsx
@@ -43,11 +43,18 @@ export class WithIntegration extends React.Component<IWithIntegrationProps> {
             this.props.children(response)
           ) : (
             <ServerEventsContext.Consumer>
-              {({ registerChangeListener, unregisterChangeListener }) => (
+              {({
+                registerChangeListener,
+                unregisterChangeListener,
+                registerMessageListener,
+                unregisterMessageListener,
+              }) => (
                 <WithChangeListener
                   read={read}
                   registerChangeListener={registerChangeListener}
                   unregisterChangeListener={unregisterChangeListener}
+                  registerMessageListener={registerMessageListener}
+                  unregisterMessageListener={unregisterMessageListener}
                   filter={this.changeFilter}
                 >
                   {() => this.props.children(response)}

--- a/app/ui-react/packages/api/src/WithIntegrations.tsx
+++ b/app/ui-react/packages/api/src/WithIntegrations.tsx
@@ -34,11 +34,18 @@ export class WithIntegrations extends React.Component<IWithIntegrationsProps> {
             this.props.children(response)
           ) : (
             <ServerEventsContext.Consumer>
-              {({ registerChangeListener, unregisterChangeListener }) => (
+              {({
+                registerChangeListener,
+                unregisterChangeListener,
+                registerMessageListener,
+                unregisterMessageListener,
+              }) => (
                 <WithChangeListener
                   read={read}
                   registerChangeListener={registerChangeListener}
                   unregisterChangeListener={unregisterChangeListener}
+                  registerMessageListener={registerMessageListener}
+                  unregisterMessageListener={unregisterMessageListener}
                   filter={this.changeFilter}
                 >
                   {() => this.props.children(response)}

--- a/app/ui-react/packages/api/src/WithMonitoredIntegration.tsx
+++ b/app/ui-react/packages/api/src/WithMonitoredIntegration.tsx
@@ -68,11 +68,18 @@ export class WithMonitoredIntegration extends React.Component<
               }
               return (
                 <ServerEventsContext.Consumer>
-                  {({ registerChangeListener, unregisterChangeListener }) => (
+                  {({
+                    registerChangeListener,
+                    unregisterChangeListener,
+                    registerMessageListener,
+                    unregisterMessageListener,
+                  }) => (
                     <WithChangeListener
                       read={read}
                       registerChangeListener={registerChangeListener}
                       unregisterChangeListener={unregisterChangeListener}
+                      registerMessageListener={registerMessageListener}
+                      unregisterMessageListener={unregisterMessageListener}
                       filter={this.changeFilter}
                     >
                       {() => {

--- a/app/ui-react/packages/api/src/WithMonitoredIntegrations.tsx
+++ b/app/ui-react/packages/api/src/WithMonitoredIntegrations.tsx
@@ -64,11 +64,18 @@ export class WithMonitoredIntegrations extends React.Component<
               }
               return (
                 <ServerEventsContext.Consumer>
-                  {({ registerChangeListener, unregisterChangeListener }) => (
+                  {({
+                    registerChangeListener,
+                    unregisterChangeListener,
+                    registerMessageListener,
+                    unregisterMessageListener,
+                  }) => (
                     <WithChangeListener
                       read={read}
                       registerChangeListener={registerChangeListener}
                       unregisterChangeListener={unregisterChangeListener}
+                      registerMessageListener={registerMessageListener}
+                      unregisterMessageListener={unregisterMessageListener}
                       filter={this.changeFilter}
                     >
                       {() => {

--- a/app/ui-react/packages/api/src/WithServerEvents.tsx
+++ b/app/ui-react/packages/api/src/WithServerEvents.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { callFetch, IFetchHeaders } from './callFetch';
 
+export const EVENT_SERVICE_CONNECTED = 'connected';
+
 export interface IChangeEvent {
   action: string;
   kind: string;


### PR DESCRIPTION
fixes #119 

I was totally gonna sneak this onto my last PR but @riccardo-forina merged it while I had stepped away :-)

Anyway, this fully fixes #119, I noticed that the app wasn't reverting back to showing the items once successfully reconnecting.  This ensures that when we reconnect and receive a connected event from the server the app will re-read, and that read will clear any previous read errors.  So if you don't happen to refresh the page it'll just go back to showing whatever list you were looking at.