### PR TITLE
chore(ux): remove avatar and stopped status icon, truncate long titles

### DIFF
--- a/app/ui-react/packages/ui/src/Dashboard/RecentUpdatesItem.css
+++ b/app/ui-react/packages/ui/src/Dashboard/RecentUpdatesItem.css
@@ -1,7 +1,14 @@
 
 .recent-updates-item {
-  cursor: pointer;
+  cursor: default;
   padding: 10px 0;
+}
+
+.recent-updates-item .recent-updates-item__title-container {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  min-width: 0;
 }
 
 .recent-updates-item:hover {

--- a/app/ui-react/packages/ui/src/Dashboard/RecentUpdatesItem.tsx
+++ b/app/ui-react/packages/ui/src/Dashboard/RecentUpdatesItem.tsx
@@ -27,7 +27,9 @@ export const RecentUpdatesItem: React.FunctionComponent<IRecentUpdatesItem> = ({
     className={'recent-updates-item'}
     data-testid={`recent-updates-item-${toValidHtmlId(integrationName)}-row`}
   >
-    <Grid.Col xs={5}>{integrationName}</Grid.Col>
+    <Grid.Col className="recent-updates-item__title-container" xs={5}>
+      {integrationName}
+    </Grid.Col>
     <Grid.Col xs={3}>
       <IntegrationStatus
         currentState={integrationCurrentState}

--- a/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailInfo.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Details/IntegrationDetailInfo.tsx
@@ -46,12 +46,7 @@ export class IntegrationDetailInfo extends React.PureComponent<
               Published version {this.props.version}
             </div>
           )}
-          {this.props.currentState === 'Unpublished' && (
-            <>
-              <span className="pficon pficon-paused pf-u-mr-xs" />
-              <Label>Stopped</Label>
-            </>
-          )}
+          {this.props.currentState === 'Unpublished' && <Label>Stopped</Label>}
         </>
       </div>
     );

--- a/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.css
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationsListItem.css
@@ -15,3 +15,20 @@
 .integration-list-item__config-required {
   text-align: left;
 }
+
+.integration-list-item .list-view-pf-body .list-group-item-heading,
+.support-integration-list-item .list-view-pf-body .list-group-item-heading {
+  white-space: nowrap;
+}
+
+.integration-list-item .list-view-pf-body .list-view-pf-description,
+.support-integration-list-item .list-view-pf-body .list-view-pf-description {
+  min-width: 0;
+}
+
+.support-integration-list-item .list-view-pf-additional-info-item {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}

--- a/app/ui-react/packages/ui/src/Integration/IntegrationsListItemBasic.tsx
+++ b/app/ui-react/packages/ui/src/Integration/IntegrationsListItemBasic.tsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import { ListView } from 'patternfly-react';
 import * as React from 'react';
 
@@ -5,15 +6,22 @@ export interface IIntegrationsListItemBasicProps {
   integrationName: string;
   checkboxComponent?: React.ReactNode;
   additionalInfo: string;
+  className?: string;
 }
 
 export class IntegrationsListItemBasic extends React.Component<
   IIntegrationsListItemBasicProps
 > {
   public render() {
-    const { checkboxComponent, integrationName, additionalInfo } = this.props;
+    const {
+      className,
+      checkboxComponent,
+      integrationName,
+      additionalInfo,
+    } = this.props;
     return (
       <ListView.Item
+        className={classnames('', className)}
         checkboxInput={checkboxComponent || undefined}
         heading={integrationName}
         additionalInfo={[

--- a/app/ui-react/packages/ui/src/index.css
+++ b/app/ui-react/packages/ui/src/index.css
@@ -175,8 +175,3 @@ body {
 .wizard-pf-step-title {
   line-height: 24px;
 }
-
-.list-view-pf .list-group-item-heading {
-  white-space: normal;
-  word-break: break-all;
-}

--- a/app/ui-react/syndesis/src/app/UI.tsx
+++ b/app/ui-react/syndesis/src/app/UI.tsx
@@ -22,7 +22,6 @@ import { Workbox } from 'workbox-window';
 import resolvers from '../modules/resolvers';
 import { ApiError, PageNotFound, WithErrorBoundary } from '../shared';
 import favicon from '../shared/images/favicon.ico';
-import avatarImg from '../shared/images/img_avatar.svg';
 import brandImg from '../shared/images/pf4-downstream-bg.svg';
 import redHatBrandLogo from '../shared/images/red-hat-brand-logo.png';
 import redHatFuseOnlineLogo from '../shared/images/red-hat-fuse-online-logo.png';
@@ -209,7 +208,6 @@ export const UI: React.FunctionComponent<IAppUIProps> = ({ routes }) => {
                             {({ logout }) => {
                               return (
                                 <AppLayout
-                                  avatar={avatarImg}
                                   onShowAboutModal={toggleAboutModal}
                                   onSelectSupport={() => {
                                     history.push(resolvers.support.root());

--- a/app/ui-react/syndesis/src/modules/support/components/SelectiveIntegrationList.tsx
+++ b/app/ui-react/syndesis/src/modules/support/components/SelectiveIntegrationList.tsx
@@ -95,6 +95,7 @@ export const SelectiveIntegrationList: React.FunctionComponent<
                   (si: IntegrationOverview) => {
                     return (
                       <IntegrationsListItemBasic
+                        className="support-integration-list-item"
                         key={`${si.updatedAt}-${si.name.split(' ').join('-')}`}
                         additionalInfo={si.description || ''}
                         integrationName={si.name}


### PR DESCRIPTION
This PR truncates long integration names onto a single line using an ellipsis to indicate more content. It also removes the avatar from the header as profile images are not currently a feature we offer. Lastly, it removes the pause icon for stopped integrations from the integration details page.

The treatment of long integration names here is in line with patternfly 3 standards. An upcoming milestone will be to convert innermost components to use patternfly 4, which would be a good time to re-think the design of the overflowing integration names. I point that out because one of the options we've entertained was to show the first two lines of the integration name instead of a single line, but it's not simple to pull off implementation wise and it would be better to research out options before jumping straight to a complex solution like that.

Should help close https://github.com/syndesisio/syndesis/issues/5658

remove avatar from header
remove pause icon from integration details page
truncate integration title in various places