### PR TITLE
Dashboard Recent Updates should support error handling like other components

### DIFF
--- a/app/ui-react/syndesis/src/modules/dashboard/pages/DashboardPage.tsx
+++ b/app/ui-react/syndesis/src/modules/dashboard/pages/DashboardPage.tsx
@@ -224,7 +224,7 @@ export default () => (
                           i18nTitle={t('titleIntegrationUpdates')}
                         >
                           <WithLoader
-                            error={false}
+                            error={integrationsError}
                             loading={!hasIntegrations}
                             loaderChildren={<RecentUpdatesSkeleton />}
                             errorChildren={<ApiError />}


### PR DESCRIPTION
- see #293 
- the dashboard's `RecentUpdatesCard` now indicates there is an error if there was a problem fetching integrations