### PR TITLE
fix: api provider detection and atlasmap url composition

### DIFF
--- a/app/ui-react/packages/atlasmap-assembly/src/app/data-mapper-host.component.ts
+++ b/app/ui-react/packages/atlasmap-assembly/src/app/data-mapper-host.component.ts
@@ -81,13 +81,24 @@ export class DataMapperHostComponent implements OnInit, OnDestroy, OnChanges {
     c.initCfg.xsrfDefaultTokenValue = environment.xsrf.defaultTokenValue;
     c.initCfg.xsrfHeaderName = environment.xsrf.headerName;
 
-    console.log(c.initCfg);
+    const makeUrl = (url: string) => {
+      return !url.startsWith('http') &&
+        !url.startsWith(this.baseMappingServiceUrl)
+        ? this.baseMappingServiceUrl + url
+        : url;
+    };
 
     // initialize base urls for our service calls
-    c.initCfg.baseJavaInspectionServiceUrl = this.baseJavaInspectionServiceUrl;
-    c.initCfg.baseXMLInspectionServiceUrl = this.baseXMLInspectionServiceUrl;
-    c.initCfg.baseJSONInspectionServiceUrl = this.baseJSONInspectionServiceUrl;
     c.initCfg.baseMappingServiceUrl = this.baseMappingServiceUrl;
+    c.initCfg.baseJavaInspectionServiceUrl = makeUrl(
+      this.baseJavaInspectionServiceUrl
+    );
+    c.initCfg.baseXMLInspectionServiceUrl = makeUrl(
+      this.baseXMLInspectionServiceUrl
+    );
+    c.initCfg.baseJSONInspectionServiceUrl = makeUrl(
+      this.baseJSONInspectionServiceUrl
+    );
 
     // // enable the navigation bar and import/export for stand-alone
     c.initCfg.disableNavbar = true;

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/dataMapper/DataMapperPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/dataMapper/DataMapperPage.tsx
@@ -132,25 +132,7 @@ export const DataMapperPage: React.FunctionComponent<
                         initialMappings={
                           (state.step.configuredProperties || {})[MAPPING_KEY]
                         }
-                        baseXMLInspectionServiceUrl={
-                          appContext.config.apiBase +
-                          appContext.config.datamapper
-                            .baseXMLInspectionServiceUrl
-                        }
-                        baseMappingServiceUrl={
-                          appContext.config.apiBase +
-                          appContext.config.datamapper.baseMappingServiceUrl
-                        }
-                        baseJSONInspectionServiceUrl={
-                          appContext.config.apiBase +
-                          appContext.config.datamapper
-                            .baseJSONInspectionServiceUrl
-                        }
-                        baseJavaInspectionServiceUrl={
-                          appContext.config.apiBase +
-                          appContext.config.datamapper
-                            .baseJavaInspectionServiceUrl
-                        }
+                        {...appContext.config.datamapper}
                         onMappings={onMappings}
                       />
                     </PageSection>

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
@@ -43,7 +43,7 @@ type StepKindHrefCallback = (
 ) => H.LocationDescriptorObject;
 
 export function getStepKind(step: Step): IUIStep['uiStepKind'] {
-  if (step.connection && step.connection.connectorId === 'api-provider') {
+  if (step.connection && step.connection.id === 'api-provider') {
     return 'api-provider';
   }
   return step.stepKind;


### PR DESCRIPTION
Fix the API provider detection logic.
Fix the URL composition for Atlasmap, checking if we are dealing with absolute or relative paths and act accordingly.

CC @igarashitm one thing that's not clear to me if the `baseMappingServiceUrl` property in the configuration plays a role or not with the other URLs - `baseJavaInspectionServiceUrl`, `baseXMLInspectionServiceUrl`, `baseJSONInspectionServiceUrl`. Right now the logic is that if `baseMappingServiceUrl` is not contained in the specialized URL, we prepend it to it. Logic [is here](https://github.com/syndesisio/syndesis-react/compare/master...riccardo-forina:bugfixes?expand=1#diff-b9d98e0dd7b4c930d63d5c031dff8d6aR84)

Does it sound correct to you?