### PR TITLE
fix: let the staging URL be overridden via environment varible

### DIFF
--- a/tools/bin/commands/ui
+++ b/tools/bin/commands/ui
@@ -176,7 +176,9 @@ do_things() {
       fi
     else
       echo -e "\nRunning against the staging environment"
-      export BACKEND=https://syndesis-staging.b6ff.rh-idev.openshiftapps.com
+      if [ -z ${BACKEND+x} ]; then
+        export BACKEND=https://syndesis-staging.b6ff.rh-idev.openshiftapps.com
+      fi
       if [ $(hasflag --angular) ]; then
         yarn start:staging $UI_VERBOSE_YARN &
       else


### PR DESCRIPTION
Just a quick tweak for now, with this change you can do `export BACKEND=https://syndesis-staging-2.b6ff.rh-idev.openshiftapps.com` and then `syndesis ui --serve` will point to the second staging backend.