### PR TITLE
feat: update required field prompts for auto forms

### DIFF
--- a/app/ui-react/packages/api/src/useIntegrationHelpers.tsx
+++ b/app/ui-react/packages/api/src/useIntegrationHelpers.tsx
@@ -206,22 +206,18 @@ export const useIntegrationHelpers = () => {
     actionId: string,
     configuredProperties: any
   ): Promise<ActionDescriptor | null> => {
-    if (configuredProperties) {
-      const response = await callFetch({
-        body: configuredProperties,
-        headers: apiContext.headers,
-        method: 'POST',
-        url: `${
-          apiContext.apiUri
-        }/connections/${connectionId}/actions/${actionId}`,
-      });
-      if (!response.ok) {
-        throw new Error(response.statusText);
-      }
-      return (await response.json()) as ActionDescriptor;
-    } else {
-      return null;
+    const response = await callFetch({
+      body: configuredProperties || {},
+      headers: apiContext.headers,
+      method: 'POST',
+      url: `${
+        apiContext.apiUri
+      }/connections/${connectionId}/actions/${actionId}`,
+    });
+    if (!response.ok) {
+      throw new Error(response.statusText);
     }
+    return (await response.json()) as ActionDescriptor;
   };
 
   /**

--- a/app/ui-react/packages/auto-form/src/AutoForm.tsx
+++ b/app/ui-react/packages/auto-form/src/AutoForm.tsx
@@ -17,9 +17,17 @@ export interface IAutoFormProps<T> {
    */
   isInitialValid?: boolean;
   /**
+   * If all fields in the form are required or not
+   */
+  allFieldsRequired?: boolean;
+  /**
    * String to be displayed when a required field isn't set
    */
   i18nRequiredProperty: string;
+  /**
+   * String to be displayed when some or all properties are required
+   */
+  i18nFieldsStatusText?: string;
   /**
    * Callback function that will be called when the form is submitted
    */
@@ -88,8 +96,18 @@ export class AutoForm<T> extends React.Component<IAutoFormProps<T>> {
                 errors,
                 fields: (
                   <React.Fragment>
+                    {this.props.i18nFieldsStatusText && (
+                      <p
+                        className="fields-status-pf"
+                        dangerouslySetInnerHTML={{
+                          __html: this.props.i18nFieldsStatusText,
+                        }}
+                      />
+                    )}
                     {fields.map(property =>
                       getField({
+                        allFieldsRequired:
+                          this.props.allFieldsRequired || false,
                         errors,
                         property,
                         touched,

--- a/app/ui-react/packages/auto-form/src/FormBuilder.tsx
+++ b/app/ui-react/packages/auto-form/src/FormBuilder.tsx
@@ -15,6 +15,7 @@ export interface INamedConfigurationProperty extends IFormDefinitionProperty {
 }
 
 export interface IRenderFieldProps {
+  allFieldsRequired: boolean;
   property: INamedConfigurationProperty;
   value: any;
   [name: string]: any;
@@ -51,7 +52,7 @@ export class FormBuilder<T> extends React.Component<IFormBuilderProps<T>> {
       textarea: FormTextAreaComponent,
     };
     const validate = (value: any) => {
-      if (props.property.required && !value) {
+      if (props.property.required && typeof value === 'undefined') {
         return this.props.i18nRequiredProperty;
       }
       return undefined;

--- a/app/ui-react/packages/auto-form/src/models.ts
+++ b/app/ui-react/packages/auto-form/src/models.ts
@@ -65,7 +65,8 @@ export interface IFormDefinitionProperty {
 }
 
 export interface IFormControl extends FieldProps {
-  name?: string;
-  type?: string;
+  name: string;
+  type: string;
+  allFieldsRequired: boolean;
   property: IFormDefinitionProperty;
 }

--- a/app/ui-react/packages/auto-form/src/widgets/FormDurationComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormDurationComponent.tsx
@@ -106,7 +106,15 @@ export class FormDurationComponent extends React.Component<
         controlId={this.props.field.name}
         validationState={getValidationState(this.props)}
       >
-        <ControlLabel>{this.props.property.displayName}</ControlLabel>
+        <ControlLabel
+          className={
+            this.props.property.required && !this.props.allFieldsRequired
+              ? 'required-pf'
+              : ''
+          }
+        >
+          {this.props.property.displayName}
+        </ControlLabel>
         {this.props.property.labelHint && (
           <ControlLabel>
             <FieldLevelHelp content={this.props.property.labelHint} />

--- a/app/ui-react/packages/auto-form/src/widgets/FormInputComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormInputComponent.tsx
@@ -16,7 +16,13 @@ export const FormInputComponent: React.FunctionComponent<
     controlId={props.field.name}
     validationState={getValidationState(props)}
   >
-    <ControlLabel>{props.property.displayName}</ControlLabel>
+    <ControlLabel
+      className={
+        props.property.required && !props.allFieldsRequired ? 'required-pf' : ''
+      }
+    >
+      {props.property.displayName}
+    </ControlLabel>
     {props.property.labelHint && (
       <ControlLabel>
         <FieldLevelHelp content={props.property.labelHint} />

--- a/app/ui-react/packages/auto-form/src/widgets/FormSelectComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormSelectComponent.tsx
@@ -32,7 +32,15 @@ export const FormSelectComponent: React.FunctionComponent<
       controlId={field.name}
       validationState={getValidationState(props)}
     >
-      <ControlLabel>{props.property.displayName}</ControlLabel>
+      <ControlLabel
+        className={
+          props.property.required && !props.allFieldsRequired
+            ? 'required-pf'
+            : ''
+        }
+      >
+        {props.property.displayName}
+      </ControlLabel>
       {props.property.labelHint && (
         <ControlLabel>
           <FieldLevelHelp content={props.property.labelHint} />

--- a/app/ui-react/packages/auto-form/src/widgets/FormTextAreaComponent.tsx
+++ b/app/ui-react/packages/auto-form/src/widgets/FormTextAreaComponent.tsx
@@ -16,7 +16,13 @@ export const FormTextAreaComponent: React.FunctionComponent<
     controlId={props.field.name}
     validationState={getValidationState(props)}
   >
-    <ControlLabel>{props.property.displayName}</ControlLabel>
+    <ControlLabel
+      className={
+        props.property.required && !props.allFieldsRequired ? 'required-pf' : ''
+      }
+    >
+      {props.property.displayName}
+    </ControlLabel>
     {props.property.labelHint && (
       <ControlLabel>
         <FieldLevelHelp content={props.property.labelHint} />

--- a/app/ui-react/packages/utils/src/autoformHelpers.ts
+++ b/app/ui-react/packages/utils/src/autoformHelpers.ts
@@ -86,6 +86,51 @@ export function applyInitialValues(
   return configuredProperties;
 }
 
+export function anyFieldsRequired(properties: IConfigurationProperties) {
+  return (
+    Object.keys(properties)
+      .filter(key => requiredTypeMask(properties[key]))
+      .filter(key => properties[key].required).length > 0
+  );
+}
+
+function requiredTypeMask(property: IConfigurationProperty) {
+  switch (property.type) {
+    case 'boolean':
+    case 'checkbox':
+    case 'hidden':
+      return false;
+    default:
+      return true;
+  }
+}
+
+export function allFieldsRequired(properties: IConfigurationProperties) {
+  const keys = Object.keys(properties).filter(key =>
+    requiredTypeMask(properties[key])
+  );
+  const allRequired = keys.filter(key => properties[key].required);
+  if (allRequired.length === 0) {
+    return false;
+  }
+  return keys.length === allRequired.length;
+}
+
+export function getRequiredStatusText(
+  properties: IConfigurationProperties,
+  allRequired: string,
+  someRequired: string,
+  noneRequired: string
+) {
+  if (allFieldsRequired(properties)) {
+    return allRequired;
+  }
+  if (anyFieldsRequired(properties)) {
+    return someRequired;
+  }
+  return noneRequired;
+}
+
 export function validateConfiguredProperties(
   properties: IConfigurationProperties,
   values?: { [name: string]: any }

--- a/app/ui-react/syndesis/src/i18n/locales/shared-translations.en.json
+++ b/app/ui-react/syndesis/src/i18n/locales/shared-translations.en.json
@@ -69,6 +69,8 @@
       "viewLogs": "View Logs",
       "HideDetails": "Hide Details",
       "ShowDetails": "Show Details",
+      "FieldsMarkedWithStarRequired": "The fields marked with <span class=\"required-pf\">*</span> are required.",
+      "AllFieldsRequired": "All fields are required.",
       "links": {
         "contactus": "//access.redhat.com/support/cases/#/case/new",
         "userguide": "//access.redhat.com/documentation/en-us/red_hat_fuse/$t(project.version)/html-single/integrating_applications_with_fuse_online",

--- a/app/ui-react/syndesis/src/modules/connections/components/WithConnectorForm.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/components/WithConnectorForm.tsx
@@ -2,8 +2,13 @@ import { WithConnectionHelpers } from '@syndesis/api';
 import { AutoForm } from '@syndesis/auto-form';
 import { Connector } from '@syndesis/models';
 import { IConnectorConfigurationFormValidationResult } from '@syndesis/ui';
-import { toFormDefinition } from '@syndesis/utils';
+import {
+  allFieldsRequired,
+  getRequiredStatusText,
+  toFormDefinition,
+} from '@syndesis/utils';
 import * as React from 'react';
+import i18n from '../../../i18n';
 
 export interface IWithConnectorFormChildrenProps {
   /**
@@ -165,11 +170,18 @@ export class WithConnectorForm extends React.Component<
               }
             }
           };
-
+          const requiredPrompt = getRequiredStatusText(
+            definition,
+            i18n.t('shared:AllFieldsRequired'),
+            i18n.t('shared:FieldsMarkedWithStarRequired'),
+            ''
+          );
           return (
             <AutoForm<{ [key: string]: string }>
               i18nRequiredProperty={'* Required field'}
               definition={toFormDefinition(definition)}
+              i18nFieldsStatusText={requiredPrompt}
+              allFieldsRequired={allFieldsRequired(definition)}
               initialValue={this.props.initialValue!}
               validate={validateFormAgainstBackend}
               onSave={this.props.onSave}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/WithConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/WithConfigurationForm.tsx
@@ -17,12 +17,15 @@ import {
   PageSectionLoader,
 } from '@syndesis/ui';
 import {
+  allFieldsRequired,
   applyInitialValues,
+  getRequiredStatusText,
   toFormDefinition,
   validateConfiguredProperties,
   WithLoader,
 } from '@syndesis/utils';
 import * as React from 'react';
+import i18n from '../../../../../i18n';
 import { ApiError } from '../../../../../shared';
 
 export interface IWithConfigurationFormChildrenProps {
@@ -152,9 +155,17 @@ export class WithConfigurationForm extends React.Component<
         definition,
         initialValue
       );
+      const requiredPrompt = getRequiredStatusText(
+        definition,
+        i18n.t('shared:AllFieldsRequired'),
+        i18n.t('shared:FieldsMarkedWithStarRequired'),
+        ''
+      );
       return (
         <AutoForm<{ [key: string]: string }>
           i18nRequiredProperty={'* Required field'}
+          allFieldsRequired={allFieldsRequired(definition)}
+          i18nFieldsStatusText={requiredPrompt}
           definition={toFormDefinition(definition)}
           initialValue={initialValue}
           isInitialValid={isInitialValid}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/step/WithConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/step/WithConfigurationForm.tsx
@@ -8,11 +8,14 @@ import { AutoForm } from '@syndesis/auto-form';
 import { ConfigurationProperty, StepKind } from '@syndesis/models';
 import { IntegrationEditorForm } from '@syndesis/ui';
 import {
+  allFieldsRequired,
   applyInitialValues,
+  getRequiredStatusText,
   toFormDefinition,
   validateConfiguredProperties,
 } from '@syndesis/utils';
 import * as React from 'react';
+import i18n from '../../../../../i18n';
 
 export interface IWithConfigurationFormChildrenProps {
   /**
@@ -113,9 +116,17 @@ export class WithConfigurationForm extends React.Component<
       definition,
       initialValue
     );
+    const requiredPrompt = getRequiredStatusText(
+      definition,
+      i18n.t('shared:AllFieldsRequired'),
+      i18n.t('shared:FieldsMarkedWithStarRequired'),
+      ''
+    );
     return (
       <AutoForm<{ [key: string]: string }>
         i18nRequiredProperty={'* Required field'}
+        allFieldsRequired={allFieldsRequired(definition)}
+        i18nFieldsStatusText={requiredPrompt}
         definition={toFormDefinition(definition)}
         initialValue={initialValue}
         isInitialValid={isInitialValid}

--- a/app/ui-react/syndesis/src/modules/settings/pages/OAuthAppsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/settings/pages/OAuthAppsPage.tsx
@@ -15,7 +15,11 @@ import {
   OAuthAppListItemView,
 } from '@syndesis/ui';
 import {
+  allFieldsRequired,
+  applyInitialValues,
+  getRequiredStatusText,
   toFormDefinition,
+  validateConfiguredProperties,
   WithListViewToolbarHelpers,
   WithLoader,
 } from '@syndesis/utils';
@@ -186,13 +190,28 @@ export class OAuthAppsPage extends React.Component<{}, IOAuthAppsPageState> {
                                     <OAuthAppList>
                                       {filteredAndSortedOAuthApps.map(
                                         (oauthApp, index) => {
+                                          const definition = oauthApp.properties!;
                                           const configured =
                                             typeof oauthApp.configuredProperties !==
                                             'undefined';
-                                          const configuration =
-                                            oauthApp.configuredProperties || {};
+                                          const configuration = applyInitialValues(
+                                            definition,
+                                            oauthApp.configuredProperties
+                                          );
                                           const key = JSON.stringify(
                                             configuration
+                                          );
+                                          const isInitialValid = validateConfiguredProperties(
+                                            definition,
+                                            configuration
+                                          );
+                                          const requiredPrompt = getRequiredStatusText(
+                                            definition,
+                                            i18n.t('shared:AllFieldsRequired'),
+                                            i18n.t(
+                                              'shared:FieldsMarkedWithStarRequired'
+                                            ),
+                                            ''
                                           );
                                           return (
                                             <OAuthAppListItem
@@ -212,8 +231,15 @@ export class OAuthAppsPage extends React.Component<{}, IOAuthAppsPageState> {
                                               <AutoForm
                                                 key={index + '-' + key}
                                                 definition={toFormDefinition(
-                                                  oauthApp.properties!
+                                                  definition
                                                 )}
+                                                allFieldsRequired={allFieldsRequired(
+                                                  definition
+                                                )}
+                                                i18nFieldsStatusText={
+                                                  requiredPrompt
+                                                }
+                                                isInitialValid={isInitialValid}
                                                 i18nRequiredProperty={t(
                                                   'shared:requiredFieldMessage'
                                                 )}


### PR DESCRIPTION
Was quicker to fix this than write up a bug.  With the required field indicated in place I thought it'd be good to take it a little further and show the required field prompt per a lot of designs and pf guidelines.  So now this:

![image](https://user-images.githubusercontent.com/351660/57970557-8f4c5600-7950-11e9-8c99-45f362fc2d31.png)

Shows up as:

![image](https://user-images.githubusercontent.com/351660/57970562-996e5480-7950-11e9-9064-9d15a5872e20.png)

and when there's a mix:

![image](https://user-images.githubusercontent.com/351660/57970579-ddf9f000-7950-11e9-8437-338fd8d318dd.png)

also adds a fix for #316