### PR TITLE
fix: template step requires an output data shape to be selected

### DIFF
--- a/app/ui-react/packages/api/src/WithSteps.tsx
+++ b/app/ui-react/packages/api/src/WithSteps.tsx
@@ -48,7 +48,7 @@ export const ALL_STEPS: StepKind[] = [
     },
     true
   ),
-  {
+  requiresOutputDataShape({
     id: undefined,
     connection: undefined,
     action: undefined,
@@ -59,7 +59,7 @@ export const ALL_STEPS: StepKind[] = [
     configuredProperties: undefined,
     properties: undefined,
     visible: [],
-  },
+  }),
   noCollectionSupport({
     id: undefined,
     connection: undefined,

--- a/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.tsx
@@ -71,7 +71,7 @@ export class IntegrationsListItem extends React.Component<
             )}
           </ListView.InfoItem>,
           <ListView.InfoItem
-            key={1}
+            key={2}
             className={'integration-list-item__additional-info'}
           >
             {this.props.isConfigurationRequired && (


### PR DESCRIPTION
Bug reported [here](https://github.com/syndesisio/syndesis/issues/5622#issuecomment-500343788).

(oh also fixes a bug with the integration list item that was causing a lot of console errors to be logged)