### PR TITLE
The connections list page's disabled 'delete' menu item no longer triggers a delete confirmation

### DIFF
--- a/app/ui-react/packages/ui/src/Connection/ConnectionCard.css
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionCard.css
@@ -27,7 +27,7 @@
 .connection-card__heading .heading__dropdown {
   position: absolute;
   top: 35px;
-  right: 35px;
+  right: 10px;
 }
 
 a.connection-card__content:hover,

--- a/app/ui-react/packages/ui/src/Connection/ConnectionCard.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionCard.tsx
@@ -1,4 +1,8 @@
 import {
+  Button,
+  Dropdown,
+  DropdownPosition,
+  KebabToggle,
   Level,
   LevelItem,
   Popover,
@@ -7,7 +11,7 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import * as H from '@syndesis/history';
-import { Card, DropdownKebab, Icon } from 'patternfly-react';
+import { Card, Icon } from 'patternfly-react';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { toValidHtmlId } from '../helpers';
@@ -15,6 +19,7 @@ import {
   ConfirmationButtonStyle,
   ConfirmationDialog,
   ConfirmationIconType,
+  PfDropdownItem,
 } from '../Shared';
 import './ConnectionCard.css';
 
@@ -47,6 +52,7 @@ export interface IConnectionProps {
 }
 
 export interface IConnectionCardState {
+  isMenuOpen: boolean;
   showDeleteDialog: boolean;
 }
 
@@ -58,6 +64,7 @@ export class ConnectionCard extends React.PureComponent<
     super(props);
 
     this.state = {
+      isMenuOpen: false,
       showDeleteDialog: false, // initial visibility of delete dialog
     };
 
@@ -83,6 +90,19 @@ export class ConnectionCard extends React.PureComponent<
       this.props.menuProps.onDelete();
     }
   }
+  public onToggle = (isMenuOpen: boolean) => {
+    this.setState({
+      isMenuOpen,
+    });
+  };
+
+  public onMenuSelect = (
+    event: React.SyntheticEvent<HTMLDivElement, Event>
+  ) => {
+    this.setState({
+      isMenuOpen: !this.state.isMenuOpen,
+    });
+  };
 
   public showDeleteDialog() {
     this.setState({
@@ -144,66 +164,73 @@ export class ConnectionCard extends React.PureComponent<
             )}
             {this.props.menuProps && (
               <div className="heading__dropdown pull-right">
-                <DropdownKebab
+                <Dropdown
                   id={`connection-${this.props.name}-menu`}
-                  pullRight={true}
-                  title={this.props.menuProps.i18nMenuTitle}
-                >
-                  <li role={'presentation'} key={0}>
-                    <Link
-                      data-testid={'connection-card-view-action'}
-                      to={this.props.href}
-                      role={'menuitem'}
-                      tabIndex={1}
-                    >
-                      {this.props.menuProps.i18nViewLabel}
-                    </Link>
-                  </li>
-                  <li role={'presentation'} key={1}>
-                    <Link
-                      data-testid={'connection-card-edit-action'}
-                      to={this.props.menuProps.editHref}
-                      role={'menuitem'}
-                      tabIndex={2}
-                    >
-                      {this.props.menuProps.i18nEditLabel}
-                    </Link>
-                  </li>
-                  <li
-                    className={
-                      !this.props.menuProps.isDeleteEnabled ? 'disabled' : ''
-                    }
-                    role={'presentation'}
-                    key={2}
-                  >
-                    {this.props.configurationRequired ? (
-                      <Tooltip
-                        content={this.props.i18nCannotDelete!}
-                        position={'bottom'}
+                  onSelect={this.onMenuSelect}
+                  toggle={
+                    <KebabToggle
+                      id="connection-card-kebab"
+                      onToggle={this.onToggle}
+                    />
+                  }
+                  isOpen={this.state.isMenuOpen}
+                  isPlain={true}
+                  dropdownItems={[
+                    <PfDropdownItem key="view-action">
+                      <Link
+                        className="pf-c-dropdown__menu-item"
+                        data-testid={'connection-card-view-action'}
+                        to={this.props.href}
+                        role={'menuitem'}
+                        tabIndex={1}
                       >
+                        {this.props.menuProps.i18nViewLabel}
+                      </Link>
+                    </PfDropdownItem>,
+                    <PfDropdownItem key="edit-action">
+                      <Link
+                        className="pf-c-dropdown__menu-item"
+                        data-testid={'connection-card-edit-action'}
+                        to={this.props.menuProps.editHref}
+                        role={'menuitem'}
+                        tabIndex={2}
+                      >
+                        {this.props.menuProps.i18nEditLabel}
+                      </Link>
+                    </PfDropdownItem>,
+                    <PfDropdownItem
+                      disabled={!this.props.menuProps.isDeleteEnabled}
+                      key="delete-action"
+                      onClick={this.showDeleteDialog}
+                    >
+                      {!this.props.menuProps.isDeleteEnabled ? (
+                        <Tooltip
+                          content={this.props.i18nCannotDelete!}
+                          position={'bottom'}
+                        >
+                          <Button
+                            className="pf-c-dropdown__menu-item"
+                            isDisabled={true}
+                            variant={'link'}
+                          >
+                            {this.props.menuProps.i18nDeleteLabel}
+                          </Button>
+                        </Tooltip>
+                      ) : (
                         <a
+                          className="pf-c-dropdown__menu-item"
                           data-testid={'connection-card-delete-action'}
                           href={'javascript:void(0)'}
-                          onClick={this.showDeleteDialog}
                           role={'menuitem'}
                           tabIndex={3}
                         >
                           {this.props.menuProps.i18nDeleteLabel}
                         </a>
-                      </Tooltip>
-                    ) : (
-                      <a
-                        data-testid={'connection-card-delete-action'}
-                        href={'javascript:void(0)'}
-                        onClick={this.showDeleteDialog}
-                        role={'menuitem'}
-                        tabIndex={3}
-                      >
-                        {this.props.menuProps.i18nDeleteLabel}
-                      </a>
-                    )}
-                  </li>
-                </DropdownKebab>
+                      )}
+                    </PfDropdownItem>,
+                  ]}
+                  position={DropdownPosition.right}
+                />
               </div>
             )}
           </Card.Heading>

--- a/app/ui-react/packages/ui/src/Connection/ConnectionDetailsForm.tsx
+++ b/app/ui-react/packages/ui/src/Connection/ConnectionDetailsForm.tsx
@@ -129,26 +129,28 @@ export class ConnectionDetailsForm extends React.Component<
                   </div>
                 </form>
               </Card.Body>
-              <Card.Footer>
-                <Button
-                  data-testid={'connection-details-form-cancel-button'}
-                  bsStyle="default"
-                  className="connection-details-form__editButton"
-                  disabled={this.props.isWorking}
-                  onClick={this.props.onCancelEditing}
-                >
-                  {this.props.i18nCancelLabel}
-                </Button>
-                <Button
-                  data-testid={'connection-details-form-save-button'}
-                  bsStyle="primary"
-                  className="connection-details-form__editButton"
-                  disabled={this.props.isWorking || !this.props.isValid}
-                  onClick={this.props.handleSubmit}
-                >
-                  {this.props.i18nSaveLabel}
-                </Button>
-              </Card.Footer>
+              {this.props.isEditing ? (
+                <Card.Footer>
+                  <Button
+                    data-testid={'connection-details-form-cancel-button'}
+                    bsStyle="default"
+                    className="connection-details-form__editButton"
+                    disabled={this.props.isWorking}
+                    onClick={this.props.onCancelEditing}
+                  >
+                    {this.props.i18nCancelLabel}
+                  </Button>
+                  <Button
+                    data-testid={'connection-details-form-save-button'}
+                    bsStyle="primary"
+                    className="connection-details-form__editButton"
+                    disabled={this.props.isWorking || !this.props.isValid}
+                    onClick={this.props.handleSubmit}
+                  >
+                    {this.props.i18nSaveLabel}
+                  </Button>
+                </Card.Footer>
+              ) : null}
             </Card>
           </div>
         </Container>

--- a/app/ui-react/packages/ui/src/Shared/PfDropdownItem.tsx
+++ b/app/ui-react/packages/ui/src/Shared/PfDropdownItem.tsx
@@ -3,12 +3,16 @@ import * as React from 'react';
 
 export interface IPfDropdownItem {
   children: React.ReactNode;
+  disabled?: boolean;
   onClick?(event?: React.MouseEvent): void;
 }
 class PfDropdownItem extends React.Component<IPfDropdownItem> {
   public render() {
     return (
-      <DropdownItem onClick={this.props.onClick}>
+      <DropdownItem
+        isDisabled={this.props.disabled}
+        onClick={this.props.onClick}
+      >
         {this.props.children}
       </DropdownItem>
     );

--- a/app/ui-react/packages/ui/stories/Connection/ConnectionDetailsForm.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Connection/ConnectionDetailsForm.stories.tsx
@@ -1,0 +1,93 @@
+import { action } from '@storybook/addon-actions';
+import { boolean } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import {
+  ConnectionDetailsForm,
+  IConnectionDetailsValidationResult,
+} from '../../src';
+
+const stories = storiesOf('Connection/ConnectionDetailsForm', module);
+const cancelLabel = 'Cancel';
+const editLabel = 'Edit';
+const errorMessage = 'An error message';
+const saveLabel = 'Save';
+const successMessage = 'A success message';
+const title = 'Connection Details Form';
+const validateLabel = 'Validate';
+
+const cancelEditingText = 'editing canceled';
+const startEditingText = 'editing started';
+const submitText = 'saving';
+const validateText = 'validating';
+
+const validationResults: IConnectionDetailsValidationResult[] = [
+  { message: successMessage, type: 'success' },
+  { message: errorMessage, type: 'error' },
+];
+
+const storyNotes =
+  '- Verify title is "' +
+  title +
+  '"\n' +
+  '- Verify there is a success message with the text: "' +
+  successMessage +
+  '"\n' +
+  '- Verify there is an error message with the text: "' +
+  errorMessage +
+  '"\n' +
+  '- Verify there is an edit button that is enabled and has the text of "' +
+  editLabel +
+  '"\n' +
+  '- Verify clicking the edit button prints "' +
+  startEditingText +
+  '" in the action log' +
+  '"\n' +
+  '- Verify clicking on the **isEditing** knob hides the edit button and shows the validate, cancel, and save buttons' +
+  '"\n' +
+  '- Verify the validate button is enabled and has the text of "' +
+  validateLabel +
+  '"\n' +
+  '- Verify clicking the validate button prints "' +
+  validateText +
+  '" in the action log' +
+  '"\n' +
+  '- Verify the cancel button is enabled and has the text of "' +
+  cancelLabel +
+  '"\n' +
+  '- Verify clicking the cancel button prints "' +
+  cancelEditingText +
+  '" in the action log' +
+  '"\n' +
+  '- Verify the save button is enabled and has the text of "' +
+  saveLabel +
+  '"\n' +
+  '- Verify clicking the save button prints "' +
+  submitText +
+  '" in the action log' +
+  '"\n' +
+  '- Verify clicking on the **isWorking** knob shows a spinner on the validate button and disables the cancel and save buttons' +
+  '"\n' +
+  '- Verify clicking off the **isEditing** knob hides the validate, cancel, and save buttons and shows the edit button.';
+
+stories.add(
+  'render',
+  () => (
+    <ConnectionDetailsForm
+      handleSubmit={action(submitText)}
+      i18nCancelLabel={cancelLabel}
+      i18nEditLabel={editLabel}
+      i18nSaveLabel={saveLabel}
+      i18nTitle={title}
+      i18nValidateLabel={validateLabel}
+      isEditing={boolean('isEditing', false)}
+      isValid={boolean('isValid', true)}
+      isWorking={boolean('isWorking', false)}
+      onCancelEditing={action(cancelEditingText)}
+      onStartEditing={action(startEditingText)}
+      onValidate={action(validateText)}
+      validationResults={validationResults}
+    />
+  ),
+  { notes: storyNotes }
+);


### PR DESCRIPTION
- See #208
- `ConnectionCard` now uses PF4 Dropdown
- Fixes a regression bug in `ConnectionDetailsForm` that kept the cancel and save buttons always visible
- Added property to `PfDropdownItem` that indicates if item should be disabled
- Added a `ConnectionDetailsForm` story