### PR TITLE
fix: address the data mapper page error when adding a map on newly created integrations

### DIFF
--- a/app/ui-react/packages/auto-form/src/FormBuilder.tsx
+++ b/app/ui-react/packages/auto-form/src/FormBuilder.tsx
@@ -171,6 +171,9 @@ export class FormBuilder<T> extends React.Component<IFormBuilderProps<T>> {
    */
   private massageValue(property: IFormDefinitionProperty, value?: string) {
     if (value === undefined || value === null) {
+      if (property.enum && property.enum.length > 0) {
+        return property.enum[0].value;
+      }
       return value;
     }
     switch (property.type) {

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/dataMapper/DataMapperPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/dataMapper/DataMapperPage.tsx
@@ -73,8 +73,9 @@ export const DataMapperPage: React.FunctionComponent<
             const outputDocument = getOutputDocument(
               state.integration,
               params.flowId,
-              props.mode === 'adding' ? positionAsNumber - 1 : positionAsNumber,
-              state.step.id!
+              positionAsNumber,
+              state.step.id!,
+              props.mode === 'adding'
             );
 
             const saveMappingStep = async () => {

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/dataMapper/utils.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/dataMapper/utils.ts
@@ -165,13 +165,21 @@ export function getOutputDocument(
   integration: IntegrationOverview,
   flowId: string,
   position: number,
-  stepId: string
+  stepId: string,
+  isAddingStep: boolean
 ) {
   const subsequentSteps = getSubsequentIntegrationStepsWithDataShape(
     integration,
     flowId,
-    position
-  )!;
+    isAddingStep ? position - 1 : position
+  )!.map(s =>
+    isAddingStep
+      ? {
+          index: s.index + 1,
+          step: s.step,
+        }
+      : s
+  );
 
   const outputDocuments = subsequentSteps
     .map(s => stepToProps(s.step, false, true, s.index))

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigureActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigureActionPage.tsx
@@ -144,9 +144,8 @@ export class ConfigureActionPage extends React.Component<
                         },
                         {
                           connection,
-                          integration,
+                          integration: updatedIntegration!,
                           step: stepKind,
-                          updatedIntegration,
                         }
                       )
                     );
@@ -165,21 +164,24 @@ export class ConfigureActionPage extends React.Component<
                         {
                           configuredProperties,
                           connection,
-                          integration,
+                          integration: updatedIntegration!,
                           step,
-                          updatedIntegration,
                         } as IConfigureActionRouteState
                       )
                     );
                   };
                   const descriptor = stepKind.action!.descriptor!;
-                  if (isStartStep(integration, flowId, positionAsNumber)) {
+                  if (
+                    isStartStep(updatedIntegration, flowId, positionAsNumber)
+                  ) {
                     if (requiresOutputDescribeDataShape(descriptor)) {
                       gotoDescribeData(DataShapeDirection.OUTPUT);
                     } else {
                       gotoDefaultNextPage();
                     }
-                  } else if (isEndStep(integration, flowId, positionAsNumber)) {
+                  } else if (
+                    isEndStep(updatedIntegration, flowId, positionAsNumber)
+                  ) {
                     if (requiresInputDescribeDataShape(descriptor)) {
                       gotoDescribeData(DataShapeDirection.INPUT);
                     } else {
@@ -233,7 +235,6 @@ export class ConfigureActionPage extends React.Component<
                             configuredProperties,
                             connection,
                             integration,
-                            updatedIntegration,
                           }
                         )}
                       />
@@ -244,7 +245,6 @@ export class ConfigureActionPage extends React.Component<
                         configuredProperties,
                         connection,
                         integration,
-                        updatedIntegration,
                       }
                     )}
                   />


### PR DESCRIPTION
This flow was giving an error on Atlasmap: new integration -> sql query -> sql stored procedure -> add data mapper step in between the two.