### PR TITLE
fix(listviewtoolbar): decrease left/right padding so it aligns with list view content

### DIFF
--- a/app/ui-react/packages/ui/src/Shared/DndFileChooser.tsx
+++ b/app/ui-react/packages/ui/src/Shared/DndFileChooser.tsx
@@ -275,7 +275,7 @@ export class DndFileChooser extends React.Component<
             {this.props.i18nHelpMessage ? (
               <Grid.Row>
                 <Grid.Col className="dnd-file-chooser__helpText">
-                  {this.props.i18nHelpMessage}
+                  <em>{this.props.i18nHelpMessage}</em>
                 </Grid.Col>
               </Grid.Row>
             ) : null}

--- a/app/ui-react/packages/ui/src/Shared/ListViewToolbar.css
+++ b/app/ui-react/packages/ui/src/Shared/ListViewToolbar.css
@@ -1,3 +1,8 @@
+.list-view-toolbar .toolbar-pf > .col-sm-12 {
+  padding-left: 15px;
+  padding-right: 15px;
+}
+
 @media (max-width: 768px) {
   .toolbar-pf-actions > .toolbar-pf-filter,
   .toolbar-pf-actions > .form-group {

--- a/app/ui-react/packages/ui/src/Shared/ListViewToolbar.tsx
+++ b/app/ui-react/packages/ui/src/Shared/ListViewToolbar.tsx
@@ -59,7 +59,7 @@ export interface IListViewToolbarProps {
 export class ListViewToolbar extends React.Component<IListViewToolbarProps> {
   public render() {
     return (
-      <Toolbar>
+      <Toolbar className="list-view-toolbar">
         <Filter>
           <Filter.TypeSelector
             filterTypes={this.props.filterTypes}


### PR DESCRIPTION
Aligns `<ListViewToolbar>` inside with the list row content below it.

Italicizes note text at the bottom of integration import drag 'n drop box