### PR TITLE
chore(ux): use appropriate icon for help dropdown

### DIFF
--- a/app/ui-react/packages/ui/src/Layout/AppLayout.tsx
+++ b/app/ui-react/packages/ui/src/Layout/AppLayout.tsx
@@ -103,6 +103,7 @@ export const AppLayout: React.FunctionComponent<ILayoutBase> = ({
                 >
                   <ToolbarItem>
                     <HelpDropdown
+                      isMobileView={isMobileView}
                       className="syn-help-dropdown"
                       isOpen={false}
                       launchSupportPage={onSelectSupport}

--- a/app/ui-react/packages/ui/src/Shared/HelpDropdown.tsx
+++ b/app/ui-react/packages/ui/src/Shared/HelpDropdown.tsx
@@ -15,6 +15,8 @@ export interface IHelpDropdownProps {
   className?: string;
   isMobileView: boolean;
   isOpen: boolean;
+  dropdownDirection?: keyof typeof DropdownDirection;
+  dropdownPosition?: keyof typeof DropdownPosition;
   launchAboutModal: () => void;
   launchSupportPage: () => void;
   launchSampleIntegrationTutorials: () => void;
@@ -55,6 +57,8 @@ export class HelpDropdown extends React.Component<
     const { isOpen } = this.state;
     const {
       additionalDropdownItems = [],
+      dropdownDirection,
+      dropdownPosition,
       launchSampleIntegrationTutorials,
       launchUserGuide,
       launchConnectorsGuide,
@@ -117,8 +121,8 @@ export class HelpDropdown extends React.Component<
     return (
       <>
         <Dropdown
-          direction={DropdownDirection.down}
-          position={DropdownPosition.right}
+          direction={dropdownDirection || DropdownDirection.down}
+          position={dropdownPosition || DropdownPosition.right}
           onSelect={this.onSelect}
           toggle={
             isMobileView ? (

--- a/app/ui-react/packages/ui/src/Shared/HelpDropdown.tsx
+++ b/app/ui-react/packages/ui/src/Shared/HelpDropdown.tsx
@@ -3,14 +3,17 @@ import {
   DropdownDirection,
   DropdownItem,
   DropdownPosition,
+  DropdownToggle,
   KebabToggle,
 } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
 import classNames from 'classnames';
 import * as React from 'react';
 
 export interface IHelpDropdownProps {
   additionalDropdownItems?: React.ReactNode[];
   className?: string;
+  isMobileView: boolean;
   isOpen: boolean;
   launchAboutModal: () => void;
   launchSupportPage: () => void;
@@ -58,6 +61,7 @@ export class HelpDropdown extends React.Component<
       launchSupportPage,
       launchContactUs,
       launchAboutModal,
+      isMobileView,
     } = this.props;
     const dropdownItems = [
       <DropdownItem
@@ -109,6 +113,7 @@ export class HelpDropdown extends React.Component<
         About
       </DropdownItem>,
     ];
+    const dropdownId = 'helpDropdownButton';
     return (
       <>
         <Dropdown
@@ -116,12 +121,24 @@ export class HelpDropdown extends React.Component<
           position={DropdownPosition.right}
           onSelect={this.onSelect}
           toggle={
-            <KebabToggle
-              id="helpDropdownButton"
-              data-testid="helpDropdownButton"
-              className={classNames('', this.props.className)}
-              onToggle={this.onToggle}
-            />
+            isMobileView ? (
+              <KebabToggle
+                id={dropdownId}
+                data-testid={dropdownId}
+                className={classNames('', this.props.className)}
+                onToggle={this.onToggle}
+              />
+            ) : (
+              <DropdownToggle
+                id={dropdownId}
+                data-testid={dropdownId}
+                className={classNames('', this.props.className)}
+                onToggle={this.onToggle}
+                iconComponent={null}
+              >
+                <HelpIcon />
+              </DropdownToggle>
+            )
           }
           isOpen={isOpen}
           isPlain={true}

--- a/app/ui-react/packages/ui/src/index.css
+++ b/app/ui-react/packages/ui/src/index.css
@@ -26,8 +26,12 @@
   height: 40px;
 }
 
-.pf-c-dropdown {
-  --pf-c-dropdown__toggle--FontSize: var(--pf-global--FontSize--xs);
+.pf-c-dropdown__toggle {
+  --pf-c-dropdown__toggle--FontSize: var(--pf-global--FontSize--sm);
+}
+
+.pf-c-dropdown__toggle.syn-help-dropdown {
+  --pf-c-dropdown__toggle--FontSize: var(--pf-global--FontSize--md);
 }
 
 .pf-c-page {
@@ -94,10 +98,6 @@ body {
 .pf-c-content {
   --pf-c-content--FontSize: var(--pf-global--FontSize--sm);
   --pf-c-content--dt--FontWeight: bold; /* override for OpenSans not supporting weight 500 */
-}
-
-.pf-c-dropdown__toggle.syn-help-dropdown {
-  --pf-c-dropdown__toggle--FontSize: var(--pf-global--FontSize--md);
 }
 
 .list-view-pf-view {

--- a/app/ui-react/packages/ui/stories/Shared/HelpDropdown.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Shared/HelpDropdown.stories.tsx
@@ -1,5 +1,5 @@
 import { action } from '@storybook/addon-actions';
-import { withKnobs } from '@storybook/addon-knobs';
+import { boolean, select, withKnobs } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 import { HelpDropdown } from '../../src';
 import * as React from 'react';
@@ -11,6 +11,17 @@ stories.add('HelpDropdown', () => {
     <div className="pf-u-display-flex pf-u-align-items-flex-start pf-u-flex-wrap">
       <div className="pf-u-m-xl">
         <HelpDropdown
+          dropdownDirection={select(
+            'dropdownDirection',
+            ['down', 'up'],
+            'down'
+          )}
+          dropdownPosition={select(
+            'dropdownPosition',
+            ['left', 'right'],
+            'left'
+          )}
+          isMobileView={boolean('isMobileView', false)}
           launchConnectorsGuide={logDropdownItemSelection}
           launchContactUs={logDropdownItemSelection}
           launchSampleIntegrationTutorials={logDropdownItemSelection}


### PR DESCRIPTION
This PR applies further adjustments to the user/help dropdown menus. We now get the proper "help" icon on large viewports, which converts to a kebab on smaller viewports.

Desktop:

<img width="1087" alt="Screen Shot 2019-06-05 at 12 53 38 PM" src="https://user-images.githubusercontent.com/5942899/58975056-04fa5380-8792-11e9-9351-0b823c55fa2f.png">

Tablet:

<img width="788" alt="Screen Shot 2019-06-05 at 12 54 20 PM" src="https://user-images.githubusercontent.com/5942899/58975079-15123300-8792-11e9-9b6c-a7153fc48f3f.png">

Mobile:

<img width="562" alt="Screen Shot 2019-06-05 at 12 53 51 PM" src="https://user-images.githubusercontent.com/5942899/58975098-22c7b880-8792-11e9-9717-d4b1e4702aa5.png">
