### PR TITLE
feat: disallow nested conditional flow steps

### DIFF
--- a/app/ui-react/packages/models/src/extra.d.ts
+++ b/app/ui-react/packages/models/src/extra.d.ts
@@ -92,11 +92,17 @@ export interface IntegrationMonitoring {
   podName: string;
 }
 
+export type isVisibleFunction = (
+  position: number,
+  previous: StepKind[],
+  subsequent: StepKind[]
+) => boolean;
+
 export interface StepKind extends Step {
   name: string;
   description: string;
   properties: any;
-  visible?: (position: number, previous: Step[], subsequent: Step[]) => boolean;
+  visible?: isVisibleFunction[];
 }
 
 export interface IListResult<T> {

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/utils.ts
@@ -413,8 +413,15 @@ export function visibleStepsByPosition(
     previousSteps.length === 0,
     subsequentSteps.length === 0
   ).filter(s => {
-    if (typeof s.visible === 'function') {
-      return s.visible(position, previousSteps, subsequentSteps);
+    if (Array.isArray(s.visible) && s.visible.length > 0) {
+      const matches = s.visible.map(visible =>
+        visible(
+          position,
+          previousSteps as StepKind[],
+          subsequentSteps as StepKind[]
+        )
+      );
+      return matches.find(m => !m) === undefined;
     }
     return true;
   });


### PR DESCRIPTION
fixes syndesisio/syndesis#5492

Also refactors the `StepKind` visible function to be an array of functions to allow for applying multiple conditions that must all be true for a step to be visible.