### PR TITLE
fix: ensure any configured properties get passed into the state

### DIFF
--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/EditorApp.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/EditorApp.tsx
@@ -135,7 +135,7 @@ export const EditorApp: React.FunctionComponent<IEditorApp> = ({
       backHref={(p, s) => appResolvers.connection.selectAction({ ...p, ...s })}
       cancelHref={cancelHref}
       mode={mode}
-      nextStepHref={(p, s) =>
+      nextPageHref={(p, s) =>
         appResolvers.connection.configureAction({
           ...p,
           ...s,

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigurationForm.tsx
@@ -19,7 +19,7 @@ import i18n from '../../../../../i18n';
 import { IWithConfigurationFormProps } from './WithConfigurationForm';
 
 export interface IConfigurationFormProps
-  extends Pick<IWithConfigurationFormProps, 'configurationStep'>,
+  extends Pick<IWithConfigurationFormProps, 'configurationPage'>,
     Pick<IWithConfigurationFormProps, 'initialValue'>,
     Pick<IWithConfigurationFormProps, 'oldAction'>,
     Pick<IWithConfigurationFormProps, 'onUpdatedIntegration'>,
@@ -33,7 +33,7 @@ export const ConfigurationForm: React.FunctionComponent<
   IConfigurationFormProps
 > = ({
   action,
-  configurationStep,
+  configurationPage,
   descriptor,
   initialValue,
   oldAction,
@@ -45,9 +45,9 @@ export const ConfigurationForm: React.FunctionComponent<
   const [error, setError] = React.useState();
   try {
     const steps = getActionSteps(descriptor);
-    const step = getActionStep(steps, configurationStep);
+    const step = getActionStep(steps, configurationPage);
     const definition = getActionStepDefinition(step);
-    const moreConfigurationSteps = configurationStep < steps.length - 1;
+    const moreConfigurationSteps = configurationPage < steps.length - 1;
     const onSave = async (
       values: { [key: string]: string },
       actions: any

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigureActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigureActionPage.tsx
@@ -38,7 +38,7 @@ export interface IConfigureActionPageProps extends IPageWithEditorBreadcrumb {
     s: IConfigureActionRouteState
   ) => H.LocationDescriptor;
   mode: 'adding' | 'editing';
-  nextStepHref: (
+  nextPageHref: (
     p: IConfigureActionRouteParams,
     s: IConfigureActionRouteState
   ) => H.LocationDescriptorObject;
@@ -77,20 +77,21 @@ export class ConfigureActionPage extends React.Component<
             IConfigureActionRouteState
           >>
             {(params, state, { history }) => {
-              const stepAsNumber = parseInt(params.step, 10);
+              const pageAsNumber = parseInt(params.page, 10);
               const positionAsNumber = parseInt(params.position, 10);
               const oldStepConfig = getStep(
                 state.integration,
                 params.flowId,
                 positionAsNumber
               );
+              const configuredProperties = state.configuredProperties;
               const onUpdatedIntegration = async ({
                 action,
                 moreConfigurationSteps,
                 values,
               }: IOnUpdatedIntegrationProps) => {
                 const updatedIntegration = await (this.props.mode ===
-                  'adding' && stepAsNumber === 0
+                  'adding' && pageAsNumber === 0
                   ? addConnection
                   : updateConnection)(
                   state.updatedIntegration || state.integration,
@@ -102,13 +103,14 @@ export class ConfigureActionPage extends React.Component<
                 );
                 if (moreConfigurationSteps) {
                   history.push(
-                    this.props.nextStepHref(
+                    this.props.nextPageHref(
                       {
                         ...params,
-                        step: `${stepAsNumber + 1}`,
+                        page: `${pageAsNumber + 1}`,
                       },
                       {
                         ...state,
+                        configuredProperties: values || {},
                         updatedIntegration,
                       }
                     )
@@ -210,6 +212,7 @@ export class ConfigureActionPage extends React.Component<
                     })}
                     content={
                       <WithConfigurationForm
+                        key={`${positionAsNumber}:${pageAsNumber}`}
                         connection={state.connection}
                         actionId={params.actionId}
                         oldAction={
@@ -217,8 +220,8 @@ export class ConfigureActionPage extends React.Component<
                             ? oldStepConfig!.action!
                             : undefined
                         }
-                        configurationStep={stepAsNumber}
-                        initialValue={state.configuredProperties}
+                        configurationPage={pageAsNumber}
+                        initialValue={configuredProperties}
                         onUpdatedIntegration={onUpdatedIntegration}
                         chooseActionHref={this.props.backHref(params, state)}
                       />

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/DescribeDataShapePage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/DescribeDataShapePage.tsx
@@ -82,7 +82,7 @@ export class DescribeDataShapePage extends React.Component<
                   {
                     ...params,
                     actionId: state.step.action!.id!,
-                    step: '0',
+                    page: '0',
                   },
                   state
                 );
@@ -147,7 +147,7 @@ export class DescribeDataShapePage extends React.Component<
                         {
                           ...params,
                           actionId: stepKind.action!.id!,
-                          step: '0',
+                          page: '0',
                         } as IConfigureActionRouteParams,
                         {
                           ...state,

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/WithConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/WithConfigurationForm.tsx
@@ -22,7 +22,7 @@ export interface IOnUpdatedIntegrationProps {
    * true if the configuration is not complete because there are other steps,
    * false otherwise.
    * If true the form should be re-rendered with an incremented
-   * [configurationStep]{@link IWithConfigurationFormProps#configurationStep}.
+   * [configurationPage]{@link IWithConfigurationFormProps#configurationPage}.
    */
   moreConfigurationSteps: boolean;
   /**
@@ -48,7 +48,7 @@ export interface IWithConfigurationFormProps {
    * for actions whose configuration must be performed in multiple steps,
    * indicates the current step.
    */
-  configurationStep: number;
+  configurationPage: number;
   /**
    * the values to assign to the form once rendered. These can come either from
    * an existing integration or from the [onUpdatedIntegration]{@link IWithConfigurationFormProps#onUpdatedIntegration}

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/interfaces.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/interfaces.ts
@@ -97,7 +97,7 @@ export interface IConfigureStepRouteState extends IBaseRouteState {
 export interface IConfigureActionRouteParams extends IBaseFlowRouteParams {
   position: string;
   actionId: string;
-  step: string;
+  page: string;
 }
 
 /**
@@ -206,7 +206,7 @@ export const stepRoutes = {
   // if selected step kind is endpoint
   connection: include('connection/:connectionId', {
     selectAction: '',
-    configureAction: ':actionId/:step',
+    configureAction: ':actionId/:page',
     // if 'any' data shape
     describeData: 'describe-data/:position/:direction',
   }),

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/makeEditorResolvers.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/makeEditorResolvers.ts
@@ -1,5 +1,6 @@
 /* tslint:disable:object-literal-sort-keys no-empty-interface */
 import { getStep } from '@syndesis/api';
+import { IFormValue } from '@syndesis/auto-form';
 import { ConnectionOverview, Integration, StepKind } from '@syndesis/models';
 import { makeResolver, makeResolverNoParams } from '@syndesis/utils';
 import { configureIndexMapper } from '../../resolvers';
@@ -52,7 +53,8 @@ export interface IEditorSelectAction extends IEditorSelectConnection {
 
 export interface IEditorConfigureAction extends IEditorSelectAction {
   actionId: string;
-  step?: string;
+  configuredProperties?: IFormValue;
+  page?: string;
   updatedIntegration?: Integration;
 }
 
@@ -98,8 +100,9 @@ export const configureSelectActionMapper = ({
 };
 export const configureConfigureActionMapper = ({
   actionId,
+  configuredProperties,
   flowId,
-  step,
+  page,
   integration,
   updatedIntegration,
   position,
@@ -117,12 +120,13 @@ export const configureConfigureActionMapper = ({
     params: {
       ...params,
       actionId,
-      step: `${step || 0}`,
+      page: `${page || 0}`,
     } as IConfigureActionRouteParams,
     state: {
       ...state,
       updatedIntegration,
-      configuredProperties: stepObject.configuredProperties || {},
+      configuredProperties:
+        configuredProperties || stepObject.configuredProperties || {},
     } as IConfigureActionRouteState,
   };
 };


### PR DESCRIPTION
fixes #382

Now page 2 of the salesforce configuration looks like it should:

![image](https://user-images.githubusercontent.com/351660/59386338-6c854580-8d34-11e9-886f-4065817f6869.png)

Also I had to finally rename "step" on this particular page to "page", it's been confusing me each time I've been in this code :confused: 
