### PR TITLE
fix: add the exposed URL if available to the detail page

### DIFF
--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationExposedURL.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationExposedURL.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { PageSection } from '../../Layout';
+import { CopyToClipboard } from '../../Shared/CopyToClipboard';
+
+export interface IIntegrationExposedURLProps {
+  url?: string;
+}
+
+export const IntegrationExposedURL: React.FunctionComponent<
+  IIntegrationExposedURLProps
+> = ({ url }) => (
+  <>
+    {url && (
+      <PageSection>
+        <CopyToClipboard>{url}</CopyToClipboard>
+      </PageSection>
+    )}
+  </>
+);

--- a/app/ui-react/packages/ui/src/Integration/Details/index.ts
+++ b/app/ui-react/packages/ui/src/Integration/Details/index.ts
@@ -1,6 +1,6 @@
 export * from './IntegrationActions';
-export * from './IntegrationBulletinBoardAlert';
 export * from './IntegrationActionSelectorCard';
+export * from './IntegrationBulletinBoardAlert';
 export * from './IntegrationDetailBreadcrumb';
 export * from './IntegrationDetailDescription';
 export * from './IntegrationDetailEditableName';
@@ -8,3 +8,4 @@ export * from './IntegrationDetailHistoryListView';
 export * from './IntegrationDetailHistoryListViewItem';
 export * from './IntegrationDetailHistoryListViewItemActions';
 export * from './IntegrationDetailInfo';
+export * from './IntegrationExposedURL';

--- a/app/ui-react/syndesis/src/modules/integrations/pages/detail/DetailsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/pages/detail/DetailsPage.tsx
@@ -9,6 +9,7 @@ import {
   IntegrationDetailHistoryListView,
   IntegrationDetailHistoryListViewItem,
   IntegrationDetailHistoryListViewItemActions,
+  IntegrationExposedURL,
   PageLoader,
 } from '@syndesis/ui';
 import { WithLoader, WithRouteData } from '@syndesis/utils';
@@ -81,6 +82,9 @@ export class DetailsPage extends React.Component {
                                     />
                                     <IntegrationDetailSteps
                                       integration={data.integration}
+                                    />
+                                    <IntegrationExposedURL
+                                      url={data.integration.url}
                                     />
                                     <WithIntegrationHelpers>
                                       {({ setAttributes }) => {


### PR DESCRIPTION
 fixes syndesisio/syndesis#5575

@seanforyou23 FYI worked for me on firefox

![image](https://user-images.githubusercontent.com/351660/59117037-e5dafd80-891a-11e9-9dd5-c262602748e7.png)
