### PR TITLE
Fix for escaped view names

### DIFF
--- a/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
+++ b/app/ui-react/syndesis/src/modules/data/shared/VirtualizationUtils.ts
@@ -41,7 +41,9 @@ export function getPreviewVdbName(): string {
 export function getViewDdl(vdbModel: RestVdbModel, viewName: string): string {
   const views = vdbModel.keng__ddl.split('CREATE VIEW ');
   if (views.length > 0) {
-    const viewDdl = views.find(view => view.startsWith(viewName));
+    const viewDdl = views.find(
+      view => view.startsWith(viewName) || view.startsWith('"' + viewName)
+    );
     if (viewDdl) {
       return 'CREATE VIEW ' + viewDdl;
     }


### PR DESCRIPTION
Fix for issue ENTESB-10723 - also handle case where the view name is escaped with "  