### PR TITLE
fix: api provider bugs

### DIFF
--- a/app/ui-react/packages/api/src/useApiProviderSummary.tsx
+++ b/app/ui-react/packages/api/src/useApiProviderSummary.tsx
@@ -26,7 +26,7 @@ export function useApiProviderSummary(specification: string) {
           url: `${apiContext.apiUri}/apis/info`,
         });
         const summary = await response.json();
-        if (summary.errorCode || summary.errors) {
+        if (summary.errorCode && summary.errors) {
           throw new Error(
             summary.userMsg ||
               (summary.errors || [])

--- a/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorLayout.tsx
+++ b/app/ui-react/packages/ui/src/Integration/Editor/IntegrationEditorLayout.tsx
@@ -121,6 +121,7 @@ export const IntegrationEditorLayout: React.FunctionComponent<
                     onClick={onSave}
                     href={saveHref}
                     disabled={isSaveLoading || isSaveDisabled}
+                    as={publishHref || onPublish ? 'default' : 'primary'}
                   >
                     {isSaveLoading ? (
                       <Loader size={'xs'} inline={true} />

--- a/app/ui-react/packages/ui/src/Integration/OperationsDropdown.css
+++ b/app/ui-react/packages/ui/src/Integration/OperationsDropdown.css
@@ -1,0 +1,4 @@
+.operations-dropdown .pf-c-dropdown__menu {
+  max-height: 300px;
+  overflow-y: auto;
+}

--- a/app/ui-react/packages/ui/src/Integration/OperationsDropdown.tsx
+++ b/app/ui-react/packages/ui/src/Integration/OperationsDropdown.tsx
@@ -1,5 +1,6 @@
 import { Dropdown, DropdownToggle } from '@patternfly/react-core';
 import * as React from 'react';
+import './OperationsDropdown.css';
 
 export interface IOperationsDropdownProps {
   selectedOperation: React.ReactNode;
@@ -12,6 +13,7 @@ export const OperationsDropdown: React.FunctionComponent<
   const toggleDropdown = () => setIsOpen(!isOpen);
   return (
     <Dropdown
+      className={'operations-dropdown'}
       onSelect={closeDropdown}
       toggle={
         <DropdownToggle onToggle={toggleDropdown}>

--- a/app/ui-react/packages/ui/src/Layout/Breadcrumb.tsx
+++ b/app/ui-react/packages/ui/src/Layout/Breadcrumb.tsx
@@ -3,13 +3,17 @@
 import {
   Breadcrumb as PFBreadcrumb,
   BreadcrumbItem,
+  BreadcrumbItemProps,
   Level,
   LevelItem,
 } from '@patternfly/react-core';
 import * as React from 'react';
 import { AppBreadcrumb } from './AppBreadcrumb';
 
+export { BreadcrumbItem, BreadcrumbItemProps };
+
 export interface IBreadcrumbProps {
+  items?: Array<React.ReactElement<BreadcrumbItemProps>>;
   actions?: React.ReactNode;
 }
 
@@ -21,22 +25,23 @@ export interface IBreadcrumbProps {
  * It's suggested to use only anchors or spans as children node.
  */
 export const Breadcrumb: React.FunctionComponent<IBreadcrumbProps> = ({
+  items,
   actions,
   children,
 }) => {
-  const items = React.Children.toArray(children).filter(c => c);
+  items =
+    items ||
+    React.Children.toArray(children).map((c, idx) => (
+      <BreadcrumbItem key={idx} isActive={idx === count - 1}>
+        {c}
+      </BreadcrumbItem>
+    ));
   const count = items.length;
   return (
     <AppBreadcrumb>
       <Level gutter={'md'}>
         <LevelItem>
-          <PFBreadcrumb>
-            {items.map((c, idx) => (
-              <BreadcrumbItem key={idx} isActive={idx === count - 1}>
-                {c}
-              </BreadcrumbItem>
-            ))}
-          </PFBreadcrumb>
+          <PFBreadcrumb>{items}</PFBreadcrumb>
         </LevelItem>
         {actions && <LevelItem>{actions}</LevelItem>}
       </Level>

--- a/app/ui-react/packages/ui/src/Shared/OpenApiReviewActions.tsx
+++ b/app/ui-react/packages/ui/src/Shared/OpenApiReviewActions.tsx
@@ -109,15 +109,17 @@ export class OpenApiReviewActions extends React.Component<
                   </Label>
                 </Title>
               )}
-              {this.props.errorMessages
-                ? this.props.errorMessages.map(
-                    (errorMsg: string, index: number) => (
-                      <Text component={TextVariants.p} key={index}>
-                        {index + 1}. {errorMsg}
-                      </Text>
+              <Container className={'review-actions__errors'}>
+                {this.props.errorMessages
+                  ? this.props.errorMessages.map(
+                      (errorMsg: string, index: number) => (
+                        <Text component={TextVariants.p} key={index}>
+                          {index + 1}. {errorMsg}
+                        </Text>
+                      )
                     )
-                  )
-                : null}
+                  : null}
+              </Container>
 
               {/* warning messages */}
               {this.props.i18nWarningsHeading && this.props.warningMessages && (

--- a/app/ui-react/syndesis/src/modules/integrations/IntegrationCreatorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/IntegrationCreatorApp.tsx
@@ -105,8 +105,8 @@ export const IntegrationCreatorApp: React.FunctionComponent = () => {
                               integration,
                             })
                           : resolvers.create.finish.selectStep({
-                              integration,
                               ...params,
+                              integration,
                               position: '1',
                             })
                       }
@@ -131,8 +131,8 @@ export const IntegrationCreatorApp: React.FunctionComponent = () => {
                       cancelHref={resolvers.list}
                       postConfigureHref={(integration, p) =>
                         resolvers.create.configure.index({
-                          integration,
                           ...p,
+                          integration,
                         })
                       }
                       getBreadcrumb={getBreadcrumb}
@@ -312,8 +312,8 @@ export const IntegrationCreatorApp: React.FunctionComponent = () => {
                       }
                       postConfigureHref={(integration, p) =>
                         resolvers.create.configure.index({
-                          integration,
                           ...p,
+                          integration,
                         })
                       }
                       getBreadcrumb={getBreadcrumb}
@@ -342,8 +342,8 @@ export const IntegrationCreatorApp: React.FunctionComponent = () => {
                       }
                       postConfigureHref={(integration, p) =>
                         resolvers.create.configure.index({
-                          integration,
                           ...p,
+                          integration,
                         })
                       }
                       getBreadcrumb={getBreadcrumb}

--- a/app/ui-react/syndesis/src/modules/integrations/IntegrationEditorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/IntegrationEditorApp.tsx
@@ -262,8 +262,8 @@ export const IntegrationEditorApp: React.FunctionComponent = () => {
                       }
                       postConfigureHref={(updatedIntegration, p) =>
                         resolvers.integration.edit.index({
-                          integration: updatedIntegration,
                           ...p,
+                          integration: updatedIntegration,
                         })
                       }
                       getBreadcrumb={getBreadcrumb}
@@ -292,8 +292,8 @@ export const IntegrationEditorApp: React.FunctionComponent = () => {
                       }
                       postConfigureHref={(updatedIntegration, p) =>
                         resolvers.integration.edit.index({
-                          integration: updatedIntegration,
                           ...p,
+                          integration: updatedIntegration,
                         })
                       }
                       getBreadcrumb={getBreadcrumb}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/EditorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/EditorApp.tsx
@@ -1,4 +1,5 @@
 /* tslint:disable:object-literal-sort-keys */
+import { NEW_INTEGRATION_ID } from '@syndesis/api';
 import * as H from '@syndesis/history';
 import { Integration } from '@syndesis/models';
 import * as React from 'react';
@@ -305,7 +306,9 @@ export const EditorApp: React.FunctionComponent<IEditorApp> = ({
   const editSpecificationPage = (
     <EditSpecificationPage
       cancelHref={(params, state) =>
-        appResolvers.apiProvider.selectMethod({ ...params, ...state })
+        state.integration.id === NEW_INTEGRATION_ID
+          ? appResolvers.apiProvider.selectMethod({ ...params, ...state })
+          : cancelHref(params, state)
       }
       saveHref={(params, state) =>
         appResolvers.apiProvider.reviewActions({ ...params, ...state })

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/EditorBreadcrumb.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/EditorBreadcrumb.tsx
@@ -20,10 +20,65 @@ import {
   ConditionsDropdownHeader,
   ConditionsDropdownItem,
   HttpMethodColors,
-  OperationsDropdown,
+  OperationsDropdown as OperationsDropdownUI,
 } from '@syndesis/ui';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import resolvers from '../../resolvers';
+
+export interface IBaseBreadcrumbItemsProps extends IEditorBreadcrumbProps {
+  currentFlow?: Flow;
+  isApiProvider: boolean;
+  operationsDropdown: React.ReactNode;
+  flowsDropdown: React.ReactNode;
+}
+export const BaseBreadcrumbItems: React.FunctionComponent<
+  IBaseBreadcrumbItemsProps
+> = ({
+  rootHref,
+  integration,
+  currentFlow,
+  isApiProvider,
+  apiProviderEditorHref,
+  operationsDropdown,
+  flowsDropdown,
+  children,
+}) => (
+  <Breadcrumb
+    actions={
+      isApiProvider ? (
+        <ButtonLink href={apiProviderEditorHref} as={'link'}>
+          View/Edit API Definition <i className="fa fa-external-link" />
+        </ButtonLink>
+      ) : (
+        undefined
+      )
+    }
+  >
+    <Link to={resolvers.list()}>Integrations</Link>
+    <Link
+      to={rootHref}
+      title={integration.name}
+      style={{
+        maxWidth: 200,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }}
+      onClick={(ev: React.MouseEvent) => {
+        if (!currentFlow || (currentFlow.steps || []).length < 2) {
+          ev.stopPropagation();
+          ev.preventDefault();
+        }
+      }}
+    >
+      {integration.name || 'New integration'}
+    </Link>
+    {operationsDropdown}
+    {flowsDropdown}
+    {children}
+  </Breadcrumb>
+);
 
 export interface IApiProviderOperationItemProps {
   description: string;
@@ -38,6 +93,112 @@ export const ApiProviderOperationItem: React.FunctionComponent<
       &nbsp;{desc}
     </>
   );
+};
+
+export interface IApiProviderDropdownProps extends IEditorBreadcrumbProps {
+  currentFlow: Flow;
+}
+const OperationsDropdown: React.FunctionComponent<
+  IApiProviderDropdownProps
+> = ({ currentFlow, integration, getFlowHref }) => {
+  const isPrimary = isPrimaryFlow(currentFlow);
+  const primaryFlow = isPrimary
+    ? currentFlow
+    : getFlow(
+        integration,
+        getMetadataValue<string>('primaryFlowId', currentFlow!.metadata)!
+      );
+  const isMultiflow =
+    integration.flows && integration.flows.filter(f => f.name).length > 0;
+
+  return primaryFlow && isMultiflow ? (
+    <>
+      <span>Operation&nbsp;&nbsp;</span>
+      <OperationsDropdownUI
+        selectedOperation={
+          getMetadataValue<string>(
+            EXCERPT_METADATA_KEY,
+            primaryFlow.metadata
+          ) ? (
+            <ApiProviderOperationItem description={primaryFlow.description!} />
+          ) : (
+            primaryFlow.name
+          )
+        }
+      >
+        {getApiProviderFlows(integration).map(f => (
+          <Link to={getFlowHref(f.id!)} key={f.id}>
+            <ApiProviderOperationItem description={f.description!} />
+            <div>
+              <strong>{f.name}</strong>
+            </div>
+          </Link>
+        ))}
+      </OperationsDropdownUI>
+    </>
+  ) : null;
+};
+
+export interface IFlowsDropdownProps extends IEditorBreadcrumbProps {
+  currentFlow: Flow;
+  isApiProvider: boolean;
+}
+const FlowsDropdown: React.FunctionComponent<IFlowsDropdownProps> = ({
+  currentFlow,
+  integration,
+  isApiProvider,
+  getFlowHref,
+}) => {
+  const isPrimary = isPrimaryFlow(currentFlow);
+  const primaryFlow = isPrimary
+    ? currentFlow
+    : getFlow(
+        integration,
+        getMetadataValue<string>('primaryFlowId', currentFlow!.metadata)!
+      );
+  const flowGroups = getConditionalFlowGroupsFor(integration, primaryFlow!.id!);
+  return !isPrimary && flowGroups.length > 0 ? (
+    <>
+      <span>Flow&nbsp;&nbsp;</span>
+      <ConditionsDropdown
+        selectedFlow={
+          <ConditionsDropdownBody
+            description={currentFlow.description!}
+            condition={isDefaultFlow(currentFlow) ? 'OTHERWISE' : 'WHEN'}
+          />
+        }
+      >
+        <>
+          {!isPrimary && (
+            <ConditionsBackButtonItem
+              title={
+                isApiProvider
+                  ? 'Back to Operation Flow'
+                  : 'Back to Primary Flow'
+              }
+              href={getFlowHref(primaryFlow!.id!)}
+            />
+          )}
+          {flowGroups.map((group, groupIndex) => (
+            <ConditionsDropdownHeader
+              key={groupIndex}
+              title={`${groupIndex + 1} Conditional Flow Step`}
+            >
+              {group.flows.map(f => (
+                <ConditionsDropdownItem
+                  key={`${group.id} ${f.id}`}
+                  name={getFlowName(f)}
+                  description={f.description!}
+                  condition={isDefaultFlow(f) ? 'OTHERWISE' : 'WHEN'}
+                  link={getFlowHref(f.id!)}
+                />
+              ))}
+            </ConditionsDropdownHeader>
+          ))}
+        </>
+      </ConditionsDropdown>
+    </>
+  ) : null;
 };
 
 function getFlowName(flow: Flow) {
@@ -65,132 +226,32 @@ export interface IEditorBreadcrumbProps {
 }
 export const EditorBreadcrumb: React.FunctionComponent<
   IEditorBreadcrumbProps
-> = ({
-  currentFlowId,
-  integration,
-  rootHref,
-  apiProviderEditorHref,
-  getFlowHref,
-  children,
-}) => {
+> = props => {
+  const { integration, currentFlowId } = props;
   const isApiProvider = isIntegrationApiProvider(integration);
-  const isMultiflow =
-    integration.flows && integration.flows.filter(f => f.name).length > 0;
   const currentFlow = currentFlowId
     ? getFlow(integration, currentFlowId)
     : undefined;
-  if (!currentFlow) {
-    return <></>;
-  }
-  const isPrimary = isPrimaryFlow(currentFlow!);
-  const primaryFlow = isPrimary
-    ? currentFlow
-    : getFlow(
-        integration,
-        getMetadataValue<string>('primaryFlowId', currentFlow!.metadata)!
-      );
-  const flowGroups = getConditionalFlowGroupsFor(integration, primaryFlow!.id!);
+
   return (
-    <Breadcrumb
-      actions={
-        isApiProvider ? (
-          <ButtonLink href={apiProviderEditorHref} as={'link'}>
-            View/Edit API Definition <i className="fa fa-external-link" />
-          </ButtonLink>
-        ) : (
-          undefined
+    <BaseBreadcrumbItems
+      currentFlow={currentFlow}
+      isApiProvider={isApiProvider}
+      operationsDropdown={
+        currentFlow && (
+          <OperationsDropdown currentFlow={currentFlow} {...props} />
         )
       }
-    >
-      <Link
-        to={rootHref}
-        title={integration.name}
-        style={{
-          maxWidth: 200,
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-        }}
-        onClick={(ev: React.MouseEvent) => {
-          if (!currentFlow || (currentFlow.steps || []).length < 2) {
-            ev.stopPropagation();
-            ev.preventDefault();
-          }
-        }}
-      >
-        {integration.name || 'New integration'}
-      </Link>
-      {primaryFlow && isApiProvider && isMultiflow && (
-        <>
-          <span>Operation&nbsp;&nbsp;</span>
-          <OperationsDropdown
-            selectedOperation={
-              getMetadataValue<string>(
-                EXCERPT_METADATA_KEY,
-                primaryFlow.metadata
-              ) ? (
-                <ApiProviderOperationItem
-                  description={primaryFlow.description!}
-                />
-              ) : (
-                primaryFlow.name
-              )
-            }
-          >
-            {getApiProviderFlows(integration).map(f => (
-              <Link to={getFlowHref(f.id!)} key={f.id}>
-                <ApiProviderOperationItem description={f.description!} />
-                <div>
-                  <strong>{f.name}</strong>
-                </div>
-              </Link>
-            ))}
-          </OperationsDropdown>
-        </>
-      )}
-      {!isPrimary && flowGroups.length > 0 && (
-        <>
-          <span>Flow&nbsp;&nbsp;</span>
-          <ConditionsDropdown
-            selectedFlow={
-              <ConditionsDropdownBody
-                description={currentFlow.description!}
-                condition={isDefaultFlow(currentFlow) ? 'OTHERWISE' : 'WHEN'}
-              />
-            }
-          >
-            <>
-              {!isPrimary && (
-                <ConditionsBackButtonItem
-                  title={
-                    isApiProvider
-                      ? 'Back to Operation Flow'
-                      : 'Back to Primary Flow'
-                  }
-                  href={getFlowHref(primaryFlow!.id!)}
-                />
-              )}
-              {flowGroups.map((group, groupIndex) => (
-                <ConditionsDropdownHeader
-                  key={groupIndex}
-                  title={`${groupIndex + 1} Conditional Flow Step`}
-                >
-                  {group.flows.map(f => (
-                    <ConditionsDropdownItem
-                      key={`${group.id} ${f.id}`}
-                      name={getFlowName(f)}
-                      description={f.description!}
-                      condition={isDefaultFlow(f) ? 'OTHERWISE' : 'WHEN'}
-                      link={getFlowHref(f.id!)}
-                    />
-                  ))}
-                </ConditionsDropdownHeader>
-              ))}
-            </>
-          </ConditionsDropdown>
-        </>
-      )}
-      {children}
-    </Breadcrumb>
+      flowsDropdown={
+        currentFlow && (
+          <FlowsDropdown
+            currentFlow={currentFlow}
+            isApiProvider={isApiProvider}
+            {...props}
+          />
+        )
+      }
+      {...props}
+    />
   );
 };

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/apiProvider/ReviewActionsPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/apiProvider/ReviewActionsPage.tsx
@@ -134,6 +134,16 @@ export const ReviewActionsPage: React.FunctionComponent<
                               )
                             : undefined
                         }
+                        i18nErrorsHeading={t(
+                          'integrations:apiProvider:reviewActions:sectionErrors'
+                        )}
+                        errorMessages={
+                          apiSummary!.errors
+                            ? apiSummary!.errors.map(
+                                (e: any) => `${e.property}: ${e.message}`
+                              )
+                            : undefined
+                        }
                       />
                       <div>
                         <ButtonLink

--- a/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
+++ b/app/ui-react/syndesis/src/modules/integrations/locales/integrations-translations.en.json
@@ -120,6 +120,7 @@
       "sectionApiDefinition": "API DEFINITION",
       "sectionImported": "IMPORTED",
       "sectionWarnings": "WARNINGS",
+      "sectionErrors": "ERRORS",
       "title": "Review Actions"
     },
     "reviewOperations": {

--- a/app/ui-react/syndesis/src/modules/integrations/resolvers.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/resolvers.ts
@@ -1,5 +1,9 @@
 /* tslint:disable:object-literal-sort-keys no-empty-interface */
-import { getEmptyIntegration, isIntegrationApiProvider } from '@syndesis/api';
+import {
+  getEmptyIntegration,
+  getFlow,
+  isIntegrationApiProvider,
+} from '@syndesis/api';
 import { IIntegrationOverviewWithDraft } from '@syndesis/models';
 import {
   makeResolver,
@@ -27,18 +31,19 @@ import {
 } from './pages/detail/interfaces';
 import routes from './routes';
 
-export const configureIndexMapper = ({
-  flowId,
-  integration,
-}: IEditorIndex) => ({
-  params: {
-    flowId: flowId ? flowId : integration.flows![0].id!,
-    integrationId: integration.id!,
-  } as IBaseFlowRouteParams,
-  state: {
-    integration,
-  } as IBaseRouteState,
-});
+export const configureIndexMapper = ({ flowId, integration }: IEditorIndex) => {
+  flowId =
+    flowId && getFlow(integration, flowId) ? flowId : integration.flows![0].id!;
+  return {
+    params: {
+      flowId,
+      integrationId: integration.id!,
+    } as IBaseFlowRouteParams,
+    state: {
+      integration,
+    } as IBaseRouteState,
+  };
+};
 
 export const configureIndexOrApiProviderMapper = (
   indexRoute: string,


### PR DESCRIPTION
Partially fixes https://github.com/syndesisio/syndesis/issues/5697
Partially fixes https://github.com/syndesisio/syndesis/issues/5600
Fixes https://github.com/syndesisio/syndesis/issues/5675
Fixes https://github.com/syndesisio/syndesis-react/issues/397

Since the spec is returned by an API, every time you go to the API definition you get the one relative to the last saved version of the integration. 
So if edit the definition, change your mind and try to edit it again, you'll lose the previous changes.

Also, this will completely delete whatever was present on the integration before the change in the spec. @zregvart can you confirm this is right?