### PR TITLE
fix: clicking on the about link doesn't change the history anymore

### DIFF
--- a/app/ui-react/packages/ui/src/Shared/HelpDropdown.tsx
+++ b/app/ui-react/packages/ui/src/Shared/HelpDropdown.tsx
@@ -112,7 +112,10 @@ export class HelpDropdown extends React.Component<
         data-testid={'help-dropdown-about-dropdown-item'}
         key="action"
         component="a"
-        onClick={launchAboutModal}
+        onClick={ev => {
+          ev.preventDefault();
+          launchAboutModal();
+        }}
       >
         About
       </DropdownItem>,


### PR DESCRIPTION
Relative issue https://github.com/syndesisio/syndesis/issues/5720