### PR TITLE
fix(integration): increase uptime metric text size

### DIFF
--- a/app/ui-react/packages/ui/src/Dashboard/UptimeMetric.css
+++ b/app/ui-react/packages/ui/src/Dashboard/UptimeMetric.css
@@ -1,0 +1,10 @@
+.metrics-uptime__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.metrics-uptime__uptime {
+  font-size: 11px;
+  color: #8b8d8f;
+}

--- a/app/ui-react/packages/ui/src/Dashboard/UptimeMetric.tsx
+++ b/app/ui-react/packages/ui/src/Dashboard/UptimeMetric.tsx
@@ -1,5 +1,6 @@
 import { Card } from 'patternfly-react';
 import * as React from 'react';
+import './UptimeMetric.css';
 
 export interface IUptimeMetricProps {
   start: number;
@@ -18,9 +19,9 @@ export class UptimeMetric extends React.PureComponent<IUptimeMetricProps> {
         aggregated={true}
         matchHeight={true}
       >
-        <Card.Title className={'text-left'}>
-          <small className={'pull-right'}>since {startAsHuman}</small>
+        <Card.Title className="metrics-uptime__header">
           <div>{this.props.i18nTitle}</div>
+          <div className="metrics-uptime__uptime">since {startAsHuman}</div>
         </Card.Title>
         <Card.Body>
           <span>{this.props.durationDifference}</span>

--- a/app/ui-react/packages/ui/src/Integration/Metrics/IntegrationDetailMetrics.css
+++ b/app/ui-react/packages/ui/src/Integration/Metrics/IntegrationDetailMetrics.css
@@ -2,3 +2,14 @@
   padding-top: 10px;
   padding-bottom: 10px;
 }
+
+.integration-detail-metrics__uptime-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.integration-detail-metrics__uptime-uptime {
+  font-size: 11px;
+  color: #8b8d8f;
+}

--- a/app/ui-react/packages/ui/src/Integration/Metrics/IntegrationDetailMetrics.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Metrics/IntegrationDetailMetrics.tsx
@@ -109,12 +109,12 @@ export class IntegrationDetailMetrics extends React.Component<
                 aggregated={true}
                 matchHeight={true}
               >
-                <Card.Title className={'text-left'}>
-                  <small className={'pull-right'}>
+                <Card.Title className="integration-detail-metrics__uptime-header">
+                  <div>{this.props.i18nUptime}</div>
+                  <div className="integration-detail-metrics__uptime-uptime">
                     {this.props.i18nSince}
                     {startAsHuman}
-                  </small>
-                  <div>{this.props.i18nUptime}</div>
+                  </div>
                 </Card.Title>
                 <Card.Body>
                   <AggregateStatusNotifications>


### PR DESCRIPTION
The uptime text was ~9px which is inaccessible. Bumping it to 11px.