### PR TITLE
chore(integration-list-view): clean up styles around integration list

### DIFF
--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationActions.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationActions.tsx
@@ -22,7 +22,11 @@ export class IntegrationActions extends React.Component<
   public render() {
     return (
       <>
-        <ButtonLink href={this.props.detailsHref} as={'primary'}>
+        <ButtonLink
+          className="view-integration-btn"
+          href={this.props.detailsHref}
+          as={'default'}
+        >
           View
         </ButtonLink>
         <DropdownKebab

--- a/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.css
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.css
@@ -2,12 +2,14 @@
   cursor: pointer;
 }
 
-.integration-list-item .config-required {
-  font-size: smaller;
+.integration-list-item .label,
+.integration-list-item .view-integration-btn {
+  font-size: var(--pf-global--FontSize--sm);
 }
 
-.integration-list-item .config-required .pficon {
-  padding-right: 5px;
+.integration-list-item .integration-icon__divider:before {
+  font-size: 20px;
+  line-height: 1.6;
 }
 
 .integration-list-item .integration-list-item__additional-info {

--- a/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.css
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.css
@@ -17,3 +17,10 @@
     margin-left: 0 !important;
   }
 }
+
+@media (min-width: 992px) {
+  .list-view-pf .list-group-item-heading {
+    min-width: 150px;
+    white-space: normal;
+  }
+}

--- a/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.css
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.css
@@ -11,3 +11,9 @@
 .integration-list-item .integration-list-item__additional-info {
   display: inline-block;
 }
+
+@media (max-width: 1204px) {
+  .integration-list-item .config-required {
+    margin-left: 0 !important;
+  }
+}

--- a/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.css
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.css
@@ -1,7 +1,3 @@
-.integration-list-item {
-  cursor: pointer;
-}
-
 .integration-list-item .label,
 .integration-list-item .view-integration-btn {
   font-size: var(--pf-global--FontSize--sm);

--- a/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.tsx
@@ -41,7 +41,11 @@ export class IntegrationsListItem extends React.Component<
         actions={this.props.actions}
         heading={this.props.integrationName}
         className={'integration-list-item'}
-        description={this.props.integrationDescription}
+        description={
+          <div className="syn-truncate__ellipsis">
+            {this.props.integrationDescription}
+          </div>
+        }
         additionalInfo={[
           <ListView.InfoItem
             key={1}
@@ -71,7 +75,11 @@ export class IntegrationsListItem extends React.Component<
           <ListView.InfoItem key={2}>
             {this.props.isConfigurationRequired && (
               <div className={'config-required pf-u-my-sm'}>
-                <Icon type={'pf'} name={'warning-triangle-o'} />
+                <Icon
+                  type={'pf'}
+                  name={'warning-triangle-o'}
+                  className="pf-u-mr-xs"
+                />
                 {this.props.i18nConfigurationRequired}
               </div>
             )}
@@ -83,7 +91,7 @@ export class IntegrationsListItem extends React.Component<
             finishConnectionIcon={this.props.finishConnectionIcon}
           />
         }
-        stacked={true}
+        stacked={false}
       />
     );
   }

--- a/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.tsx
@@ -9,6 +9,7 @@ import './IntegrationsListItem.css';
 
 export interface IIntegrationsListItemProps {
   integrationName: string;
+  integrationDescription?: string;
   currentState: IntegrationState;
   targetState: IntegrationState;
   isConfigurationRequired: boolean;
@@ -40,14 +41,7 @@ export class IntegrationsListItem extends React.Component<
         actions={this.props.actions}
         heading={this.props.integrationName}
         className={'integration-list-item'}
-        description={
-          this.props.isConfigurationRequired && (
-            <div className={'config-required'}>
-              <Icon type={'pf'} name={'warning-triangle-o'} />
-              {this.props.i18nConfigurationRequired}
-            </div>
-          )
-        }
+        description={this.props.integrationDescription}
         additionalInfo={[
           <ListView.InfoItem
             key={1}
@@ -72,6 +66,14 @@ export class IntegrationsListItem extends React.Component<
                 i18nUnpublished={this.props.i18nUnpublished}
                 i18nError={this.props.i18nError}
               />
+            )}
+          </ListView.InfoItem>,
+          <ListView.InfoItem key={2}>
+            {this.props.isConfigurationRequired && (
+              <div className={'config-required pf-u-my-sm'}>
+                <Icon type={'pf'} name={'warning-triangle-o'} />
+                {this.props.i18nConfigurationRequired}
+              </div>
             )}
           </ListView.InfoItem>,
         ]}

--- a/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.tsx
@@ -9,7 +9,6 @@ import './IntegrationsListItem.css';
 
 export interface IIntegrationsListItemProps {
   integrationName: string;
-  integrationDescription?: string;
   currentState: IntegrationState;
   targetState: IntegrationState;
   isConfigurationRequired: boolean;
@@ -42,9 +41,16 @@ export class IntegrationsListItem extends React.Component<
         heading={this.props.integrationName}
         className={'integration-list-item'}
         description={
-          <div className="syn-truncate__ellipsis">
-            {this.props.integrationDescription}
-          </div>
+          this.props.isConfigurationRequired && (
+            <div className={'config-required pf-u-my-sm pf-u-ml-2xl'}>
+              <Icon
+                type={'pf'}
+                name={'warning-triangle-o'}
+                className="pf-u-mr-xs"
+              />
+              {this.props.i18nConfigurationRequired}
+            </div>
+          )
         }
         additionalInfo={[
           <ListView.InfoItem
@@ -70,18 +76,6 @@ export class IntegrationsListItem extends React.Component<
                 i18nUnpublished={this.props.i18nUnpublished}
                 i18nError={this.props.i18nError}
               />
-            )}
-          </ListView.InfoItem>,
-          <ListView.InfoItem key={2}>
-            {this.props.isConfigurationRequired && (
-              <div className={'config-required pf-u-my-sm pf-u-ml-2xl'}>
-                <Icon
-                  type={'pf'}
-                  name={'warning-triangle-o'}
-                  className="pf-u-mr-xs"
-                />
-                {this.props.i18nConfigurationRequired}
-              </div>
             )}
           </ListView.InfoItem>,
         ]}

--- a/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.tsx
@@ -74,7 +74,7 @@ export class IntegrationsListItem extends React.Component<
           </ListView.InfoItem>,
           <ListView.InfoItem key={2}>
             {this.props.isConfigurationRequired && (
-              <div className={'config-required pf-u-my-sm'}>
+              <div className={'config-required pf-u-my-sm pf-u-ml-2xl'}>
                 <Icon
                   type={'pf'}
                   name={'warning-triangle-o'}

--- a/app/ui-react/packages/ui/src/index.css
+++ b/app/ui-react/packages/ui/src/index.css
@@ -76,7 +76,7 @@ body {
   width: 100%;
 }
 
-.list-view-pf-stacked .list-group-item-heading {
+.list-view-pf-body .list-group-item-heading {
   font-size: var(--pf-global--FontSize--sm);
 }
 

--- a/app/ui-react/packages/ui/src/index.css
+++ b/app/ui-react/packages/ui/src/index.css
@@ -114,3 +114,9 @@ body {
 .list-view-pf-view {
   margin-top: 0;
 }
+
+.syn-truncate__ellipsis {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}

--- a/app/ui-react/packages/ui/src/index.css
+++ b/app/ui-react/packages/ui/src/index.css
@@ -76,7 +76,10 @@ body {
   width: 100%;
 }
 
-.list-view-pf-stacked .list-group-item-heading,
+.list-view-pf-stacked .list-group-item-heading {
+  font-size: var(--pf-global--FontSize--sm);
+}
+
 .label {
   font-size: var(--pf-global--FontSize--xs);
 }

--- a/app/ui-react/syndesis/src/modules/integrations/components/Integrations.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/Integrations.tsx
@@ -46,9 +46,6 @@ export class Integrations extends React.Component<IIntegrationsProps> {
                             >
                               {({ actions }) => (
                                 <IntegrationsListItem
-                                  integrationDescription={
-                                    mi.integration.description
-                                  }
                                   integrationName={mi.integration.name}
                                   currentState={mi.integration!.currentState!}
                                   targetState={mi.integration!.targetState!}

--- a/app/ui-react/syndesis/src/modules/integrations/components/Integrations.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/Integrations.tsx
@@ -46,6 +46,9 @@ export class Integrations extends React.Component<IIntegrationsProps> {
                             >
                               {({ actions }) => (
                                 <IntegrationsListItem
+                                  integrationDescription={
+                                    mi.integration.description
+                                  }
                                   integrationName={mi.integration.name}
                                   currentState={mi.integration!.currentState!}
                                   targetState={mi.integration!.targetState!}


### PR DESCRIPTION
This PR updates the integration list page with some UX and styling improvements. 

<img width="1288" alt="Screen Shot 2019-05-16 at 1 05 51 PM" src="https://user-images.githubusercontent.com/5942899/57874309-470d2680-77de-11e9-8564-c170093caf4a.png">


move config required notice to its own column
align font sizes in integration list rows
view integration button is now secondary
include integration description in the integration list