### PR TITLE
fix(ui): fix integration editor layout, wizard ui

### DIFF
--- a/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorCreatorLayout.tsx
+++ b/app/ui-react/packages/ui/src/Customization/apiClientConnectors/ApiConnectorCreatorLayout.tsx
@@ -21,7 +21,13 @@ export const ApiConnectorCreatorLayout: React.FunctionComponent<
 > = ({ header, content }: IApiClientConnectorCreatorLayoutProps) => {
   return (
     <div className={'integration-editor-layout'}>
-      <div className={'integration-editor-layout__header'}>{header}</div>
+      <div
+        className={
+          'integration-editor-layout__header api-connector-creator-layout__header'
+        }
+      >
+        {header}
+      </div>
       <div className={'integration-editor-layout__body'}>
         <div className={'integration-editor-layout__contentOuter'}>
           <div className={'integration-editor-layout__contentInner'}>

--- a/app/ui-react/packages/ui/src/Customization/extensions/ExtensionImportReview.css
+++ b/app/ui-react/packages/ui/src/Customization/extensions/ExtensionImportReview.css
@@ -1,27 +1,14 @@
-.extension-import-review__buttonBar {
-  margin: 12px;
-}
-
 .extension-import-review__cancelButton {
   margin-left: 4px;
 }
 
-.extension-import-review__container {
-  background: white;
-  width: 100%;
-}
-
-.extension-import-review__propertyLabel {
-  font-weight: bold;
+.extension-import-review .extension-import-review__propertyLabel {
   text-align: right;
+  font-weight: bold;
 }
 
-.extension-import-review__propertyValue {
-  text-align: left;
-}
-
-.extension-import-review__title {
-  font-size: 1.5em;
-  padding: 12px;
-  text-align: left;
+.extension-import-review .extension-import-review__actions-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }

--- a/app/ui-react/packages/ui/src/Customization/extensions/ExtensionImportReview.tsx
+++ b/app/ui-react/packages/ui/src/Customization/extensions/ExtensionImportReview.tsx
@@ -1,7 +1,16 @@
+import {
+  Stack,
+  TextContent,
+  TextList,
+  TextListItem,
+  TextListItemVariants,
+  TextListVariants,
+  Title,
+} from '@patternfly/react-core';
 import * as H from '@syndesis/history';
-import { Button, Grid } from 'patternfly-react';
+import { Button, Card, CardBody, Grid } from 'patternfly-react';
 import * as React from 'react';
-import { ButtonLink, Container } from '../../Layout';
+import { ButtonLink } from '../../Layout';
 import './ExtensionImportReview.css';
 
 export interface IImportAction {
@@ -116,12 +125,12 @@ export class ExtensionImportReview extends React.Component<
     }
 
     return (
-      <Container>
-        {this.props.actions
-          ? this.props.actions.map((action, index) =>
-              index === 0 ? (
-                <Grid.Col
-                  key={0}
+      <TextContent>
+        <TextList className="extension-import-review__actions-list">
+          {this.props.actions
+            ? this.props.actions.map((action, index) => (
+                <TextListItem
+                  key={index}
                   dangerouslySetInnerHTML={{
                     __html: this.props.i18nActionText(
                       action.name,
@@ -129,23 +138,10 @@ export class ExtensionImportReview extends React.Component<
                     ),
                   }}
                 />
-              ) : (
-                <Grid.Row key={index}>
-                  <Grid.Col key={0} xs={2} />
-                  <Grid.Col
-                    key={1}
-                    dangerouslySetInnerHTML={{
-                      __html: this.props.i18nActionText(
-                        action.name,
-                        action.description
-                      ),
-                    }}
-                  />
-                </Grid.Row>
-              )
-            )
-          : null}
-      </Container>
+              ))
+            : null}
+        </TextList>
+      </TextContent>
     );
   }
 
@@ -155,72 +151,95 @@ export class ExtensionImportReview extends React.Component<
 
   public render() {
     return (
-      <Grid className="extension-import-review__container">
-        <Grid.Row className="extension-import-review__title">
-          {this.props.i18nTitle}
-        </Grid.Row>
-        <Grid.Row>
-          <Grid.Col xs={2} className="extension-import-review__propertyLabel">
-            {this.props.i18nIdLabel}
-          </Grid.Col>
-          <Grid.Col className="extension-import-review__propertyValue">
-            {this.props.extensionId}
-          </Grid.Col>
-        </Grid.Row>
-        <Grid.Row>
-          <Grid.Col xs={2} className="extension-import-review__propertyLabel">
-            {this.props.i18nNameLabel}
-          </Grid.Col>
-          <Grid.Col className="extension-import-review__propertyValue">
-            {this.props.extensionName}
-          </Grid.Col>
-        </Grid.Row>
-        <Grid.Row>
-          <Grid.Col xs={2} className="extension-import-review__propertyLabel">
-            {this.props.i18nDescriptionLabel}
-          </Grid.Col>
-          <Grid.Col className="extension-import-review__propertyValue">
-            {this.props.extensionDescription
-              ? this.props.extensionDescription
-              : null}
-          </Grid.Col>
-        </Grid.Row>
-        <Grid.Row>
-          <Grid.Col xs={2} className="extension-import-review__propertyLabel">
-            {this.props.i18nTypeLabel}
-          </Grid.Col>
-          <Grid.Col className="extension-import-review__propertyValue">
-            {this.props.i18nExtensionTypeMessage}
-          </Grid.Col>
-        </Grid.Row>
-        <Grid.Row>
-          <Grid.Col xs={2} className="extension-import-review__propertyLabel">
-            {this.props.i18nActionsLabel}
-          </Grid.Col>
-          {this.getActions()}
-        </Grid.Row>
-        <Grid.Row>
-          <Grid.Col xsOffset={2}>
-            <Grid.Row>
-              <Grid.Col>
-                <Container className="extension-import-review__buttonBar">
-                  <Button bsStyle="primary" onClick={this.handleImport}>
-                    {this.props.i18nImport}
-                  </Button>
-                  <ButtonLink
-                    data-testid={'extension-import-review-cancel-button'}
-                    className="extension-import-review__cancelButton"
-                    href={this.props.cancelLink}
-                    as={'default'}
-                  >
-                    {this.props.i18nCancel}
-                  </ButtonLink>
-                </Container>
-              </Grid.Col>
-            </Grid.Row>
-          </Grid.Col>
-        </Grid.Row>
-      </Grid>
+      <Card className="extension-import-review">
+        <CardBody>
+          <Stack gutter="md">
+            <Title
+              headingLevel="h1"
+              size="xl"
+              className="extension-import-review__title"
+            >
+              {this.props.i18nTitle}
+            </Title>
+            <TextContent>
+              <TextList component={TextListVariants.dl}>
+                <TextListItem
+                  component={TextListItemVariants.dt}
+                  className="extension-import-review__propertyLabel"
+                >
+                  {this.props.i18nIdLabel}
+                </TextListItem>
+                <TextListItem
+                  component={TextListItemVariants.dd}
+                  className="extension-import-review__propertyValue"
+                >
+                  {this.props.extensionId}
+                </TextListItem>
+                <TextListItem
+                  component={TextListItemVariants.dt}
+                  className="extension-import-review__propertyLabel"
+                >
+                  {this.props.i18nNameLabel}
+                </TextListItem>
+                <TextListItem
+                  component={TextListItemVariants.dd}
+                  className="extension-import-review__propertyValue"
+                >
+                  {this.props.extensionName}
+                </TextListItem>
+                <TextListItem
+                  component={TextListItemVariants.dt}
+                  className="extension-import-review__propertyLabel"
+                >
+                  {this.props.i18nDescriptionLabel}
+                </TextListItem>
+                <TextListItem
+                  component={TextListItemVariants.dd}
+                  className="extension-import-review__propertyValue"
+                >
+                  {this.props.extensionDescription
+                    ? this.props.extensionDescription
+                    : null}
+                </TextListItem>
+                <TextListItem
+                  component={TextListItemVariants.dt}
+                  className="extension-import-review__propertyLabel"
+                >
+                  {this.props.i18nTypeLabel}
+                </TextListItem>
+                <TextListItem
+                  component={TextListItemVariants.dd}
+                  className="extension-import-review__propertyValue"
+                >
+                  {this.props.i18nExtensionTypeMessage}
+                </TextListItem>
+                <TextListItem
+                  component={TextListItemVariants.dt}
+                  className="extension-import-review__propertyLabel"
+                >
+                  {this.props.i18nActionsLabel}
+                </TextListItem>
+                <TextListItem component={TextListItemVariants.dd}>
+                  {this.getActions()}
+                </TextListItem>
+              </TextList>
+            </TextContent>
+            <div className="extension-import-review__buttonBar">
+              <Button bsStyle="primary" onClick={this.handleImport}>
+                {this.props.i18nImport}
+              </Button>
+              <ButtonLink
+                data-testid={'extension-import-review-cancel-button'}
+                className="extension-import-review__cancelButton"
+                href={this.props.cancelLink}
+                as={'default'}
+              >
+                {this.props.i18nCancel}
+              </ButtonLink>
+            </div>
+          </Stack>
+        </CardBody>
+      </Card>
     );
   }
 }

--- a/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorLayout.css
+++ b/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorLayout.css
@@ -13,11 +13,19 @@
 .integration-editor-layout__body {
   display: flex;
   flex: 1 0;
+  width: 100%;
 }
 
 .integration-editor-layout__contentOuter {
   display: flex;
   flex-flow: column;
+  flex-grow: 1;
+}
+
+.integration-editor-layout__contentInner {
+  display: flex;
+  flex-flow: column;
+  flex-grow: 1;
 }
 
 .integration-editor-layout__sectionLight,
@@ -51,9 +59,6 @@
   }
 
   .integration-editor-layout__body {
-    flex: 1 0;
-    display: flex;
-    width: 100%;
     overflow: hidden;
   }
 
@@ -64,7 +69,6 @@
   }
 
   .integration-editor-layout__contentInner {
-    flex: 1;
     display: flex;
     flex-flow: column;
   }

--- a/app/ui-react/packages/ui/src/index.css
+++ b/app/ui-react/packages/ui/src/index.css
@@ -152,3 +152,39 @@ body {
   padding: 4px 8px;
 }
 
+/* Wizard overrides */
+.wizard-pf-steps-indicator,
+.wizard-pf-steps {
+  background: #fff;
+}
+
+.wizard-pf-step-alt .wizard-pf-step-alt-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+@media (min-width: 768px) {
+  .wizard-pf-steps-indicator {
+    height: auto;
+    padding-bottom: calc(1em + 25px);
+  }
+}
+
+@media (min-width: 768px) {
+  .wizard-pf-steps-indicator .wizard-pf-step .wizard-pf-step-number {
+    top: 100%;
+    left: 50%;
+    transform: translate(-50%, .5em);
+  }
+}
+
+.wizard-pf-steps-indicator .wizard-pf-step:before {
+  top: calc(100% + .5em + calc(25px / 2));
+  transform: translateY(-100%);
+}
+
+.wizard-pf-step-title {
+  line-height: 24px;
+}


### PR DESCRIPTION
fixes https://github.com/syndesisio/syndesis-react/issues/401

* fix integration-editor-layout in mobile view (see original problem in screenshots in #401)
* fix mobile wizard steps/toggle/menu in mobile view
* redo extension import review UI


wizard before:
<img width="563" alt="Screen Shot 2019-06-05 at 3 59 44 PM" src="https://user-images.githubusercontent.com/35148959/59054623-ae584c80-8859-11e9-9bf7-9d12375533dc.png">

wizard after: 
<img width="540" alt="Screen Shot 2019-06-05 at 4 35 23 PM" src="https://user-images.githubusercontent.com/35148959/59054629-b2846a00-8859-11e9-9b87-5e7a31a202b6.png">

extension import review before:

<img width="709" alt="Screen Shot 2019-06-05 at 5 22 39 PM" src="https://user-images.githubusercontent.com/35148959/59054647-be702c00-8859-11e9-9b25-b07fc86ae3da.png">

after:

<img width="633" alt="Screen Shot 2019-06-05 at 5 38 30 PM" src="https://user-images.githubusercontent.com/35148959/59054653-c203b300-8859-11e9-86cc-26188d899128.png">

