### PR TITLE
fix: show the right steps in the editor

### DIFF
--- a/app/ui-react/packages/api/src/WithSteps.tsx
+++ b/app/ui-react/packages/api/src/WithSteps.tsx
@@ -194,9 +194,10 @@ function requiresInputOutputDataShapes(
   ) => {
     if (!anyPrevious) {
       // only test the first previous step that has some kind of data shape
-      const previousStep = previousSteps
-        .reverse()
-        .find(s => dataShapeExists(s));
+      const previousStep = previousSteps.reduceRight(
+        (foundStep, s) => (!foundStep && dataShapeExists(s) ? s : foundStep),
+        undefined as Step | undefined
+      );
       previousSteps = previousStep ? [previousStep] : [];
     }
     if (!anySubsequent) {
@@ -233,9 +234,10 @@ function dataShapeExists(step: Step, input = false): boolean {
 }
 
 function hasPrecedingCollection(previousSteps: Step[]) {
-  const previousDataShape = previousSteps
-    .reverse()
-    .find(s => dataShapeExists(s));
+  const previousDataShape = previousSteps.reduceRight(
+    (foundStep, s) => (!foundStep && dataShapeExists(s) ? s : foundStep),
+    undefined as Step | undefined
+  );
   return (
     previousDataShape &&
     previousDataShape.action &&

--- a/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorForm.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorForm.tsx
@@ -1,7 +1,7 @@
 import * as H from '@syndesis/history';
 import { Alert } from 'patternfly-react';
 import * as React from 'react';
-import { ButtonLink, Container, PageSection } from '../../Layout';
+import { ButtonLink, Container, Loader, PageSection } from '../../Layout';
 
 export interface IIntegrationEditorFormProps {
   /**
@@ -16,6 +16,7 @@ export interface IIntegrationEditorFormProps {
    * @param e
    */
   isValid: boolean;
+  isLoading: boolean;
   error?: string;
   backActionHref?: H.LocationDescriptor;
   handleSubmit: (e?: any) => void;
@@ -72,10 +73,16 @@ export class IntegrationEditorForm extends React.Component<
                   <ButtonLink
                     id={'integration-editor-form-next-button'}
                     onClick={this.props.submitForm}
-                    disabled={!this.props.isValid}
+                    disabled={!this.props.isValid || this.props.isLoading}
                     as={'primary'}
                   >
                     {this.props.i18nNext}
+                    {this.props.isLoading ? (
+                      <>
+                        &nbsp;&nbsp;
+                        <Loader inline={true} size={'xs'} />
+                      </>
+                    ) : null}
                   </ButtonLink>
                 </div>
               </div>

--- a/app/ui-react/packages/ui/src/Integration/IntegrationSaveForm.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationSaveForm.tsx
@@ -19,6 +19,8 @@ export interface IIntegrationSaveFormProps {
   isSaveLoading: boolean;
   isPublishDisabled: boolean;
   isPublishLoading: boolean;
+  i18nSave: string;
+  i18nSaveAndPublish: string;
 }
 
 /**
@@ -26,7 +28,6 @@ export interface IIntegrationSaveFormProps {
  * editor. This does *not* build the form itself, form's field should be passed
  * as the `children` value.
  * @see [i18nTitle]{@link IIntegrationSaveFormProps#i18nTitle}
- * @see [i18nSubtitle]{@link IIntegrationSaveFormProps#i18nSubtitle}
  */
 export const IntegrationSaveForm: React.FunctionComponent<
   IIntegrationSaveFormProps
@@ -39,6 +40,8 @@ export const IntegrationSaveForm: React.FunctionComponent<
   isSaveLoading,
   isPublishDisabled,
   isPublishLoading,
+  i18nSave,
+  i18nSaveAndPublish,
   children,
 }) => {
   return (
@@ -67,7 +70,7 @@ export const IntegrationSaveForm: React.FunctionComponent<
                 disabled={isSaveLoading || isSaveDisabled}
               >
                 {isSaveLoading ? <Loader size={'xs'} inline={true} /> : null}
-                Save
+                {i18nSave}
               </ButtonLink>
               &nbsp;
               <ButtonLink
@@ -76,7 +79,7 @@ export const IntegrationSaveForm: React.FunctionComponent<
                 as={'primary'}
                 disabled={isPublishLoading || isPublishDisabled}
               >
-                Save and publish
+                {i18nSaveAndPublish}
               </ButtonLink>
             </div>
           </div>

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/AddStepPage.tsx
@@ -2,7 +2,7 @@ import {
   getFirstPosition,
   getLastPosition,
   getSteps,
-  removeStepFromFlow,
+  useIntegrationHelpers,
 } from '@syndesis/api';
 import * as H from '@syndesis/history';
 import { Step } from '@syndesis/models';
@@ -11,8 +11,9 @@ import {
   ConfirmationDialog,
   ConfirmationIconType,
   IntegrationEditorLayout,
+  PageLoader,
 } from '@syndesis/ui';
-import { useRouteData } from '@syndesis/utils';
+import { useRouteData, WithLoader } from '@syndesis/utils';
 import * as React from 'react';
 import { Translation } from 'react-i18next';
 import { PageTitle } from '../../../../shared';
@@ -94,6 +95,8 @@ export const AddStepPage: React.FunctionComponent<
   >();
   const [position, setPosition] = React.useState(0);
   const [showDeleteDialog, setShowDeleteDialog] = React.useState(false);
+  const [isDeleting, setIsDeleting] = React.useState(false);
+  const { removeStep } = useIntegrationHelpers();
 
   const closeDeleteDialog = (): void => {
     setShowDeleteDialog(false);
@@ -130,7 +133,7 @@ export const AddStepPage: React.FunctionComponent<
               i18nTitle={t('integrations:editor:confirmDeleteStepDialogTitle')}
               showDialog={showDeleteDialog}
               onCancel={closeDeleteDialog}
-              onConfirm={() => {
+              onConfirm={async () => {
                 handleDeleteConfirm();
 
                 /**
@@ -150,12 +153,13 @@ export const AddStepPage: React.FunctionComponent<
                    * Remove the step from the integration flow
                    * and receive a copy of the new integration.
                    */
-                  const newInt = removeStepFromFlow(
+                  setIsDeleting(true);
+                  const newInt = await removeStep(
                     state.integration,
                     params.flowId,
                     position!
                   );
-
+                  setIsDeleting(false);
                   /**
                    * If is a middle step, simply remove the step
                    * and update the UI.
@@ -180,19 +184,33 @@ export const AddStepPage: React.FunctionComponent<
               state
             )}
             content={
-              <IntegrationEditorStepAdder
-                steps={getSteps(state.integration, params.flowId)}
-                addDataMapperStepHref={p =>
-                  getAddMapperStepHref(p, params, state)
-                }
-                addStepHref={p => getAddStepHref(p, params, state)}
-                configureStepHref={(p: number, s: Step) =>
-                  getStepHref(s, { ...params, position: `${p}` }, state, props)
-                }
-                flowId={params.flowId}
-                integration={state.integration}
-                onDelete={onDelete}
-              />
+              <WithLoader
+                loading={isDeleting}
+                loaderChildren={<PageLoader />}
+                error={false}
+                errorChildren={<span />}
+              >
+                {() => (
+                  <IntegrationEditorStepAdder
+                    steps={getSteps(state.integration, params.flowId)}
+                    addDataMapperStepHref={p =>
+                      getAddMapperStepHref(p, params, state)
+                    }
+                    addStepHref={p => getAddStepHref(p, params, state)}
+                    configureStepHref={(p: number, s: Step) =>
+                      getStepHref(
+                        s,
+                        { ...params, position: `${p}` },
+                        state,
+                        props
+                      )
+                    }
+                    flowId={params.flowId}
+                    integration={state.integration}
+                    onDelete={onDelete}
+                  />
+                )}
+              </WithLoader>
             }
             cancelHref={cancelHref(params, state)}
             saveHref={saveHref(params, state)}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/SaveIntegrationPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/SaveIntegrationPage.tsx
@@ -140,13 +140,13 @@ export const SaveIntegrationPage: React.FunctionComponent<
                     const definition: IFormDefinition = {
                       description: {
                         defaultValue: '',
-                        displayName: 'Description',
+                        displayName: t('shared:Description'),
                         order: 1,
                         type: 'textarea',
                       },
                       name: {
                         defaultValue: '',
-                        displayName: 'Name',
+                        displayName: t('shared:Name'),
                         order: 0,
                         required: true,
                         type: 'string',
@@ -178,14 +178,16 @@ export const SaveIntegrationPage: React.FunctionComponent<
                           submitForm,
                         }) => (
                           <>
-                            <PageTitle title={'Save the integration'} />
+                            <PageTitle
+                              title={t('integrations:editor:save:title')}
+                            />
                             <IntegrationEditorLayout
-                              title={'Save the integration'}
-                              description={
-                                'Update details about this integration.'
-                              }
+                              title={t('integrations:editor:save:title')}
+                              description={t(
+                                'integrations:editor:save:description'
+                              )}
                               toolbar={getBreadcrumb(
-                                'Save the integration',
+                                t('integrations:editor:save:title'),
                                 params,
                                 state
                               )}
@@ -201,6 +203,10 @@ export const SaveIntegrationPage: React.FunctionComponent<
                                   }}
                                   isPublishDisabled={!isValid}
                                   isPublishLoading={isSubmitting}
+                                  i18nSave={t('shared:Save')}
+                                  i18nSaveAndPublish={t(
+                                    'integrations:editor:save:saveAndPublish'
+                                  )}
                                 >
                                   {fields}
                                 </IntegrationSaveForm>

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/dataMapper/DataMapperPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/dataMapper/DataMapperPage.tsx
@@ -57,8 +57,6 @@ export const DataMapperPage: React.FunctionComponent<
   const [mappings, setMapping] = React.useState<string | undefined>(undefined);
 
   const onMappings = (newMappings: string) => {
-    // tslint:disable-next-line
-    console.log('onMappings', newMappings, mappings);
     setMapping(newMappings);
   };
 

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigurationForm.tsx
@@ -95,13 +95,14 @@ export const ConfigurationForm: React.FunctionComponent<
         validateInitial={validator}
         key={key}
       >
-        {({ fields, handleSubmit, isValid, submitForm }) => (
+        {({ fields, handleSubmit, isValid, isSubmitting, submitForm }) => (
           <>
             <IntegrationEditorForm
               i18nFormTitle={`${action.name} - ${action.description}`}
               i18nBackAction={'Choose Action'}
               i18nNext={'Next'}
               isValid={isValid}
+              isLoading={isSubmitting}
               submitForm={() => {
                 setError(undefined);
                 submitForm();

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/ruleFilter/WithRuleFilterForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/ruleFilter/WithRuleFilterForm.tsx
@@ -58,15 +58,15 @@ export const WithRuleFilterForm: React.FunctionComponent<
   const definition = {
     predicate: {
       defaultValue: 'AND',
-      displayName: 'Continue only if incoming data match ',
+      displayName: t('integrations:editor:ruleForm:predicateDescription'),
       enum: [
         {
-          label: 'ALL of the following',
+          label: t('integrations:editor:ruleForm:predicateEnumAll'),
           value: 'AND',
         },
 
         {
-          label: 'ANY of the following',
+          label: t('integrations:editor:ruleForm:predicateEnumAny'),
           value: 'OR',
         },
       ],
@@ -75,8 +75,8 @@ export const WithRuleFilterForm: React.FunctionComponent<
     rules: {
       arrayDefinition: {
         op: {
-          description: 'Must meet this condition',
-          displayName: 'Operator',
+          description: t('integrations:editor:ruleForm:operatorDescription'),
+          displayName: t('integrations:editor:ruleForm:operatorDisplay'),
           enum: filterOptions.ops,
           order: 1,
           required: true,
@@ -84,18 +84,18 @@ export const WithRuleFilterForm: React.FunctionComponent<
         },
         path: {
           dataList: filterOptions.paths,
-          description: 'The data you want to evaluate',
-          displayName: 'Property Name',
+          description: t('integrations:editor:ruleForm:pathDescription'),
+          displayName: t('integrations:editor:ruleForm:pathDisplay'),
           order: 0,
-          placeholder: 'Property name',
+          placeholder: t('integrations:editor:ruleForm:pathPlaceholder'),
           required: true,
           type: 'text',
         },
         value: {
-          description: 'For this value',
-          displayName: 'Keywords',
+          description: t('integrations:editor:ruleForm:keywordsDescription'),
+          displayName: t('integrations:editor:ruleForm:keywordsDisplay'),
           order: 2,
-          placeholder: 'Keywords',
+          placeholder: t('integrations:editor:ruleForm:keywordsPlaceholder'),
           required: true,
           type: 'text',
         },
@@ -110,7 +110,7 @@ export const WithRuleFilterForm: React.FunctionComponent<
         formGroupAttributes: {
           className: 'col-md-3',
         },
-        i18nAddElementText: '+ Add another rule',
+        i18nAddElementText: t('integrations:editor:ruleForm:addRule'),
         minElements: 1,
       },
       required: true,
@@ -133,7 +133,8 @@ export const WithRuleFilterForm: React.FunctionComponent<
   const validator = (values: IRuleFilterConfig) =>
     validateRequiredProperties(
       definition,
-      (name: string) => `${name} is required`,
+      (field: string) =>
+        t('integrations:editor:ruleForm:fieldRequired', { field }),
       values
     );
   return (

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/step/WithConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/step/WithConfigurationForm.tsx
@@ -145,8 +145,9 @@ export const WithConfigurationForm: React.FunctionComponent<
                   ? `${step!.name} - ${step!.description}`
                   : step!.name
               }
-              i18nNext={'Next'}
+              i18nNext={t('shared:Next')}
               isValid={isValid}
+              isLoading={isSubmitting}
               submitForm={submitForm}
               handleSubmit={handleSubmit}
             >

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
@@ -11,8 +11,10 @@ import {
   EXTENSION,
   getExtensionIcon,
   getNextAggregateStep,
+  getPreviousSteps,
   getPreviousStepWithDataShape,
   getStepIcon,
+  getSubsequentSteps,
   HIDE_FROM_STEP_SELECT,
   LOG,
   SPLIT,
@@ -409,8 +411,8 @@ export function visibleStepsByPosition(
   position: number,
   flowSteps: Step[]
 ) {
-  const previousSteps = flowSteps.slice(0, position);
-  const subsequentSteps = flowSteps.slice(position);
+  const previousSteps = getPreviousSteps(flowSteps, position);
+  const subsequentSteps = getSubsequentSteps(flowSteps, position - 1);
   return filterStepsByPosition(
     steps,
     position,

--- a/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -75,6 +75,11 @@
     "confirmDeleteStepDialogBody": "Are you sure you want to delete this step from the integration?",
     "confirmDeleteStepDialogTitle": "Confirm Delete",
     "saveOrAddStep": "Save or Add Step",
+    "save": {
+      "title": "Save the integration",
+      "description": "Update details about this integration.",
+      "saveAndPublish": "Save and publish"
+    },
     "choiceForm": {
       "conditionDescription": "Provide a condition that you want to evaluate.",
       "conditionName": "Condition",
@@ -83,6 +88,21 @@
       "addConditionTitle": "When",
       "useDefaultFlowDescription": "Use this flow when no other condition matches",
       "useDefaultFlowTitle": "Use a default flow",
+      "fieldRequired": "{{field}} is required"
+    },
+    "ruleForm": {
+      "predicateDescription": "Continue only if incoming data match ",
+      "predicateEnumAll": "ALL of the following",
+      "predicateEnumAny": "ANY of the following",
+      "operatorDescription": "Must meet this condition",
+      "operatorDisplay": "Operator",
+      "pathDescription": "The data you want to evaluate",
+      "pathDisplay": "Property Name",
+      "pathPlaceholder": "Property name",
+      "keywordsDescription": "For this value",
+      "keywordsDisplay": "Keywords",
+      "keywordsPlaceholder": "Keywords",
+      "addRule": "+ Add another rule",
       "fieldRequired": "{{field}} is required"
     }
   },


### PR DESCRIPTION
We were missing a call to the API that fetches the updated descriptor for steps, now we have that.
This fixes - together with some other changes - the steps we display in the editor.

Steps to reproduce:
1. new integration: select * from todo > log
2. add split step in between
3. add a step after the split, basic filter should now show up (it wasn't showing up before)

Also actions like adding/updating/removing steps are all now async, so we show the right spinners where we should.