### PR TITLE
fix: properly show the initial value for the form fields in all cases

### DIFF
--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigureActionPage.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigureActionPage.tsx
@@ -84,7 +84,17 @@ export class ConfigureActionPage extends React.Component<
                 params.flowId,
                 positionAsNumber
               );
-              const configuredProperties = state.configuredProperties;
+              /**
+               * configured properties will be set in the route state for
+               * configuration pages higher than 0. If it's not set, its value
+               * depends on the mode: for `adding` there is no initial value,
+               * for `editing` we can fetch it from the old step config object.
+               */
+              const configuredProperties =
+                state.configuredProperties ||
+                (this.props.mode === 'editing' && oldStepConfig
+                  ? oldStepConfig.configuredProperties
+                  : {});
               const onUpdatedIntegration = async ({
                 action,
                 moreConfigurationSteps,
@@ -110,7 +120,10 @@ export class ConfigureActionPage extends React.Component<
                       },
                       {
                         ...state,
-                        configuredProperties: values || {},
+                        configuredProperties: {
+                          ...values,
+                          ...configuredProperties,
+                        },
                         updatedIntegration,
                       }
                     )

--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/makeEditorResolvers.ts
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/makeEditorResolvers.ts
@@ -1,5 +1,4 @@
 /* tslint:disable:object-literal-sort-keys no-empty-interface */
-import { getStep } from '@syndesis/api';
 import { IFormValue } from '@syndesis/auto-form';
 import { ConnectionOverview, Integration, StepKind } from '@syndesis/models';
 import { makeResolver, makeResolverNoParams } from '@syndesis/utils';
@@ -100,12 +99,12 @@ export const configureSelectActionMapper = ({
 };
 export const configureConfigureActionMapper = ({
   actionId,
-  configuredProperties,
   flowId,
   page,
   integration,
   updatedIntegration,
   position,
+  configuredProperties,
   ...rest
 }: IEditorConfigureAction) => {
   const { params, state } = configureSelectActionMapper({
@@ -114,8 +113,6 @@ export const configureConfigureActionMapper = ({
     integration,
     position,
   });
-  const positionAsNumber = parseInt(position, 10);
-  const stepObject = getStep(integration, flowId, positionAsNumber) || {};
   return {
     params: {
       ...params,
@@ -124,9 +121,8 @@ export const configureConfigureActionMapper = ({
     } as IConfigureActionRouteParams,
     state: {
       ...state,
+      configuredProperties,
       updatedIntegration,
-      configuredProperties:
-        configuredProperties || stepObject.configuredProperties || {},
     } as IConfigureActionRouteState,
   };
 };


### PR DESCRIPTION
We should compute the `configuredProperties` in the configuration page since it depends on the mode (adding vs editing) and the page we are currently on.

Relative issue https://github.com/syndesisio/syndesis/issues/5686