### PR TITLE
fix(wiz-toggle): fix wizard toggle icon click-ability

### DIFF
--- a/app/ui-react/packages/ui/package.json
+++ b/app/ui-react/packages/ui/package.json
@@ -76,6 +76,7 @@
     "@patternfly/react-core": "^3.32.9",
     "@patternfly/react-icons": "^3.9.2",
     "@patternfly/react-styles": "^3.2.0",
+    "@patternfly/react-tokens": "^2.5.3",
     "@syndesis/history": "*",
     "classnames": "^2.2.6",
     "codemirror": "^5.46.0",

--- a/app/ui-react/packages/ui/src/Layout/AppLayout.tsx
+++ b/app/ui-react/packages/ui/src/Layout/AppLayout.tsx
@@ -14,6 +14,7 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
+import { global_breakpoint_lg } from '@patternfly/react-tokens';
 import * as React from 'react';
 import { HelpDropdown } from '../Shared/HelpDropdown';
 import { AppLayoutContext } from './AppLayoutContext';
@@ -83,8 +84,15 @@ export const AppLayout: React.FunctionComponent<ILayoutBase> = ({
     setCurViewportWidth(props.windowSize);
   };
   const [isTabletView, setIsTabletView] = React.useState(false);
+  const LARGE_VIEWPORT_BREAKPOINT = parseInt(
+    global_breakpoint_lg.value.substring(
+      0,
+      global_breakpoint_lg.value.indexOf('px')
+    ),
+    10
+  );
   React.useEffect(() => {
-    setIsTabletView(curViewportWidth <= 992);
+    setIsTabletView(curViewportWidth <= LARGE_VIEWPORT_BREAKPOINT);
   }, [curViewportWidth]);
   return (
     <AppLayoutContext.Provider

--- a/app/ui-react/packages/ui/src/Layout/AppLayout.tsx
+++ b/app/ui-react/packages/ui/src/Layout/AppLayout.tsx
@@ -77,9 +77,15 @@ export const AppLayout: React.FunctionComponent<ILayoutBase> = ({
   const onNavToggleMobile = () => {
     setIsNavOpenMobile(!isNavOpenMobile);
   };
+  const [curViewportWidth, setCurViewportWidth] = React.useState(1024);
   const onPageResize = (props: { mobileView: boolean; windowSize: number }) => {
     setIsMobileView(props.mobileView);
+    setCurViewportWidth(props.windowSize);
   };
+  const [isTabletView, setIsTabletView] = React.useState(false);
+  React.useEffect(() => {
+    setIsTabletView(curViewportWidth <= 992);
+  }, [curViewportWidth]);
   return (
     <AppLayoutContext.Provider
       value={{
@@ -103,7 +109,7 @@ export const AppLayout: React.FunctionComponent<ILayoutBase> = ({
                 >
                   <ToolbarItem>
                     <HelpDropdown
-                      isMobileView={isMobileView}
+                      isTabletView={isTabletView}
                       className="syn-help-dropdown"
                       isOpen={false}
                       launchSupportPage={onSelectSupport}

--- a/app/ui-react/packages/ui/src/Layout/WizardSteps.css
+++ b/app/ui-react/packages/ui/src/Layout/WizardSteps.css
@@ -1,0 +1,4 @@
+ .wizard-pf-steps-alt-indicator:after {
+  pointer-events: none;
+  cursor: pointer;
+}

--- a/app/ui-react/packages/ui/src/Layout/WizardSteps.tsx
+++ b/app/ui-react/packages/ui/src/Layout/WizardSteps.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import './WizardSteps.css';
 
 interface IWizardStepsProps {
   mainSteps: React.ReactNode;

--- a/app/ui-react/packages/ui/src/Shared/HelpDropdown.tsx
+++ b/app/ui-react/packages/ui/src/Shared/HelpDropdown.tsx
@@ -13,7 +13,7 @@ import * as React from 'react';
 export interface IHelpDropdownProps {
   additionalDropdownItems?: React.ReactNode[];
   className?: string;
-  isMobileView: boolean;
+  isTabletView: boolean;
   isOpen: boolean;
   dropdownDirection?: keyof typeof DropdownDirection;
   dropdownPosition?: keyof typeof DropdownPosition;
@@ -65,7 +65,7 @@ export class HelpDropdown extends React.Component<
       launchSupportPage,
       launchContactUs,
       launchAboutModal,
-      isMobileView,
+      isTabletView,
     } = this.props;
     const dropdownItems = [
       <DropdownItem
@@ -125,7 +125,7 @@ export class HelpDropdown extends React.Component<
           position={dropdownPosition || DropdownPosition.right}
           onSelect={this.onSelect}
           toggle={
-            isMobileView ? (
+            isTabletView ? (
               <KebabToggle
                 id={dropdownId}
                 data-testid={dropdownId}

--- a/app/ui-react/packages/ui/stories/Shared/HelpDropdown.stories.tsx
+++ b/app/ui-react/packages/ui/stories/Shared/HelpDropdown.stories.tsx
@@ -21,7 +21,7 @@ stories.add('HelpDropdown', () => {
             ['left', 'right'],
             'left'
           )}
-          isMobileView={boolean('isMobileView', false)}
+          isTabletView={boolean('isTabletView', false)}
           launchConnectorsGuide={logDropdownItemSelection}
           launchContactUs={logDropdownItemSelection}
           launchSampleIntegrationTutorials={logDropdownItemSelection}

--- a/app/ui-react/yarn.lock
+++ b/app/ui-react/yarn.lock
@@ -2614,10 +2614,15 @@
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
 
-"@patternfly/patternfly@1.0.250", "@patternfly/patternfly@2.6.6", "@patternfly/patternfly@^2.8.1":
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-2.6.6.tgz#d4ba153f0b1470fbc91ea308c8c7260c9bcb0d28"
-  integrity sha512-lKbsTE/VlU1BiVzeo0BhfDe/qeqIqheejBz0qAm3CYuHyfUXd4+Uu+/9lfEB2EMb+wXpK4Np74OHtYCC82fP0Q==
+"@patternfly/patternfly@1.0.250":
+  version "1.0.250"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-1.0.250.tgz#02952d55039891ab4796b6e78e677ecd01c25855"
+  integrity sha512-Ew9m5sRTjb68ewzD1gk/QMgJYZl/0jyXtSSYaSdXyzpzB+0Yj+46qhcKDCGql6MzXxO7kZ8vjt4gmBRqfV+OnA==
+
+"@patternfly/patternfly@^2.8.1":
+  version "2.12.5"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-2.12.5.tgz#f2c5924deb875a8cde95e09e6d5c9022f00429da"
+  integrity sha512-zB+pwtUXZVbv6l76XMU3ggMZrbHZtbZDBHrNBeWVfDngp2xnwTNVu0Ha4WaZVtZzutyVaF6F1VHTLnef6mO5ug==
 
 "@patternfly/react-core@^3.32.9":
   version "3.32.9"


### PR DESCRIPTION
This PR updates the header to more seamlessly collapse/consolidate the user menu at smaller viewports. Previously we would collapse logout into the help menu (keeping the help icon) and later convert that icon to kebab. After further reviewing this interaction, we realized it seems strange and a better experience is to convert the icon to a kebab at the same time we move/consolidate the two menus.

Also fixes a bug where selecting the collapse "toggle" icon for wizard  wasn't actually collapsing the menu. Now it does.

One question that came up along the way was "how are we achieving this collapse functionality for the PF3 Wiz steps?". I don't see this capability in the PF3 react implementation;

http://patternfly-react.surge.sh/patternfly-3/index.html?selectedKind=patternfly-react%2FCommunication%2FWizard%2FComponents&selectedStory=Wizard&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs

But it does seem to be a thing in core;

https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/wizard.html

Should help close https://github.com/syndesisio/syndesis-react/issues/425

allow pointer events to pass through for wiz toggle icon
introduce tabletView mode where we can update aspects of the UI based on viewport size
update header icons depending on viewport size