### PR TITLE
fix(integrationdetails): various ui fixes

### DIFF
--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailEditableName.css
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailEditableName.css
@@ -1,0 +1,3 @@
+.integration-detail-editable-name {
+  margin-right: 15px;
+}

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailEditableName.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailEditableName.tsx
@@ -1,5 +1,6 @@
 import { Title } from '@patternfly/react-core';
 import * as React from 'react';
+import './IntegrationDetailEditableName.css';
 
 export interface IIntegrationDetailEditableNameProps {
   name?: React.ReactNode;
@@ -9,6 +10,14 @@ export class IntegrationDetailEditableName extends React.PureComponent<
   IIntegrationDetailEditableNameProps
 > {
   public render() {
-    return <>{this.props.name && <Title size="lg">{this.props.name}</Title>}</>;
+    return (
+      <>
+        {this.props.name && (
+          <Title size="lg" className="integration-detail-editable-name">
+            {this.props.name}
+          </Title>
+        )}
+      </>
+    );
   }
 }

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailHistoryListViewItem.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailHistoryListViewItem.tsx
@@ -59,7 +59,6 @@ export class IntegrationDetailHistoryListViewItem extends React.Component<
             {this.props.updatedAt}
           </>
         }
-        additionalInfo={[]}
         leftContent={getIntegrationState(this.props.currentState!)}
         stacked={false}
       />

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailInfo.css
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailInfo.css
@@ -1,5 +1,7 @@
 .integration-detail-info {
     display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
 }
 
 .integration-detail-info .fa-pencil {
@@ -9,4 +11,12 @@
     border: 1px solid transparent;
     padding: 2px 6px;
     font-size: 12px;
+}
+
+.integration-detail-info__status {
+    white-space: nowrap;
+}
+
+.integration-detail-info__status-icon {
+    margin-right: 5px;
 }

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailInfo.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailInfo.tsx
@@ -26,7 +26,6 @@ export class IntegrationDetailInfo extends React.PureComponent<
       <div className="integration-detail-info">
         {this.props.name}
         <>
-          &nbsp;&nbsp;&nbsp;&nbsp;
           {this.props.currentState === 'Pending' && (
             <IntegrationStatusDetail
               targetState={this.props.targetState}
@@ -41,10 +40,10 @@ export class IntegrationDetailInfo extends React.PureComponent<
             />
           )}
           {this.props.currentState === 'Published' && this.props.version && (
-            <>
-              <span className="pficon pficon-ok" />
-              &nbsp;Published version {this.props.version}
-            </>
+            <div className="integration-detail-info__status">
+              <span className="pficon pficon-ok integration-detail-info__status-icon" />
+              Published version {this.props.version}
+            </div>
           )}
         </>
       </div>

--- a/app/ui-react/packages/ui/src/Integration/IntegrationStatusDetail.css
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationStatusDetail.css
@@ -1,5 +1,4 @@
 .integration-status-detail {
   align-items: center;
   display: inline-flex;
-  flex-flow: row;
 }

--- a/app/ui-react/packages/ui/src/Integration/Metrics/IntegrationDetailMetrics.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Metrics/IntegrationDetailMetrics.tsx
@@ -65,10 +65,7 @@ export class IntegrationDetailMetrics extends React.Component<
                 aggregated={true}
                 matchHeight={true}
               >
-                <CardTitle>
-                  <Icon name="shield" />
-                  {this.props.i18nLastProcessed}
-                </CardTitle>
+                <CardTitle>{this.props.i18nLastProcessed}</CardTitle>
                 <CardBody>
                   <AggregateStatusNotifications>
                     <AggregateStatusNotification>

--- a/app/ui-react/packages/ui/src/Shared/ProgressWithLink.css
+++ b/app/ui-react/packages/ui/src/Shared/ProgressWithLink.css
@@ -1,7 +1,22 @@
 .progress-link {
-  width: 180px;
+  width: 200px;
+  font-size: 12px;
 }
 
-.progress-link .progress-link-value {
-  text-transform: capitalize;
+.progress-link__row {
+  display: flex;
+  justify-content: space-between;
+}
+
+.progress-link__status {
+  font-style: italic;
+}
+
+.progress-link__link {
+  margin-left: 5px;
+}
+
+.progress-link .progress-link__link-icon {
+  margin-right: 0;
+  margin-left: 5px;
 }

--- a/app/ui-react/packages/ui/src/Shared/ProgressWithLink.tsx
+++ b/app/ui-react/packages/ui/src/Shared/ProgressWithLink.tsx
@@ -16,19 +16,26 @@ export class ProgressWithLink extends React.PureComponent<
   public render() {
     return (
       <div className="progress-link">
-        <div>
-          <i data-testid={'progress-with-link-value'}>
+        <div className="progress-link__row">
+          <div
+            className="progress-link__status"
+            data-testid={'progress-with-link-value'}
+          >
             {this.props.value} ( {this.props.currentStep} /{' '}
             {this.props.totalSteps} )
-          </i>
+          </div>
           {this.props.logUrl && (
-            <span className="pull-right">
+            <span className="progress-link__link">
               <a
                 data-testid={'progress-with-link-log-url'}
                 target="_blank"
                 href={this.props.logUrl}
               >
-                {this.props.i18nLogUrlText} <Icon name={'external-link'} />
+                {this.props.i18nLogUrlText}{' '}
+                <Icon
+                  className="progress-link__link-icon"
+                  name={'external-link'}
+                />
               </a>
             </span>
           )}

--- a/app/ui-react/syndesis/src/modules/integrations/components/TagIntegrationDialogWrapper.css
+++ b/app/ui-react/syndesis/src/modules/integrations/components/TagIntegrationDialogWrapper.css
@@ -1,0 +1,3 @@
+.tag-integration-dialog-wrapper__description {
+  margin-bottom: 15px;
+}

--- a/app/ui-react/syndesis/src/modules/integrations/components/TagIntegrationDialogWrapper.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/TagIntegrationDialogWrapper.tsx
@@ -11,6 +11,7 @@ import { WithLoader } from '@syndesis/utils';
 import * as React from 'react';
 import { Translation } from 'react-i18next';
 import { ApiError } from '../../../shared';
+import './TagIntegrationDialogWrapper.css';
 
 export interface ITagIntegrationDialogWrapperProps {
   manageCiCdHref: H.LocationDescriptor;
@@ -61,7 +62,7 @@ export class TagIntegrationDialogWrapper extends React.Component<
                     }) => {
                       return (
                         <>
-                          <p>
+                          <p className="tag-integration-dialog-wrapper__description">
                             {t('integrations:TagThisIntegrationForRelease')}
                           </p>
                           <WithLoader


### PR DESCRIPTION
* removes shield icon from last processed card in integration detail metrics
* adds padding under description paragraph in manage ci/cd dialog in integration details
* removes unnecessary `additionalInfo` value in integration details history table, allowing "last published on date, time" line to be on a single line.
* aligns integration name and published status icon/text in integration details view
* fix the integration progress with link layout