### PR TITLE
fix: don't reset OAuth client state

### DIFF
--- a/app/ui-react/packages/api/src/useConnectorCredentials.tsx
+++ b/app/ui-react/packages/api/src/useConnectorCredentials.tsx
@@ -15,7 +15,7 @@ export const useConnectorCredentials = (connectorId: string) => {
 export interface ICredentialsConnectResponse {
   redirectUrl: string;
   type: string;
-  state: {
+  state?: {
     persist: string;
     spec: string;
   };

--- a/app/ui-react/syndesis/public/oauth-redirect.html
+++ b/app/ui-react/syndesis/public/oauth-redirect.html
@@ -4,8 +4,7 @@
 
   function authCompleted() {
     clearInterval(autocloseInterval);
-    const cred = document.cookie.split(';').filter(c => c.indexOf('cred-o2') === 0)[0];
-    window.opener.authCompleted(window.location.hash.substr(1), cred);
+    window.opener.authCompleted(window.location.hash.substr(1));
     window.close();
   }
 

--- a/app/ui-react/syndesis/src/modules/connections/pages/create/ConfigurationPage.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/pages/create/ConfigurationPage.tsx
@@ -97,8 +97,10 @@ export const ConfigurationPage: React.FunctionComponent = () => {
    * the API in the document. This cookie will be later used by the BE in the
    * redirect page set up in the 3rd party.
    */
-  if (connectResource) {
+  if (connectResource && connectResource.state) {
     window.document.cookie = connectResource.state.spec;
+    // we need to destroy the state to prevent reverting to it
+    connectResource.state = undefined;
   }
 
   /**
@@ -107,8 +109,7 @@ export const ConfigurationPage: React.FunctionComponent = () => {
    * result of the connection
    */
   const authCompleted = React.useCallback(
-    (authState: string, cookie: string) => {
-      // document.cookie = `${cookie};path=/;secure`;
+    (authState: string) => {
       try {
         const auth = JSON.parse(decodeURIComponent(authState));
         if (auth.status === 'FAILURE') {
@@ -118,7 +119,6 @@ export const ConfigurationPage: React.FunctionComponent = () => {
         history.push(
           resolvers.create.review({
             connector,
-            cookie,
           })
         );
       } catch (e) {

--- a/app/ui-react/syndesis/src/modules/connections/pages/create/ReviewPage.tsx
+++ b/app/ui-react/syndesis/src/modules/connections/pages/create/ReviewPage.tsx
@@ -31,7 +31,6 @@ export interface IReviewPageRouteParams {
 export interface IReviewPageRouteState {
   connector: Connector;
   configuredProperties?: { [key: string]: string };
-  cookie?: string;
 }
 
 export const ReviewPage: React.FunctionComponent = () => {
@@ -46,10 +45,6 @@ export const ReviewPage: React.FunctionComponent = () => {
   );
   const { pushNotification } = React.useContext(UIContext);
   const { createConnection, saveConnection } = useConnectionHelpers();
-
-  if (state.cookie) {
-    document.cookie = `${state.cookie};path=/;secure`;
-  }
 
   const definition: IFormDefinition = {
     name: {

--- a/app/ui-react/syndesis/src/modules/connections/resolvers.ts
+++ b/app/ui-react/syndesis/src/modules/connections/resolvers.ts
@@ -55,14 +55,13 @@ export default {
       IReviewPageRouteState,
       IReviewPageRouteParams,
       IReviewPageRouteState
-    >(routes.create.review, ({ connector, configuredProperties, cookie }) => ({
+    >(routes.create.review, ({ connector, configuredProperties }) => ({
       params: {
         connectorId: connector.id!,
       },
       state: {
         connector,
         configuredProperties,
-        cookie,
       },
     })),
   },


### PR DESCRIPTION
We need to destroy the state received from backend on API call to `/api/v1/connectors/{id}/credentials` in order for it not to overwrite the cookie received on `/api/v1/credentials/callback`. This eliminates the need to parse the cookie in `oauth-redirect.html` and pass/store it in the app.