### PR TITLE
Fixes an issue when deleting an integration from it's detail page

### DIFF
--- a/app/ui-react/syndesis/src/modules/integrations/components/WithIntegrationActions.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/WithIntegrationActions.tsx
@@ -4,6 +4,7 @@ import {
   canEdit,
   WithIntegrationHelpers,
 } from '@syndesis/api';
+import * as H from '@syndesis/history';
 import { IntegrationOverview } from '@syndesis/models';
 import {
   ConfirmationButtonStyle,
@@ -31,6 +32,7 @@ export interface IWithIntegrationActionsChildrenProps {
 
 export interface IWithIntegrationActionsProps {
   integration: IntegrationOverview;
+  postDeleteHref?: H.LocationDescriptorObject;
   children: (props: IWithIntegrationActionsChildrenProps) => any;
 }
 
@@ -234,7 +236,11 @@ export class WithIntegrationActions extends React.Component<
                                   await deleteIntegration(
                                     this.props.integration.id!
                                   );
-                                  history.push(resolvers.list());
+
+                                  // redirect if requested
+                                  if (this.props.postDeleteHref) {
+                                    history.push(this.props.postDeleteHref);
+                                  }
                                 } catch (err) {
                                   pushNotification(
                                     i18n.t(

--- a/app/ui-react/syndesis/src/modules/integrations/components/WithIntegrationActions.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/WithIntegrationActions.tsx
@@ -11,6 +11,7 @@ import {
   ConfirmationIconType,
   IIntegrationAction,
 } from '@syndesis/ui';
+import { WithRouter } from '@syndesis/utils';
 import * as React from 'react';
 import { Translation } from 'react-i18next';
 import { UIContext } from '../../../app';
@@ -107,210 +108,239 @@ export class WithIntegrationActions extends React.Component<
 
   public render() {
     return (
-      <Translation ns={['integrations', 'shared']}>
-        {t => (
-          <UIContext.Consumer>
-            {({ pushNotification }) => (
-              <WithIntegrationHelpers>
-                {({
-                  deleteIntegration,
-                  deployIntegration,
-                  exportIntegration,
-                  undeployIntegration,
-                  tagIntegration,
-                }) => {
-                  const editAction: IIntegrationAction = {
-                    href: resolvers.integration.edit.entryPoint({
-                      flowId: this.props.integration.flows![0].id!,
-                      integration: this.props.integration,
-                    }),
-                    label: 'Edit',
-                  };
-                  const startAction: IIntegrationAction = {
-                    label: 'Start',
-                    onClick: () =>
-                      this.promptForAction({
-                        handleAction: async () => {
-                          pushNotification(
-                            i18n.t('integrations:PublishingIntegrationMessage'),
-                            'info'
-                          );
-                          try {
-                            await deployIntegration(
-                              this.props.integration.id!,
-                              this.props.integration.version!,
-                              false
-                            );
-                          } catch (err) {
-                            pushNotification(
-                              i18n.t(
-                                'integrations:PublishingIntegrationFailedMessage',
-                                {
-                                  error: err.errorMessage || err.message || err,
+      <WithRouter>
+        {({ history }) => {
+          return (
+            <Translation ns={['integrations', 'shared']}>
+              {t => (
+                <UIContext.Consumer>
+                  {({ pushNotification }) => (
+                    <WithIntegrationHelpers>
+                      {({
+                        deleteIntegration,
+                        deployIntegration,
+                        exportIntegration,
+                        undeployIntegration,
+                        tagIntegration,
+                      }) => {
+                        const editAction: IIntegrationAction = {
+                          href: resolvers.integration.edit.entryPoint({
+                            flowId: this.props.integration.flows![0].id!,
+                            integration: this.props.integration,
+                          }),
+                          label: 'Edit',
+                        };
+                        const startAction: IIntegrationAction = {
+                          label: 'Start',
+                          onClick: () =>
+                            this.promptForAction({
+                              handleAction: async () => {
+                                pushNotification(
+                                  i18n.t(
+                                    'integrations:PublishingIntegrationMessage'
+                                  ),
+                                  'info'
+                                );
+                                try {
+                                  await deployIntegration(
+                                    this.props.integration.id!,
+                                    this.props.integration.version!,
+                                    false
+                                  );
+                                } catch (err) {
+                                  pushNotification(
+                                    i18n.t(
+                                      'integrations:PublishingIntegrationFailedMessage',
+                                      {
+                                        error:
+                                          err.errorMessage ||
+                                          err.message ||
+                                          err,
+                                      }
+                                    ),
+                                    'warning'
+                                  );
                                 }
+                              },
+                              promptDialogButtonStyle:
+                                ConfirmationButtonStyle.NORMAL,
+                              promptDialogButtonText: t('shared:Start'),
+                              promptDialogIcon: ConfirmationIconType.NONE,
+                              promptDialogText: t(
+                                'integrations:publishIntegrationModal',
+                                { name: this.props.integration.name }
                               ),
-                              'warning'
-                            );
-                          }
-                        },
-                        promptDialogButtonStyle: ConfirmationButtonStyle.NORMAL,
-                        promptDialogButtonText: t('shared:Start'),
-                        promptDialogIcon: ConfirmationIconType.NONE,
-                        promptDialogText: t(
-                          'integrations:publishIntegrationModal',
-                          { name: this.props.integration.name }
-                        ),
-                        promptDialogTitle: t(
-                          'integrations:publishIntegrationModalTitle'
-                        ),
-                      } as IPromptActionOptions),
-                  };
-                  const stopAction: IIntegrationAction = {
-                    label: 'Stop',
-                    onClick: () =>
-                      this.promptForAction({
-                        handleAction: async () => {
-                          pushNotification(
-                            i18n.t(
-                              'integrations:UnpublishingIntegrationMessage'
+                              promptDialogTitle: t(
+                                'integrations:publishIntegrationModalTitle'
+                              ),
+                            } as IPromptActionOptions),
+                        };
+                        const stopAction: IIntegrationAction = {
+                          label: 'Stop',
+                          onClick: () =>
+                            this.promptForAction({
+                              handleAction: async () => {
+                                pushNotification(
+                                  i18n.t(
+                                    'integrations:UnpublishingIntegrationMessage'
+                                  ),
+                                  'info'
+                                );
+                                try {
+                                  undeployIntegration(
+                                    this.props.integration.id!,
+                                    this.props.integration.version!
+                                  );
+                                } catch (err) {
+                                  pushNotification(
+                                    i18n.t(
+                                      'integrations:UnpublishingIntegrationFailedMessage',
+                                      {
+                                        error:
+                                          err.errorMessage ||
+                                          err.message ||
+                                          err,
+                                      }
+                                    ),
+                                    'warning'
+                                  );
+                                }
+                              },
+                              promptDialogButtonStyle:
+                                ConfirmationButtonStyle.NORMAL,
+                              promptDialogButtonText: t('shared:Stop'),
+                              promptDialogIcon: ConfirmationIconType.NONE,
+                              promptDialogText: t(
+                                'integrations:unpublishIntegrationModal',
+                                { name: this.props.integration.name }
+                              ),
+                              promptDialogTitle: t(
+                                'integrations:unpublishIntegrationModalTitle'
+                              ),
+                            } as IPromptActionOptions),
+                        };
+                        const deleteAction: IIntegrationAction = {
+                          label: 'Delete',
+                          onClick: () =>
+                            this.promptForAction({
+                              handleAction: async () => {
+                                pushNotification(
+                                  i18n.t(
+                                    'integrations:DeletingIntegrationMessage'
+                                  ),
+                                  'info'
+                                );
+                                try {
+                                  await deleteIntegration(
+                                    this.props.integration.id!
+                                  );
+                                  history.push(resolvers.list());
+                                } catch (err) {
+                                  pushNotification(
+                                    i18n.t(
+                                      'integrations:DeletingIntegrationFailedMessage',
+                                      {
+                                        error:
+                                          err.errorMessage ||
+                                          err.message ||
+                                          err,
+                                      }
+                                    ),
+                                    'warning'
+                                  );
+                                }
+                              },
+                              promptDialogButtonStyle:
+                                ConfirmationButtonStyle.DANGER,
+                              promptDialogButtonText: t('shared:Delete'),
+                              promptDialogIcon: ConfirmationIconType.DANGER,
+                              promptDialogText: t(
+                                'integrations:deleteIntegrationModal',
+                                { name: this.props.integration.name }
+                              ),
+                              promptDialogTitle: t(
+                                'integrations:deleteIntegrationModalTitle'
+                              ),
+                            } as IPromptActionOptions),
+                        };
+                        const exportAction: IIntegrationAction = {
+                          label: 'Export',
+                          onClick: () =>
+                            exportIntegration(
+                              this.props.integration.id!,
+                              `${this.props.integration.name}-export.zip`
                             ),
-                            'info'
-                          );
-                          try {
-                            undeployIntegration(
-                              this.props.integration.id!,
-                              this.props.integration.version!
-                            );
-                          } catch (err) {
-                            pushNotification(
-                              i18n.t(
-                                'integrations:UnpublishingIntegrationFailedMessage',
-                                {
-                                  error: err.errorMessage || err.message || err,
-                                }
-                              ),
-                              'warning'
-                            );
-                          }
-                        },
-                        promptDialogButtonStyle: ConfirmationButtonStyle.NORMAL,
-                        promptDialogButtonText: t('shared:Stop'),
-                        promptDialogIcon: ConfirmationIconType.NONE,
-                        promptDialogText: t(
-                          'integrations:unpublishIntegrationModal',
-                          { name: this.props.integration.name }
-                        ),
-                        promptDialogTitle: t(
-                          'integrations:unpublishIntegrationModalTitle'
-                        ),
-                      } as IPromptActionOptions),
-                  };
-                  const deleteAction: IIntegrationAction = {
-                    label: 'Delete',
-                    onClick: () =>
-                      this.promptForAction({
-                        handleAction: async () => {
-                          pushNotification(
-                            i18n.t('integrations:DeletingIntegrationMessage'),
-                            'info'
-                          );
-                          try {
-                            await deleteIntegration(this.props.integration.id!);
-                          } catch (err) {
-                            pushNotification(
-                              i18n.t(
-                                'integrations:DeletingIntegrationFailedMessage',
-                                {
-                                  error: err.errorMessage || err.message || err,
-                                }
-                              ),
-                              'warning'
-                            );
-                          }
-                        },
-                        promptDialogButtonStyle: ConfirmationButtonStyle.DANGER,
-                        promptDialogButtonText: t('shared:Delete'),
-                        promptDialogIcon: ConfirmationIconType.DANGER,
-                        promptDialogText: t(
-                          'integrations:deleteIntegrationModal',
-                          { name: this.props.integration.name }
-                        ),
-                        promptDialogTitle: t(
-                          'integrations:deleteIntegrationModalTitle'
-                        ),
-                      } as IPromptActionOptions),
-                  };
-                  const exportAction: IIntegrationAction = {
-                    label: 'Export',
-                    onClick: () =>
-                      exportIntegration(
-                        this.props.integration.id!,
-                        `${this.props.integration.name}-export.zip`
-                      ),
-                  };
-                  const ciCdAction: IIntegrationAction = {
-                    label: 'Manage CI/CD',
-                    onClick: () => {
-                      this.promptForCiCd(this.props.integration.id!);
-                    },
-                  };
+                        };
+                        const ciCdAction: IIntegrationAction = {
+                          label: 'Manage CI/CD',
+                          onClick: () => {
+                            this.promptForCiCd(this.props.integration.id!);
+                          },
+                        };
 
-                  const actions: IIntegrationAction[] = [];
-                  if (canEdit(this.props.integration)) {
-                    actions.push(editAction);
-                  }
-                  if (canActivate(this.props.integration)) {
-                    actions.push(startAction);
-                  }
-                  if (canDeactivate(this.props.integration)) {
-                    actions.push(stopAction);
-                  }
-                  actions.push(deleteAction);
-                  actions.push(exportAction);
-                  actions.push(ciCdAction);
-                  return (
-                    <>
-                      {this.state.showCiCdPromptDialog && (
-                        <TagIntegrationDialogWrapper
-                          manageCiCdHref={resolvers.manageCicd.root()}
-                          tagIntegration={tagIntegration}
-                          targetIntegrationId={this.state.targetIntegrationId!}
-                          onSave={this.closeCiCdDialog}
-                          onHide={this.closeCiCdDialog}
-                        />
-                      )}
-                      {this.state.showActionPromptDialog && (
-                        <ConfirmationDialog
-                          buttonStyle={ConfirmationButtonStyle.NORMAL}
-                          i18nCancelButtonText={t('shared:Cancel')}
-                          i18nConfirmButtonText={
-                            this.state.promptDialogButtonText!
-                          }
-                          i18nConfirmationMessage={this.state.promptDialogText!}
-                          i18nTitle={this.state.promptDialogTitle!}
-                          icon={this.state.promptDialogIcon!}
-                          showDialog={this.state.showActionPromptDialog}
-                          onCancel={this.handleActionCancel}
-                          onConfirm={this.handleAction}
-                        />
-                      )}
-                      {this.props.children({
-                        actions,
-                        ciCdAction,
-                        deleteAction,
-                        editAction,
-                        exportAction,
-                        startAction,
-                        stopAction,
-                      })}
-                    </>
-                  );
-                }}
-              </WithIntegrationHelpers>
-            )}
-          </UIContext.Consumer>
-        )}
-      </Translation>
+                        const actions: IIntegrationAction[] = [];
+                        if (canEdit(this.props.integration)) {
+                          actions.push(editAction);
+                        }
+                        if (canActivate(this.props.integration)) {
+                          actions.push(startAction);
+                        }
+                        if (canDeactivate(this.props.integration)) {
+                          actions.push(stopAction);
+                        }
+                        actions.push(deleteAction);
+                        actions.push(exportAction);
+                        actions.push(ciCdAction);
+                        return (
+                          <>
+                            {this.state.showCiCdPromptDialog && (
+                              <TagIntegrationDialogWrapper
+                                manageCiCdHref={resolvers.manageCicd.root()}
+                                tagIntegration={tagIntegration}
+                                targetIntegrationId={
+                                  this.state.targetIntegrationId!
+                                }
+                                onSave={this.closeCiCdDialog}
+                                onHide={this.closeCiCdDialog}
+                              />
+                            )}
+                            {this.state.showActionPromptDialog && (
+                              <ConfirmationDialog
+                                buttonStyle={ConfirmationButtonStyle.NORMAL}
+                                i18nCancelButtonText={t('shared:Cancel')}
+                                i18nConfirmButtonText={
+                                  this.state.promptDialogButtonText!
+                                }
+                                i18nConfirmationMessage={
+                                  this.state.promptDialogText!
+                                }
+                                i18nTitle={this.state.promptDialogTitle!}
+                                icon={this.state.promptDialogIcon!}
+                                showDialog={this.state.showActionPromptDialog}
+                                onCancel={this.handleActionCancel}
+                                onConfirm={this.handleAction}
+                              />
+                            )}
+                            {this.props.children({
+                              actions,
+                              ciCdAction,
+                              deleteAction,
+                              editAction,
+                              exportAction,
+                              startAction,
+                              stopAction,
+                            })}
+                          </>
+                        );
+                      }}
+                    </WithIntegrationHelpers>
+                  )}
+                </UIContext.Consumer>
+              )}
+            </Translation>
+          );
+        }}
+      </WithRouter>
     );
   }
 }

--- a/app/ui-react/syndesis/src/modules/integrations/pages/detail/ActivityPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/detail/ActivityPage.tsx
@@ -9,6 +9,7 @@ import {
   IntegrationDetailHeader,
   WithIntegrationActions,
 } from '../../components';
+import resolvers from '../../resolvers';
 import { ActivityPageTable } from './ActivityPageTable';
 import { IDetailsRouteParams, IDetailsRouteState } from './interfaces';
 
@@ -28,7 +29,7 @@ export class ActivityPage extends React.Component {
             <AppContext.Consumer>
               {({ getPodLogUrl }) => (
                 <WithRouteData<IDetailsRouteParams, IDetailsRouteState>>
-                  {({ integrationId }, { integration }, { history }) => {
+                  {({ integrationId }, { integration }) => {
                     return (
                       <>
                         <WithMonitoredIntegration
@@ -45,6 +46,7 @@ export class ActivityPage extends React.Component {
                               {() => (
                                 <WithIntegrationActions
                                   integration={data.integration}
+                                  postDeleteHref={resolvers.list()}
                                 >
                                   {({
                                     ciCdAction,

--- a/app/ui-react/syndesis/src/modules/integrations/pages/detail/DetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/detail/DetailsPage.tsx
@@ -23,6 +23,7 @@ import {
   WithIntegrationActions,
 } from '../../components';
 import { WithDeploymentActions } from '../../components/WithDeploymentActions';
+import resolvers from '../../resolvers';
 import { IDetailsRouteParams, IDetailsRouteState } from './interfaces';
 
 /**
@@ -56,6 +57,7 @@ export class DetailsPage extends React.Component {
                           {() => (
                             <WithIntegrationActions
                               integration={data.integration}
+                              postDeleteHref={resolvers.list()}
                             >
                               {({
                                 ciCdAction,

--- a/app/ui-react/syndesis/src/modules/integrations/pages/detail/MetricsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/detail/MetricsPage.tsx
@@ -16,10 +16,11 @@ import {
   IntegrationDetailHeader,
   WithIntegrationActions,
 } from '../../components';
+import resolvers from '../../resolvers';
 import { IDetailsRouteParams, IDetailsRouteState } from './interfaces';
 
 /**
- * This page shows the second tab of the Integration Detail page.
+ * This page shows the third tab of the Integration Detail page.
  *
  * This component expects either an integrationId in the URL,
  * or an integration object set via the state.
@@ -52,6 +53,7 @@ export class MetricsPage extends React.Component {
                                 {() => (
                                   <WithIntegrationActions
                                     integration={data.integration}
+                                    postDeleteHref={resolvers.list()}
                                   >
                                     {({
                                       ciCdAction,


### PR DESCRIPTION
- see issue syndesisio/syndesis#5578
- added WithRouter to WithIntegrationActions
- after a successful delete, the integrations list page is displayed