### PR TITLE
feat: add navigating away confirmation when in the integration editor

### DIFF
--- a/app/ui-react/syndesis/package.json
+++ b/app/ui-react/syndesis/package.json
@@ -9,6 +9,7 @@
     ]
   },
   "dependencies": {
+    "@allpro/react-router-pause": "^1.1.3",
     "@craco/craco": "^5.0.2",
     "@syndesis/api": "*",
     "@syndesis/apicurio-adapter": "*",

--- a/app/ui-react/syndesis/src/modules/integrations/IntegrationCreatorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/IntegrationCreatorApp.tsx
@@ -1,10 +1,13 @@
 import { ALL_STEPS, createStep, DATA_MAPPER } from '@syndesis/api';
+import * as H from '@syndesis/history';
 import { StepKind } from '@syndesis/models';
 import { Breadcrumb } from '@syndesis/ui';
 import * as React from 'react';
+import { Translation } from 'react-i18next';
 import { Route, Switch } from 'react-router';
 import { Link } from 'react-router-dom';
 import { WithClosedNavigation } from '../../shared';
+import { WithLeaveConfirmation } from '../../shared/WithLeaveConfirmation';
 import { AddStepPage } from './components/editor/AddStepPage';
 import { EditorApp } from './components/editor/EditorApp';
 import { SaveIntegrationPage } from './components/editor/SaveIntegrationPage';
@@ -120,94 +123,110 @@ export const IntegrationCreatorApp: React.FunctionComponent = () => {
         <Link to={resolvers.list()}>Integrations</Link>
         <span>New integration</span>
       </Breadcrumb>
-      <Switch>
-        {/* start step */}
-        <Route path={routes.create.start.selectStep}>
-          <EditorApp
-            mode={'adding'}
-            appStepRoutes={routes.create.start}
-            appResolvers={resolvers.create.start}
-            cancelHref={resolvers.list}
-            postConfigureHref={(integration, params) => {
-              return resolvers.create.finish.selectStep({
-                integration,
-                ...params,
-                position: '1',
-              });
+      <Translation ns={['integrations']}>
+        {t => (
+          <WithLeaveConfirmation
+            i18nTitle={t('unsavedChangesTitle')}
+            i18nConfirmationMessage={t('unsavedChangesMessage')}
+            shouldDisplayDialog={(location: H.LocationDescriptor) => {
+              const url =
+                typeof location === 'string' ? location : location.pathname!;
+              return !url.startsWith(routes.create.root);
             }}
-          />
-        </Route>
+          >
+            {() => (
+              <Switch>
+                {/* start step */}
+                <Route path={routes.create.start.selectStep}>
+                  <EditorApp
+                    mode={'adding'}
+                    appStepRoutes={routes.create.start}
+                    appResolvers={resolvers.create.start}
+                    cancelHref={resolvers.list}
+                    postConfigureHref={(integration, params) => {
+                      return resolvers.create.finish.selectStep({
+                        integration,
+                        ...params,
+                        position: '1',
+                      });
+                    }}
+                  />
+                </Route>
 
-        {/* finish step */}
-        <Route path={routes.create.finish.selectStep}>
-          <EditorApp
-            mode={'adding'}
-            appStepRoutes={routes.create.finish}
-            appResolvers={resolvers.create.finish}
-            cancelHref={resolvers.list}
-            postConfigureHref={(integration, params) =>
-              resolvers.create.configure.index({
-                integration,
-                ...params,
-              })
-            }
-          />
-        </Route>
+                {/* finish step */}
+                <Route path={routes.create.finish.selectStep}>
+                  <EditorApp
+                    mode={'adding'}
+                    appStepRoutes={routes.create.finish}
+                    appResolvers={resolvers.create.finish}
+                    cancelHref={resolvers.list}
+                    postConfigureHref={(integration, params) =>
+                      resolvers.create.configure.index({
+                        integration,
+                        ...params,
+                      })
+                    }
+                  />
+                </Route>
 
-        <Route
-          path={routes.create.configure.index}
-          exact={true}
-          children={addStepPage}
-        />
+                <Route
+                  path={routes.create.configure.index}
+                  exact={true}
+                  children={addStepPage}
+                />
 
-        {/* add step */}
-        <Route path={routes.create.configure.addStep.selectStep}>
-          <EditorApp
-            mode={'adding'}
-            appStepRoutes={routes.create.configure.addStep}
-            appResolvers={resolvers.create.configure.addStep}
-            cancelHref={(params, state) =>
-              resolvers.create.configure.index({
-                ...params,
-                ...state,
-              })
-            }
-            postConfigureHref={(integration, params) =>
-              resolvers.create.configure.index({
-                integration,
-                ...params,
-              })
-            }
-          />
-        </Route>
+                {/* add step */}
+                <Route path={routes.create.configure.addStep.selectStep}>
+                  <EditorApp
+                    mode={'adding'}
+                    appStepRoutes={routes.create.configure.addStep}
+                    appResolvers={resolvers.create.configure.addStep}
+                    cancelHref={(params, state) =>
+                      resolvers.create.configure.index({
+                        ...params,
+                        ...state,
+                      })
+                    }
+                    postConfigureHref={(integration, params) =>
+                      resolvers.create.configure.index({
+                        integration,
+                        ...params,
+                      })
+                    }
+                  />
+                </Route>
 
-        {/* edit step */}
-        <Route path={routes.create.configure.editStep.selectStep}>
-          <EditorApp
-            mode={'editing'}
-            appStepRoutes={routes.create.configure.editStep}
-            appResolvers={resolvers.create.configure.editStep}
-            cancelHref={(params, state) =>
-              resolvers.create.configure.index({
-                ...params,
-                ...state,
-              })
-            }
-            postConfigureHref={(integration, params) =>
-              resolvers.create.configure.index({
-                integration,
-                ...params,
-              })
-            }
-          />
-        </Route>
+                {/* edit step */}
+                <Route path={routes.create.configure.editStep.selectStep}>
+                  <EditorApp
+                    mode={'editing'}
+                    appStepRoutes={routes.create.configure.editStep}
+                    appResolvers={resolvers.create.configure.editStep}
+                    cancelHref={(params, state) =>
+                      resolvers.create.configure.index({
+                        ...params,
+                        ...state,
+                      })
+                    }
+                    postConfigureHref={(integration, params) =>
+                      resolvers.create.configure.index({
+                        integration,
+                        ...params,
+                      })
+                    }
+                  />
+                </Route>
 
-        <Route
-          path={routes.create.configure.saveAndPublish}
-          exact={true}
-          children={saveIntegrationPage}
-        />
-      </Switch>
+                <Route
+                  path={routes.create.configure.saveAndPublish}
+                  exact={true}
+                  children={saveIntegrationPage}
+                />
+              </Switch>
+            )}
+          </WithLeaveConfirmation>
+        )}
+      </Translation>
     </WithClosedNavigation>
   );
 };

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/SelectConnectionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/SelectConnectionPage.tsx
@@ -52,7 +52,7 @@ export class SelectConnectionPage extends React.Component<
   public render() {
     return (
       <WithRouteData<ISelectConnectionRouteParams, ISelectConnectionRouteState>>
-        {(params, state) => {
+        {(params, state, { history }) => {
           const { flowId, position } = params;
           const { integration = getEmptyIntegration() } = state;
           const positionAsNumber = parseInt(position, 10) || 0;

--- a/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -111,5 +111,7 @@
     "templater-create": "Create",
     "templater-create-editor-title": "Copy and paste a template or enter text that defines a template.",
     "templater-import-review": "{{import}} review:"
-  }
+  },
+  "unsavedChangesTitle": "Unsaved Changes",
+  "unsavedChangesMessage": "Are you sure you want to exit editing the integration?"
 }

--- a/app/ui-react/syndesis/src/modules/integrations/resolvers.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/resolvers.ts
@@ -126,7 +126,10 @@ const resolvers = {
     activity: integrationActivityResolver,
     details: integrationDetailsResolver,
     edit: {
-      root: makeResolverNoParams(routes.integration.edit.root),
+      root: makeResolver<IEditorIndex, IBaseRouteParams, IBaseRouteState>(
+        routes.integration.edit.root,
+        configureIndexMapper
+      ),
       index: makeResolver<IEditorIndex, IBaseRouteParams, IBaseRouteState>(
         routes.integration.edit.index,
         configureIndexMapper

--- a/app/ui-react/syndesis/src/shared/WithLeaveConfirmation.tsx
+++ b/app/ui-react/syndesis/src/shared/WithLeaveConfirmation.tsx
@@ -1,0 +1,113 @@
+import ReactRouterPause from '@allpro/react-router-pause';
+import * as H from '@syndesis/history';
+import {
+  ConfirmationButtonStyle,
+  ConfirmationDialog,
+  ConfirmationIconType,
+} from '@syndesis/ui';
+import * as React from 'react';
+import { Translation } from 'react-i18next';
+
+export interface IWithLeaveConfirmationChildrenProps {
+  allowNavigation: (callback?: () => void) => any;
+}
+
+export interface IWithLeaveConfirmationProps {
+  i18nCancelButtonText?: string;
+  i18nConfirmButtonText?: string;
+  i18nConfirmationMessage?: string;
+  i18nTitle?: string;
+  shouldDisplayDialog?: (location: H.LocationDescriptor) => boolean;
+  children: (props: IWithLeaveConfirmationChildrenProps) => any;
+}
+
+export interface IDialogProps {
+  showDialog: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export const WithLeaveConfirmation: React.FunctionComponent<
+  IWithLeaveConfirmationProps
+> = ({
+  i18nCancelButtonText,
+  i18nConfirmButtonText,
+  i18nConfirmationMessage,
+  i18nTitle,
+  shouldDisplayDialog,
+  children,
+}) => {
+  const [blockNavigation, setBlockNavigation] = React.useState(true);
+  const [postAllowCallback, setPostAllowCallback] = React.useState();
+  React.useEffect(() => {
+    if (!blockNavigation && postAllowCallback) {
+      postAllowCallback();
+    }
+  }, [blockNavigation, postAllowCallback]);
+
+  const initialDialogProps = {
+    onCancel: () => false,
+    onConfirm: () => false,
+    showDialog: false,
+  };
+
+  const [dialogProps, setDialogProps] = React.useState<IDialogProps>(
+    initialDialogProps
+  );
+  const closeDialog = () => setDialogProps(initialDialogProps);
+
+  const handleNavigationAttempt = (
+    navigation: any,
+    location: any,
+    action: any
+  ) => {
+    const showDialog = shouldDisplayDialog
+      ? shouldDisplayDialog(location)
+      : true;
+    setDialogProps({
+      onCancel: () => {
+        closeDialog();
+        navigation.cancel();
+      },
+      onConfirm: () => {
+        closeDialog();
+        navigation.resume();
+      },
+      showDialog,
+    });
+    // Return null to 'pause' and save the route so can 'resume'
+    return showDialog ? null : true;
+  };
+
+  const allowNavigation = (callback?: () => void) => {
+    setBlockNavigation(false);
+    setPostAllowCallback(callback);
+  };
+  return (
+    <Translation ns={['integrations', 'shared']}>
+      {t => (
+        <>
+          <ReactRouterPause
+            handler={handleNavigationAttempt}
+            when={blockNavigation}
+            config={{ allowBookmarks: false }}
+          />
+
+          <ConfirmationDialog
+            buttonStyle={ConfirmationButtonStyle.NORMAL}
+            icon={ConfirmationIconType.WARNING}
+            i18nCancelButtonText={i18nCancelButtonText || t('shared:Cancel')}
+            i18nConfirmButtonText={i18nConfirmButtonText || t('shared:Confirm')}
+            i18nConfirmationMessage={
+              i18nConfirmationMessage || t('shared:confirmLeavingPageMessage')
+            }
+            i18nTitle={i18nTitle || t('shared:confirmLeavingPageTitle')}
+            {...dialogProps}
+          />
+
+          {children({ allowNavigation })}
+        </>
+      )}
+    </Translation>
+  );
+};

--- a/app/ui-react/typings/allpro__react-router-pause/index.d.ts
+++ b/app/ui-react/typings/allpro__react-router-pause/index.d.ts
@@ -1,0 +1,1 @@
+declare module '@allpro/react-router-pause';

--- a/app/ui-react/typings/allpro__react-router-pause/package.json
+++ b/app/ui-react/typings/allpro__react-router-pause/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@types/allpro__react-router-pause",
+  "version": "1.0.0",
+  "license": "MIT"
+}

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@allpro/react-router-pause@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@allpro/react-router-pause/-/react-router-pause-1.1.3.tgz#515224c8d40a0a44d41554e5556917df5e44dfa5"
+  integrity sha512-yNlkdn9CkONSKz/8eCgEdBOFRMwhGMQNuZnd/AXju9VHFjri3JoIYAGrOi0sP7ZGmzNyJjaiB41RCUeLyLuWdg==
+  dependencies:
+    lodash "^4.17.11"
+
 "@angular-devkit/architect@0.13.3":
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/@angular-devkit/architect/-/architect-0.13.3.tgz#28813279c546cdcb709ad55038bb2051736de668"


### PR DESCRIPTION
This adds a reusable component `WithLeaveConfirmation` that can be used to protect a page/section from navigating away. 

In the integration editor, it's used by setting the `shouldDisplayDialog` property to a function that checks if the following URL is outside the "mountpoint" of the editor.

## Demo

![route-guard](https://user-images.githubusercontent.com/966316/57986558-979eb100-7a76-11e9-94c9-c5e1539f297c.gif)
