### PR TITLE
308 conditional delete integration editor

### DIFF
--- a/app/ui-react/syndesis/src/modules/integrations/IntegrationCreatorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/IntegrationCreatorApp.tsx
@@ -24,6 +24,13 @@ const addStepPage = (
         ...s,
       })
     }
+    getEditStepHref={(position, p, s) =>
+      resolvers.create.configure.addStep.selectStep({
+        position: `${position}`,
+        ...p,
+        ...s,
+      })
+    }
     apiProviderHref={(step, p, s) =>
       resolvers.create.configure.editStep.apiProvider.selectMethod()
     }

--- a/app/ui-react/syndesis/src/modules/integrations/IntegrationCreatorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/IntegrationCreatorApp.tsx
@@ -24,8 +24,8 @@ const addStepPage = (
         ...s,
       })
     }
-    getEditStepHref={(position, p, s) =>
-      resolvers.create.configure.addStep.selectStep({
+    getDeleteEdgeStepHref={(position, p, s) =>
+      resolvers.create.configure.editStep.selectStep({
         position: `${position}`,
         ...p,
         ...s,

--- a/app/ui-react/syndesis/src/modules/integrations/IntegrationCreatorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/IntegrationCreatorApp.tsx
@@ -17,7 +17,7 @@ import routes from './routes';
 const addStepPage = (
   <AddStepPage
     cancelHref={resolvers.list}
-    getEditAddStepHref={(position, p, s) =>
+    getAddStepHref={(position, p, s) =>
       resolvers.create.configure.addStep.selectStep({
         position: `${position}`,
         ...p,

--- a/app/ui-react/syndesis/src/modules/integrations/IntegrationEditorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/IntegrationEditorApp.tsx
@@ -22,7 +22,7 @@ import routes from './routes';
 const addStepPage = (
   <AddStepPage
     cancelHref={resolvers.list}
-    getEditAddStepHref={(position, p, s) =>
+    getAddStepHref={(position, p, s) =>
       resolvers.integration.edit.addStep.selectStep({
         position: `${position}`,
         ...p,

--- a/app/ui-react/syndesis/src/modules/integrations/IntegrationEditorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/IntegrationEditorApp.tsx
@@ -32,8 +32,8 @@ const addStepPage = (
     apiProviderHref={
       resolvers.integration.edit.editStep.apiProvider.selectMethod
     }
-    getEditStepHref={(position, p, s) =>
-      resolvers.integration.edit.addStep.selectStep({
+    getDeleteEdgeStepHref={(position, p, s) =>
+      resolvers.integration.edit.editStep.selectStep({
         position: `${position}`,
         ...p,
         ...s,

--- a/app/ui-react/syndesis/src/modules/integrations/IntegrationEditorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/IntegrationEditorApp.tsx
@@ -32,6 +32,13 @@ const addStepPage = (
     apiProviderHref={
       resolvers.integration.edit.editStep.apiProvider.selectMethod
     }
+    getEditStepHref={(position, p, s) =>
+      resolvers.integration.edit.addStep.selectStep({
+        position: `${position}`,
+        ...p,
+        ...s,
+      })
+    }
     connectionHref={(step, params, state) =>
       resolvers.integration.edit.editStep.connection.configureAction({
         actionId: step.action!.id!,

--- a/app/ui-react/syndesis/src/modules/integrations/components/IntegrationEditorStepAdder.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/IntegrationEditorStepAdder.tsx
@@ -1,6 +1,6 @@
-import { getStepIcon } from '@syndesis/api';
+import { getStartStep, getStepIcon } from '@syndesis/api';
 import * as H from '@syndesis/history';
-import { Step } from '@syndesis/models';
+import { Integration, Step } from '@syndesis/models';
 import {
   ButtonLink,
   IntegrationEditorStepsList,
@@ -46,6 +46,8 @@ export interface IIntegrationEditorStepAdderProps {
     stepIdx: number,
     step: Step
   ) => H.LocationDescriptorObject;
+  flowId: string;
+  integration: Integration;
   onDelete: (idx: number, step: Step) => void;
 }
 
@@ -72,7 +74,8 @@ export class IntegrationEditorStepAdder extends React.Component<
                 toUIStepCollection(this.props.steps)
               ).map((s, idx) => {
                 const restrictedDelete =
-                  s.configuredProperties!.stepKind === 'choice';
+                  s.configuredProperties!.stepKind === 'choice' ||
+                  getStartStep().connection.connectorId === 'api-provider';
 
                 return (
                   <React.Fragment key={idx}>

--- a/app/ui-react/syndesis/src/modules/integrations/components/IntegrationEditorStepAdder.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/IntegrationEditorStepAdder.tsx
@@ -75,7 +75,8 @@ export class IntegrationEditorStepAdder extends React.Component<
               ).map((s, idx) => {
                 const restrictedDelete =
                   s.configuredProperties!.stepKind === 'choice' ||
-                  getStartStep().connection.connectorId === 'api-provider';
+                  getStartStep(this.props.integration, this.props.flowId)!
+                    .connection!.connectorId === 'api-provider';
 
                 return (
                   <React.Fragment key={idx}>

--- a/app/ui-react/syndesis/src/modules/integrations/components/IntegrationEditorStepAdder.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/IntegrationEditorStepAdder.tsx
@@ -1,4 +1,4 @@
-import { getStartStep, getStepIcon } from '@syndesis/api';
+import { getStepIcon } from '@syndesis/api';
 import * as H from '@syndesis/history';
 import { Integration, Step } from '@syndesis/models';
 import {
@@ -73,10 +73,16 @@ export class IntegrationEditorStepAdder extends React.Component<
               {toUIIntegrationStepCollection(
                 toUIStepCollection(this.props.steps)
               ).map((s, idx) => {
-                const restrictedDelete =
-                  s.configuredProperties!.stepKind === 'choice' ||
-                  getStartStep(this.props.integration, this.props.flowId)!
-                    .connection!.connectorId === 'api-provider';
+                let restrictedDelete = false;
+
+                if (
+                  (s.configuredProperties &&
+                    s.configuredProperties!.stepKind === 'choice') ||
+                  (s.connection &&
+                    s.connection!.connectorId! === 'api-provider')
+                ) {
+                  restrictedDelete = true;
+                }
 
                 return (
                   <React.Fragment key={idx}>

--- a/app/ui-react/syndesis/src/modules/integrations/components/IntegrationEditorStepAdder.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/IntegrationEditorStepAdder.tsx
@@ -71,6 +71,9 @@ export class IntegrationEditorStepAdder extends React.Component<
               {toUIIntegrationStepCollection(
                 toUIStepCollection(this.props.steps)
               ).map((s, idx) => {
+                const restrictedDelete =
+                  s.configuredProperties!.stepKind === 'choice';
+
                 return (
                   <React.Fragment key={idx}>
                     <IntegrationEditorStepsListItem
@@ -126,13 +129,17 @@ export class IntegrationEditorStepAdder extends React.Component<
                           >
                             {t('shared:Configure')}
                           </ButtonLink>
-                          <ButtonLink
-                            data-testid={'integration-editor-step-adder-delete'}
-                            onClick={() => this.props.onDelete(idx, s)}
-                            as={'danger'}
-                          >
-                            <i className="fa fa-trash" />
-                          </ButtonLink>
+                          {!restrictedDelete && (
+                            <ButtonLink
+                              data-testid={
+                                'integration-editor-step-adder-delete'
+                              }
+                              onClick={() => this.props.onDelete(idx, s)}
+                              as={'danger'}
+                            >
+                              <i className="fa fa-trash" />
+                            </ButtonLink>
+                          )}
                         </>
                       }
                     />

--- a/app/ui-react/syndesis/src/modules/integrations/components/IntegrationEditorStepAdder.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/IntegrationEditorStepAdder.tsx
@@ -54,7 +54,7 @@ export interface IIntegrationEditorStepAdderProps {
  * buttons to add a new step, edit an existing one, etc.
  *
  * @see [steps]{@link IIntegrationEditorStepAdderProps#steps}
- * @see [editAddStepHref]{@link IIntegrationEditorStepAdderProps#editAddStepHref}
+ * @see [addStepHref]{@link IIntegrationEditorStepAdderProps#addStepHref}
  * @see [configureStepHref]{@link IIntegrationEditorStepAdderProps#configureStepHref}
  *
  * @todo add the delete step button

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
@@ -74,19 +74,19 @@ export class AddStepPage extends React.Component<IAddStepPageProps> {
                             { integration }
                           )
                         }
-                        addStepHref={position =>
-                          this.props.getEditAddStepHref(
-                            position,
-                            { flowId },
-                            { integration }
-                          )
-                        }
                         configureStepHref={(position: number, step: Step) =>
                           getStepHref(
                             step,
                             { flowId, position: `${position}` },
                             { integration },
                             this.props
+                          )
+                        }
+                        editAddStepHref={position =>
+                          this.props.getEditAddStepHref(
+                            position,
+                            { flowId },
+                            { integration }
                           )
                         }
                         flowId={flowId}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
@@ -32,7 +32,7 @@ export interface IAddStepPageProps extends IGetStepHrefs {
     p: IBaseRouteParams,
     s: IBaseRouteState
   ) => H.LocationDescriptor;
-  getEditStepHref?: (
+  getEditStepHref: (
     position: number,
     p: IBaseRouteParams,
     s: IBaseRouteState
@@ -75,7 +75,6 @@ export class AddStepPage extends React.Component<
       step: {},
     };
 
-    // this.onDelete = this.onDelete.bind(this);
     this.closeDeleteDialog = this.closeDeleteDialog.bind(this);
     this.openDeleteDialog = this.openDeleteDialog.bind(this);
     this.handleDeleteConfirm = this.handleDeleteConfirm.bind(this);
@@ -107,32 +106,20 @@ export class AddStepPage extends React.Component<
     });
   }
 
-  /**
-  public onDelete(idx: number, step: Step): void {
-    this.setState({ position: idx, showDeleteDialog: true });
-  }
-   **/
-
   public render() {
     return (
-      <Translation ns={['integrations']}>
+      <Translation ns={['integrations', 'shared']}>
         {t => (
           <>
             <WithRouteData<IBaseRouteParams, IBaseRouteState>>
               {({ flowId }, { integration }, { history }) => {
                 const onDelete = (idx: number, step: Step): void => {
-                  console.log('step: ' + JSON.stringify(step));
-                  console.log('idx: ' + idx);
-                  // console.log('idx: ' + idx);
-                  // console.log('firstPosition: ' + getFirstPosition(this.props.integration, this.props.flowId));
-                  // console.log('lastPosition: ' + getLastPosition(this.props.integration, this.props.flowId));
-
                   if (
                     idx === getFirstPosition(integration, flowId) ||
                     idx === getLastPosition(integration, flowId)
                   ) {
                     history.push(
-                      this.props.getEditStepHref!(
+                      this.props.getEditStepHref(
                         this.state.position!,
                         { flowId },
                         { integration }
@@ -140,21 +127,8 @@ export class AddStepPage extends React.Component<
                     );
                   }
 
-                  // Check if it's an API provider step that can't be deleted
-                  if (step.configuredProperties!.stepKind === 'mapper') {
-                    console.log('Data mapper step');
-                  }
-
                   this.setStepAndPosition(idx, step);
                   this.openDeleteDialog();
-
-                  console.log(
-                    'this.state.position: ' +
-                      JSON.stringify(this.state.position)
-                  );
-                  console.log(
-                    'this.state.step: ' + JSON.stringify(this.state.step)
-                  );
                 };
 
                 return (

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
@@ -194,6 +194,8 @@ export class AddStepPage extends React.Component<
                               this.props
                             )
                           }
+                          flowId={flowId}
+                          integration={integration}
                           onDelete={onDelete}
                         />
                       }

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
@@ -102,7 +102,7 @@ export class AddStepPage extends React.Component<
   public setStepAndPosition(idx: number, step: Step): void {
     this.setState({
       position: idx,
-      step: step,
+      step,
     });
   }
 
@@ -114,19 +114,6 @@ export class AddStepPage extends React.Component<
             <WithRouteData<IBaseRouteParams, IBaseRouteState>>
               {({ flowId }, { integration }, { history }) => {
                 const onDelete = (idx: number, step: Step): void => {
-                  if (
-                    idx === getFirstPosition(integration, flowId) ||
-                    idx === getLastPosition(integration, flowId)
-                  ) {
-                    history.push(
-                      this.props.getEditStepHref(
-                        this.state.position!,
-                        { flowId },
-                        { integration }
-                      )
-                    );
-                  }
-
                   this.setStepAndPosition(idx, step);
                   this.openDeleteDialog();
                 };
@@ -150,18 +137,47 @@ export class AddStepPage extends React.Component<
                         onConfirm={() => {
                           this.handleDeleteConfirm();
 
+                          /**
+                           * Remove the step from the integration flow
+                           * and receive a copy of the new integration.
+                           */
                           const newInt = removeStepFromFlow(
                             integration,
                             flowId,
                             this.state.position!
                           );
 
-                          history.push(
-                            this.props.selfHref(
-                              { flowId },
-                              { integration: newInt }
-                            )
-                          );
+                          /**
+                           * Check if step is first or last position,
+                           * in which case you should delete the step and
+                           * subsequently redirect the user to the step select
+                           * page for that position.
+                           */
+                          if (
+                            this.state.position ===
+                              getFirstPosition(integration, flowId) ||
+                            this.state.position ===
+                              getLastPosition(integration, flowId)
+                          ) {
+                            history.push(
+                              this.props.getEditStepHref(
+                                this.state.position!,
+                                { flowId },
+                                { integration }
+                              )
+                            );
+                          } else {
+                            /**
+                             * If is a middle step, simply remove the step
+                             * and update the UI.
+                             */
+                            history.push(
+                              this.props.selfHref(
+                                { flowId },
+                                { integration: newInt }
+                              )
+                            );
+                          }
                         }}
                       />
                     )}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
@@ -32,6 +32,11 @@ export interface IAddStepPageProps extends IGetStepHrefs {
     p: IBaseRouteParams,
     s: IBaseRouteState
   ) => H.LocationDescriptor;
+  getEditStepHref?: (
+    position: number,
+    p: IBaseRouteParams,
+    s: IBaseRouteState
+  ) => H.LocationDescriptorObject;
   saveHref: (p: IBaseRouteParams, s: IBaseRouteState) => H.LocationDescriptor;
   selfHref: (
     p: IBaseRouteParams,
@@ -122,13 +127,17 @@ export class AddStepPage extends React.Component<
                   // console.log('firstPosition: ' + getFirstPosition(this.props.integration, this.props.flowId));
                   // console.log('lastPosition: ' + getLastPosition(this.props.integration, this.props.flowId));
 
-                  if (idx === getFirstPosition(integration, flowId)) {
-                    console.log('Is first position');
-                    // H.location.push({this.props.editAddStepHref(idx)});
-                  }
-
-                  if (idx === getLastPosition(integration, flowId)) {
-                    console.log('Is last position');
+                  if (
+                    idx === getFirstPosition(integration, flowId) ||
+                    idx === getLastPosition(integration, flowId)
+                  ) {
+                    history.push(
+                      this.props.getEditStepHref!(
+                        this.state.position!,
+                        { flowId },
+                        { integration }
+                      )
+                    );
                   }
 
                   // Check if it's an API provider step that can't be deleted
@@ -167,20 +176,11 @@ export class AddStepPage extends React.Component<
                         onConfirm={() => {
                           this.handleDeleteConfirm();
 
-                          console.log(
-                            'this.state.position: ' + this.state.position
-                          );
-                          console.log('this.state.step: ' + this.state.step);
-
                           const newInt = removeStepFromFlow(
                             integration,
                             flowId,
                             this.state.position!
                           );
-
-                          console.log('newInt: ' + JSON.stringify(newInt));
-
-                          // deleteAction(newInt);
 
                           history.push(
                             this.props.selfHref(

--- a/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -70,14 +70,10 @@
   },
   "editor": {
     "addStep": "Add a step",
-    "addStepDataMapping": "Add a data mapping step",
-    "addStepDataMappingTrail": "  before this connection to resolve the difference.",
     "addStepDescription": "You can continue adding steps and connections to your integration as well.",
     "addToIntegration": "Add to Integration",
     "confirmDeleteStepDialogBody": "Are you sure you want to delete this step from the integration?",
     "confirmDeleteStepDialogTitle": "Confirm Delete",
-    "dataShape": "Data Shape",
-    "defineDataTypeMessage": "<a href={'/todo'}>Define the data type</a> for the previous step to resolve this warning.",
     "saveOrAddStep": "Save or Add Step"
   },
   "ReplaceDraft": "Replace Draft",

--- a/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -70,11 +70,14 @@
   },
   "editor": {
     "addStep": "Add a step",
+    "addStepDataMapping": "Add a data mapping step",
+    "addStepDataMappingTrail": "  before this connection to resolve the difference.",
     "addStepDescription": "You can continue adding steps and connections to your integration as well.",
     "addToIntegration": "Add to Integration",
     "confirmDeleteStepDialogBody": "Are you sure you want to delete this step from the integration?",
     "confirmDeleteStepDialogTitle": "Confirm Delete",
     "dataShape": "Data Shape",
+    "defineDataTypeMessage": "<a href={'/todo'}>Define the data type</a> for the previous step to resolve this warning.",
     "saveOrAddStep": "Save or Add Step"
   },
   "ReplaceDraft": "Replace Draft",


### PR DESCRIPTION
Changes:
- Check and hide ability to delete if step is API provider or CBR
- Move most logic to `AddStepPage` for ease of use with history

Outstanding:
- Check for first and last step of integration flow, on confirmation of delete redirect the user to that position step select page. The check works fine, but the redirect does not. See comments below.

fix #308 