### PR TITLE
TTOOLS-598 SQL editor highlighting and autocomplete

### DIFF
--- a/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ViewEditContent.tsx
+++ b/app/ui-react/packages/ui/src/Data/Virtualizations/Views/ViewEditContent.tsx
@@ -111,11 +111,20 @@ export class ViewEditContent extends React.Component<
 
   public render() {
     const editorOptions = {
-      dragDrop: false,
+      autofocus: true,
+      extraKeys: { 'Ctrl-Space': 'autocomplete' },
       gutters: ['CodeMirror-lint-markers'],
+      // TODO: dynamically generate the table - column hints
+      hintOptions: {
+        tables: {
+          countries: ['name', 'population', 'size'],
+          users: ['name', 'score', 'birthDate'],
+        },
+      },
       lineNumbers: true,
       lineWrapping: true,
-      mode: 'text/x-sql',
+      matchBrackets: true,
+      mode: 'text/x-mysql',
       readOnly: false,
       showCursorWhenSelecting: true,
       styleActiveLine: true,


### PR DESCRIPTION
Would just like comments on these changes.  
The intention is to enable SQL highlighting for the codemirror component, and enable auto-complete hints.  The hightlighting is working ok, but auto-complete hints seem to be hidden, at least in dev environment.