### PR TITLE
fix: better title for the action configuration page

### DIFF
--- a/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigurationForm.tsx
+++ b/app/ui-react/syndesis/src/modules/integrations/components/editor/endpoint/ConfigurationForm.tsx
@@ -98,7 +98,7 @@ export const ConfigurationForm: React.FunctionComponent<
         {({ fields, handleSubmit, isValid, isSubmitting, submitForm }) => (
           <>
             <IntegrationEditorForm
-              i18nFormTitle={`${action.name} - ${action.description}`}
+              i18nFormTitle={`${action.name} - ${step.description}`}
               i18nBackAction={'Choose Action'}
               i18nNext={'Next'}
               isValid={isValid}


### PR DESCRIPTION
The card title now shows the action name and the step description.
![image](https://user-images.githubusercontent.com/966316/59428531-c9890600-8ddd-11e9-87a7-73e2d68d1660.png)


Relative issue https://github.com/syndesisio/syndesis/issues/5689