### PR TITLE
fix: fix loaders and random stuff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,6 @@ jobs:
           name: Lint project
           command: yarn lint
 
-
       - run:
           name: Build project
           command: yarn build
@@ -64,9 +63,6 @@ jobs:
           paths:
             - syndesis/build
             - doc
-            - node_modules
-            - packages/history/cjs
-            - packages/**/dist
 
   doc-deploy:
     docker:
@@ -82,8 +78,19 @@ jobs:
       - checkout:
           path: ~/repo
 
-      - attach_workspace:
-          at: ~/repo/app/ui-react
+      - restore_cache:
+          keys:
+            - v2-dependencies-{{ checksum "yarn.lock" }}
+            # fallback to using the latest cache if no exact match is found
+            - v2-dependencies-
+
+      - run:
+          name: Install dependencies
+          command: yarn install --frozen-lockfile
+
+      - run:
+          name: Build project
+          command: yarn build --ignore @syndesis/syndesis
 
       - run:
           name: Build app for GH-Pages
@@ -110,8 +117,19 @@ jobs:
       - checkout:
           path: ~/repo
 
-      - attach_workspace:
-          at: ~/repo/app/ui-react
+      - restore_cache:
+          keys:
+            - v2-dependencies-{{ checksum "yarn.lock" }}
+            # fallback to using the latest cache if no exact match is found
+            - v2-dependencies-
+
+      - run:
+          name: Install dependencies
+          command: yarn install --frozen-lockfile
+
+      - run:
+          name: Build project
+          command: yarn build --ignore @syndesis/syndesis
 
       - run:
           name: Build app for Circle CI artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
           name: Lint project
           command: yarn lint
 
+
       - run:
           name: Build project
           command: yarn build
@@ -61,8 +62,7 @@ jobs:
       - persist_to_workspace:
           root: ~/repo/app/ui-react
           paths:
-            - syndesis/build
-            - doc
+            - '*'
 
   doc-deploy:
     docker:
@@ -78,19 +78,8 @@ jobs:
       - checkout:
           path: ~/repo
 
-      - restore_cache:
-          keys:
-            - v2-dependencies-{{ checksum "yarn.lock" }}
-            # fallback to using the latest cache if no exact match is found
-            - v2-dependencies-
-
-      - run:
-          name: Install dependencies
-          command: yarn install --frozen-lockfile
-
-      - run:
-          name: Build project
-          command: yarn build --ignore @syndesis/syndesis
+      - attach_workspace:
+          at: ~/repo/app/ui-react
 
       - run:
           name: Build app for GH-Pages
@@ -117,19 +106,8 @@ jobs:
       - checkout:
           path: ~/repo
 
-      - restore_cache:
-          keys:
-            - v2-dependencies-{{ checksum "yarn.lock" }}
-            # fallback to using the latest cache if no exact match is found
-            - v2-dependencies-
-
-      - run:
-          name: Install dependencies
-          command: yarn install --frozen-lockfile
-
-      - run:
-          name: Build project
-          command: yarn build --ignore @syndesis/syndesis
+      - attach_workspace:
+          at: ~/repo/app/ui-react
 
       - run:
           name: Build app for Circle CI artifacts

--- a/app/ui-react/packages/models/src/extra.d.ts
+++ b/app/ui-react/packages/models/src/extra.d.ts
@@ -64,16 +64,16 @@ export interface IConnectionWithIconFile extends Connection {
 }
 
 export interface IIntegrationOverviewWithDraft extends IntegrationOverview {
-  isDraft: boolean;
+  isDraft?: boolean;
 }
 
 export interface IntegrationWithOverview {
-  integration: IntegrationOverview;
+  integration: IIntegrationOverviewWithDraft;
   overview?: IntegrationMetricsSummary;
 }
 
 export interface IntegrationWithMonitoring {
-  integration: IntegrationOverview;
+  integration: IIntegrationOverviewWithDraft;
   monitoring?: IntegrationMonitoring;
 }
 

--- a/app/ui-react/packages/ui/src/Connection/ConnectionSkeleton.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionSkeleton.tsx
@@ -1,25 +1,23 @@
-import { Card, EmptyState } from 'patternfly-react';
+import { Card } from 'patternfly-react';
 import * as React from 'react';
 import ContentLoader from 'react-content-loader';
 
 export const ConnectionSkeleton = (props: any) => (
   <Card matchHeight={true}>
     <Card.Body>
-      <EmptyState>
-        <ContentLoader
-          height={300}
-          width={200}
-          speed={2}
-          primaryColor="#f3f3f3"
-          secondaryColor="#ecebeb"
-          {...props}
-        >
-          <circle cx="100" cy="50" r="40" />
-          <rect x="5" y="125" rx="5" ry="5" width="190" height="30" />
-          <rect x="25" y="180" rx="5" ry="5" width="150" height="15" />
-          <rect x="40" y="205" rx="5" ry="5" width="120" height="15" />
-        </ContentLoader>
-      </EmptyState>
+      <ContentLoader
+        height={250}
+        width={200}
+        speed={2}
+        primaryColor="#f3f3f3"
+        secondaryColor="#ecebeb"
+        {...props}
+      >
+        <circle cx="100" cy="50" r="40" />
+        <rect x="5" y="125" rx="5" ry="5" width="190" height="30" />
+        <rect x="25" y="180" rx="5" ry="5" width="150" height="15" />
+        <rect x="40" y="205" rx="5" ry="5" width="120" height="15" />
+      </ContentLoader>
     </Card.Body>
   </Card>
 );

--- a/app/ui-react/packages/ui/src/Connection/ConnectionsListView.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionsListView.tsx
@@ -1,7 +1,6 @@
-import { PageSection } from '@patternfly/react-core';
 import * as H from '@syndesis/history';
 import * as React from 'react';
-import { ButtonLink } from '../Layout';
+import { ButtonLink, PageSection } from '../Layout';
 import { IListViewToolbarProps, ListViewToolbar } from '../Shared';
 
 export interface IConnectionsListViewProps extends IListViewToolbarProps {

--- a/app/ui-react/packages/ui/src/Customization/ApiConnectorListSkeleton.tsx
+++ b/app/ui-react/packages/ui/src/Customization/ApiConnectorListSkeleton.tsx
@@ -12,7 +12,7 @@ export const ApiConnectorListSkeleton: React.FunctionComponent<
   IApiConnectorListSkeletonProps
 > = ({ width, style }) => (
   <ContentLoader
-    height={356}
+    height={226}
     width={width}
     speed={2}
     primaryColor="#f3f3f3"

--- a/app/ui-react/packages/ui/src/Customization/ExtensionListSkeleton.tsx
+++ b/app/ui-react/packages/ui/src/Customization/ExtensionListSkeleton.tsx
@@ -12,7 +12,7 @@ export const ExtensionListSkeleton: React.FunctionComponent<
   ICustomizationsExtensionListSkeletonProps
 > = ({ width, style }) => (
   <ContentLoader
-    height={356}
+    height={226}
     width={width}
     speed={2}
     primaryColor="#f3f3f3"

--- a/app/ui-react/packages/ui/src/Integration/IntegrationsListSkeleton.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationsListSkeleton.tsx
@@ -8,27 +8,26 @@ function getRandom(min: number, max: number) {
 const ItemSkeleton = () => (
   <ContentLoader
     height={80}
-    width={500}
+    width={400}
     speed={2}
     primaryColor="#f3f3f3"
     secondaryColor="#ecebeb"
     style={{
       height: 80,
-      width: '100%',
     }}
   >
-    <circle cx="35" cy="40" r="35" />
-    <circle cx="115" cy="40" r="35" />
+    <circle cx="35" cy="40" r="25" />
+    <circle cx="95" cy="40" r="25" />
     <rect
-      x="185"
+      x="145"
       y="20"
       rx="5"
       ry="5"
-      width={400 * getRandom(0.6, 1)}
+      width={350 * getRandom(0.6, 1)}
       height="18"
     />
     <rect
-      x="185"
+      x="145"
       y="55"
       rx="5"
       ry="5"

--- a/app/ui-react/packages/ui/src/Layout/PageLoader.tsx
+++ b/app/ui-react/packages/ui/src/Layout/PageLoader.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { Loader } from './Loader';
+import { PageSection } from './Page';
+
+export class PageLoader extends React.PureComponent {
+  public render() {
+    return (
+      <PageSection>
+        <Loader size={'lg'} />
+      </PageSection>
+    );
+  }
+}

--- a/app/ui-react/packages/ui/src/Layout/index.ts
+++ b/app/ui-react/packages/ui/src/Layout/index.ts
@@ -6,6 +6,7 @@ export * from './Breadcrumb';
 export * from './Container';
 export * from './Loader';
 export * from './Page';
+export * from './PageLoader';
 export * from './PfNavLink';
 export * from './PfVerticalNavItem';
 export * from './TabBar';

--- a/app/ui-react/packages/ui/src/index.css
+++ b/app/ui-react/packages/ui/src/index.css
@@ -124,3 +124,4 @@ body {
 .pf-c-about-modal-box__hero {
   background-position: right;
 }
+

--- a/app/ui-react/syndesis/src/index.tsx
+++ b/app/ui-react/syndesis/src/index.tsx
@@ -4,7 +4,7 @@ import {
   WithServerEvents,
 } from '@syndesis/api';
 import { createBrowserHistory } from '@syndesis/history';
-import { Loader, UnrecoverableError } from '@syndesis/ui';
+import { UnrecoverableError } from '@syndesis/ui';
 import { WithLoader } from '@syndesis/utils';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
@@ -33,7 +33,7 @@ ReactDOM.render(
           <WithLoader
             loading={loading}
             error={error}
-            loaderChildren={<Loader />}
+            loaderChildren={<span />}
             errorChildren={
               <Translation ns={['shared']}>
                 {t => (

--- a/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/ApiConnectorDetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/apiClientConnectors/pages/ApiConnectorDetailsPage.tsx
@@ -5,7 +5,7 @@ import {
   ApiConnectorReview,
   Breadcrumb,
   Container,
-  Loader,
+  PageLoader,
   PageSection,
 } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
@@ -204,7 +204,7 @@ export default class ApiConnectorDetailsPage extends React.Component<
                                   <WithLoader
                                     error={error}
                                     loading={!hasData}
-                                    loaderChildren={<Loader />}
+                                    loaderChildren={<PageLoader />}
                                     errorChildren={<ApiError />}
                                   >
                                     {() => {

--- a/app/ui-react/syndesis/src/modules/connections/pages/ConnectionDetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/pages/ConnectionDetailsPage.tsx
@@ -9,7 +9,7 @@ import {
   Breadcrumb,
   ConnectionDetailsForm,
   ConnectionDetailsHeader,
-  Loader,
+  PageLoader,
 } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
 import * as React from 'react';
@@ -209,7 +209,7 @@ export class ConnectionDetailsPage extends React.Component<
                                   <WithLoader
                                     error={error}
                                     loading={!hasData}
-                                    loaderChildren={<Loader />}
+                                    loaderChildren={<PageLoader />}
                                     errorChildren={<ApiError />}
                                   >
                                     {() => {

--- a/app/ui-react/syndesis/src/modules/connections/pages/create/ConfigurationPage.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/pages/create/ConfigurationPage.tsx
@@ -5,6 +5,7 @@ import {
   ConnectionCreatorLayout,
   ConnectorConfigurationForm,
   Loader,
+  PageLoader,
 } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
 import * as React from 'react';
@@ -36,7 +37,7 @@ export default class ConfigurationPage extends React.Component {
               <WithLoader
                 error={error}
                 loading={!hasData}
-                loaderChildren={<Loader />}
+                loaderChildren={<PageLoader />}
                 errorChildren={<ApiError />}
               >
                 {() => {

--- a/app/ui-react/syndesis/src/modules/extensions/pages/ExtensionDetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/extensions/pages/ExtensionDetailsPage.tsx
@@ -6,7 +6,7 @@ import {
   ExtensionOverview,
   ExtensionSupports,
   IAction,
-  Loader,
+  PageLoader,
 } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
 import * as React from 'react';
@@ -83,7 +83,7 @@ export default class ExtensionDetailsPage extends React.Component {
                       <WithLoader
                         error={error}
                         loading={!hasData}
-                        loaderChildren={<Loader />}
+                        loaderChildren={<PageLoader />}
                         errorChildren={<ApiError />}
                       >
                         {() => (

--- a/app/ui-react/syndesis/src/modules/integrations/components/IntegrationDetailNavBar.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/IntegrationDetailNavBar.tsx
@@ -1,4 +1,5 @@
 import { Integration } from '@syndesis/models';
+import { IIntegrationOverviewWithDraft } from '@syndesis/models/src';
 import { Container, TabBar, TabBarItem } from '@syndesis/ui';
 import * as React from 'react';
 import { Translation } from 'react-i18next';
@@ -41,18 +42,21 @@ export class IntegrationDetailNavBar extends React.Component<
               <TabBarItem
                 label={'Details'}
                 to={resolvers.integration.details({
+                  integration: integration as IIntegrationOverviewWithDraft,
                   integrationId: integration.id!,
                 })}
               />
               <TabBarItem
                 label={'Activity'}
                 to={resolvers.integration.activity({
+                  integration: integration as IIntegrationOverviewWithDraft,
                   integrationId: integration.id!,
                 })}
               />
               <TabBarItem
                 label={'Metrics'}
                 to={resolvers.integration.metrics({
+                  integration: integration as IIntegrationOverviewWithDraft,
                   integrationId: integration.id!,
                 })}
               />

--- a/app/ui-react/syndesis/src/modules/integrations/components/IntegrationDetailNavBar.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/IntegrationDetailNavBar.tsx
@@ -1,4 +1,3 @@
-import { Integration } from '@syndesis/models';
 import { IIntegrationOverviewWithDraft } from '@syndesis/models/src';
 import { Container, TabBar, TabBarItem } from '@syndesis/ui';
 import * as React from 'react';
@@ -10,7 +9,7 @@ import resolvers from '../resolvers';
  * exists, it must equal to the [integrationId]{@link IIntegrationDetailNavBarProps#integration}.
  */
 export interface IIntegrationDetailNavBarProps {
-  integration: Integration;
+  integration: IIntegrationOverviewWithDraft;
 }
 
 /**
@@ -42,21 +41,21 @@ export class IntegrationDetailNavBar extends React.Component<
               <TabBarItem
                 label={'Details'}
                 to={resolvers.integration.details({
-                  integration: integration as IIntegrationOverviewWithDraft,
+                  integration,
                   integrationId: integration.id!,
                 })}
               />
               <TabBarItem
                 label={'Activity'}
                 to={resolvers.integration.activity({
-                  integration: integration as IIntegrationOverviewWithDraft,
+                  integration,
                   integrationId: integration.id!,
                 })}
               />
               <TabBarItem
                 label={'Metrics'}
                 to={resolvers.integration.metrics({
-                  integration: integration as IIntegrationOverviewWithDraft,
+                  integration,
                   integrationId: integration.id!,
                 })}
               />

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/SelectActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/SelectActionPage.tsx
@@ -5,7 +5,7 @@ import {
   IntegrationEditorActionsListItem,
   IntegrationEditorChooseAction,
   IntegrationEditorLayout,
-  Loader,
+  PageLoader,
 } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
 import * as React from 'react';
@@ -53,7 +53,7 @@ export class SelectActionPage extends React.Component<ISelectActionPageProps> {
                 <WithLoader
                   error={error}
                   loading={!hasData}
-                  loaderChildren={<Loader />}
+                  loaderChildren={<PageLoader />}
                   errorChildren={<ApiError />}
                 >
                   {() => (

--- a/app/ui-react/syndesis/src/modules/integrations/pages/detail/ActivityPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/detail/ActivityPage.tsx
@@ -1,5 +1,5 @@
 import { WithMonitoredIntegration } from '@syndesis/api';
-import { Loader } from '@syndesis/ui';
+import { PageLoader } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
 import * as React from 'react';
 import { Translation } from 'react-i18next';
@@ -39,7 +39,7 @@ export class ActivityPage extends React.Component {
                             <WithLoader
                               error={error}
                               loading={!hasData}
-                              loaderChildren={<Loader />}
+                              loaderChildren={<PageLoader />}
                               errorChildren={<ApiError />}
                             >
                               {() => (

--- a/app/ui-react/syndesis/src/modules/integrations/pages/detail/DetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/detail/DetailsPage.tsx
@@ -9,8 +9,7 @@ import {
   IntegrationDetailHistoryListView,
   IntegrationDetailHistoryListViewItem,
   IntegrationDetailHistoryListViewItemActions,
-  Loader,
-  PageSection,
+  PageLoader,
 } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
 import * as React from 'react';
@@ -50,11 +49,7 @@ export class DetailsPage extends React.Component {
                         <WithLoader
                           error={error}
                           loading={!hasData}
-                          loaderChildren={
-                            <PageSection>
-                              <Loader />
-                            </PageSection>
-                          }
+                          loaderChildren={<PageLoader />}
                           errorChildren={<ApiError />}
                         >
                           {() => (

--- a/app/ui-react/syndesis/src/modules/integrations/pages/detail/DetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/detail/DetailsPage.tsx
@@ -128,7 +128,7 @@ export class DetailsPage extends React.Component {
                                       }
                                       isDraft={
                                         (data.integration as IIntegrationOverviewWithDraft)
-                                          .isDraft
+                                          .isDraft || false
                                       }
                                       i18nTextDraft={t('shared:Draft')}
                                       i18nTextHistory={t(

--- a/app/ui-react/syndesis/src/modules/integrations/pages/detail/MetricsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/detail/MetricsPage.tsx
@@ -2,7 +2,7 @@ import {
   WithIntegrationMetrics,
   WithMonitoredIntegration,
 } from '@syndesis/api';
-import { IntegrationDetailMetrics, Loader } from '@syndesis/ui';
+import { IntegrationDetailMetrics, PageLoader } from '@syndesis/ui';
 import {
   toDurationDifferenceString,
   WithLoader,
@@ -46,7 +46,7 @@ export class MetricsPage extends React.Component {
                               <WithLoader
                                 error={error}
                                 loading={!hasData}
-                                loaderChildren={<Loader />}
+                                loaderChildren={<PageLoader />}
                                 errorChildren={<ApiError />}
                               >
                                 {() => (

--- a/app/ui-react/syndesis/src/modules/settings/pages/OAuthAppsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/settings/pages/OAuthAppsPage.tsx
@@ -7,6 +7,7 @@ import {
   ConfirmationIconType,
   IActiveFilter,
   IFilterType,
+  IntegrationsListSkeleton,
   ISortType,
   OAuthAppExpanderBody,
   OAuthAppHeader,
@@ -183,7 +184,7 @@ export class OAuthAppsPage extends React.Component<{}, IOAuthAppsPageState> {
                                 <WithLoader
                                   error={error}
                                   loading={!hasData}
-                                  loaderChildren={<div>TODO</div>}
+                                  loaderChildren={<IntegrationsListSkeleton />}
                                   errorChildren={<ApiError />}
                                 >
                                   {() => (

--- a/app/ui-react/syndesis/src/modules/support/pages/SupportPage.tsx
+++ b/app/ui-react/syndesis/src/modules/support/pages/SupportPage.tsx
@@ -1,7 +1,7 @@
 import { WithIntegrationHelpers, WithIntegrations } from '@syndesis/api';
 import {
   DownloadDiagnostics,
-  Loader,
+  PageLoader,
   PageSection,
   SimplePageHeader,
 } from '@syndesis/ui';
@@ -42,7 +42,7 @@ export const SupportPage: React.FunctionComponent = () => {
                       <WithLoader
                         error={error}
                         loading={loading}
-                        loaderChildren={<Loader />}
+                        loaderChildren={<PageLoader />}
                         errorChildren={<ApiError />}
                       >
                         {() => {


### PR DESCRIPTION
* Replaced `Loaders` when used as page loaders with the new `PageLoader` one.
* Fixed the connections skeleton loader and tweaked the others.
* Makes use of the integration skeleton loader for the oauth page too (fix #225).
* Restored the integration state passing in the integration detail page.